### PR TITLE
fix: resolve Vue template TypeScript errors for useQuery

### DIFF
--- a/.changeset/fix-vue-template-typescript-compatibility.md
+++ b/.changeset/fix-vue-template-typescript-compatibility.md
@@ -1,0 +1,10 @@
+---
+"openapi-vue-query": patch
+---
+
+Fix Vue template TypeScript compatibility for useQuery
+
+- Update UseQueryMethod return type to include unwrapped data and error properties
+- Enables direct property access in Vue templates (e.g., `{{ data.title }}`, `{{ error.message }}`)
+- Maintains compatibility with Vue Query v5 while providing better TypeScript experience
+- Resolves type errors when using noUncheckedIndexedAccess in strict TypeScript configurations

--- a/packages/openapi-vue-query/src/index.ts
+++ b/packages/openapi-vue-query/src/index.ts
@@ -22,6 +22,7 @@ import type {
 } from "openapi-fetch";
 import type { HttpMethod, MediaType, PathsWithMethod, RequiredKeysOf } from "openapi-typescript-helpers";
 import type { DeepUnwrapRef, MaybeRefDeep } from "./utils";
+import type { Ref, UnwrapRef } from "vue";
 
 // Helper type to dynamically infer the type from the `select` property
 type InferSelectReturnType<TData, TSelect> = TSelect extends (data: TData) => infer R ? R : TData;
@@ -111,7 +112,10 @@ export type UseQueryMethod<Paths extends Record<string, Record<HttpMethod, {}>>,
   ...[init, options, queryClient]: RequiredKeysOf<Init> extends never
     ? [InitWithUnknowns<Init>?, Options?, QueryClient?]
     : [InitWithUnknowns<Init>, Options?, QueryClient?]
-) => UseQueryReturnType<InferSelectReturnType<Response["data"], Options["select"]>, Response["error"]>;
+) => UseQueryReturnType<InferSelectReturnType<Response["data"], Options["select"]>, Response["error"]> & {
+  data: InferSelectReturnType<Response["data"], Options["select"]> | undefined;
+  error: Response["error"] | null;
+};
 
 export type UseInfiniteQueryMethod<Paths extends Record<string, Record<HttpMethod, {}>>, Media extends MediaType> = <
   Method extends HttpMethod,


### PR DESCRIPTION
## Changes

- Add intersection type to UseQueryMethod return type for template compatibility
- Enable direct property access in Vue templates (data.title, error.message)
- Maintain Vue Query v5 compatibility while improving TypeScript experience
- Fix issues with noUncheckedIndexedAccess strict configuration
