### PR TITLE
chore: fix repository and homepage URLs [skip ci]

### DIFF
--- a/packages/openapi-vue-query/package.json
+++ b/packages/openapi-vue-query/package.json
@@ -25,14 +25,14 @@
     },
     "./*": "./*"
   },
-  "homepage": "https://openapi-ts.dev",
+  "homepage": "https://github.com/hirotaka/openapi-typescript-vue#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/openapi-ts/openapi-typescript",
+    "url": "https://github.com/hirotaka/openapi-typescript-vue",
     "directory": "packages/openapi-vue-query"
   },
   "bugs": {
-    "url": "https://github.com/openapi-ts/openapi-typescript/issues"
+    "url": "https://github.com/hirotaka/openapi-typescript-vue/issues"
   },
   "keywords": [
     "openapi",


### PR DESCRIPTION
Updates package.json to point to correct repository URLs instead of the original openapi-ts repository.