### PR TITLE
fix: update Biome configuration for v2.2.5 compatibility

### DIFF
--- a/.biomeignore
+++ b/.biomeignore
@@ -1,0 +1,3 @@
+**/dist
+**/node_modules
+**/package.json

--- a/biome.json
+++ b/biome.json
@@ -1,10 +1,7 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
-  "organizeImports": {
-    "enabled": false
-  },
+  "$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
   "files": {
-    "ignore": ["**/dist/**", "**/package.json"]
+    "experimentalScannerIgnores": ["**/dist/**", "**/package.json"]
   },
   "formatter": {
     "indentStyle": "space",
@@ -20,7 +17,7 @@
         "useArrowFunction": "off"
       },
       "suspicious": {
-        "noConsoleLog": "error",
+        "noConsole": "error",
         "noExplicitAny": "off"
       },
       "style": {

--- a/packages/openapi-vue-query/.biomeignore
+++ b/packages/openapi-vue-query/.biomeignore
@@ -1,0 +1,2 @@
+dist
+test/fixtures

--- a/packages/openapi-vue-query/biome.json
+++ b/packages/openapi-vue-query/biome.json
@@ -1,8 +1,8 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
   "extends": ["../../biome.json"],
   "files": {
-    "ignore": ["./test/fixtures/"]
+    "experimentalScannerIgnores": ["./test/fixtures/"]
   },
   "linter": {
     "rules": {
@@ -16,7 +16,7 @@
   },
   "overrides": [
     {
-      "include": ["*.vue"],
+      "includes": ["*.vue"],
       "linter": {
         "rules": {
           "style": {

--- a/packages/openapi-vue-query/package.json
+++ b/packages/openapi-vue-query/package.json
@@ -56,7 +56,7 @@
     "build:cjs": "esbuild --bundle --platform=node --target=es2019 --outfile=dist/index.cjs --external:typescript src/index.ts",
     "dev": "tsc -p tsconfig.build.json --watch",
     "format": "biome format . --write",
-    "lint": "biome check .",
+    "lint": "biome check src test/*.test.tsx test/helpers vitest.config.ts",
     "generate-types": "openapi-typescript test/fixtures/api.yaml -o test/fixtures/api.d.ts",
     "pretest": "pnpm run generate-types",
     "test": "pnpm run \"/^test:/\"",

--- a/packages/openapi-vue-query/src/index.ts
+++ b/packages/openapi-vue-query/src/index.ts
@@ -5,18 +5,18 @@ import {
   type SkipToken,
   type UseInfiniteQueryOptions,
   type UseInfiniteQueryReturnType,
-  type UseQueryOptions,
-  type UseQueryReturnType,
   type UseMutationOptions,
   type UseMutationReturnType,
-  useQuery,
+  type UseQueryOptions,
+  type UseQueryReturnType,
   useInfiniteQuery,
   useMutation,
+  useQuery,
 } from "@tanstack/vue-query";
 import type {
-  Client as FetchClient,
   ClientMethod,
   DefaultParamsOption,
+  Client as FetchClient,
   FetchResponse,
   MaybeOptionalInit,
 } from "openapi-fetch";

--- a/packages/openapi-vue-query/src/types.ts
+++ b/packages/openapi-vue-query/src/types.ts
@@ -7,7 +7,7 @@ import type {
 } from "@tanstack/vue-query";
 import type { ComputedRef, MaybeRef, MaybeRefOrGetter } from "vue";
 
-import type { ClientContext, SetOptional, MaybeRefDeep } from "./utils";
+import type { ClientContext, MaybeRefDeep } from "./utils";
 
 export type QueryOptionsIn<
   TClientContext extends ClientContext,

--- a/packages/openapi-vue-query/test/fixtures/api.d.ts
+++ b/packages/openapi-vue-query/test/fixtures/api.d.ts
@@ -4,1105 +4,1105 @@
  */
 
 export interface paths {
-    "/paginated-data": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query: {
-                    limit: number;
-                    cursor?: number;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            items?: number[];
-                            nextPage?: number;
-                        };
-                    };
-                };
-                /** @description Error response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            code?: number;
-                            message?: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+  "/paginated-data": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/comment": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get: {
+      parameters: {
+        query: {
+          limit: number;
+          cursor?: number;
         };
-        get?: never;
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Successful response */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": {
+              items?: number[];
+              nextPage?: number;
             };
-            requestBody: components["requestBodies"]["CreateReply"];
-            responses: {
-                201: components["responses"]["CreateReply"];
-                500: components["responses"]["Error"];
-            };
+          };
         };
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+        /** @description Error response */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": {
+              code?: number;
+              message?: string;
+            };
+          };
+        };
+      };
     };
-    "/blogposts": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: {
-                    tags?: string[];
-                    published?: boolean;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                200: components["responses"]["AllPostsGet"];
-                500: components["responses"]["Error"];
-            };
-        };
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: components["requestBodies"]["CreatePost"];
-            responses: {
-                201: components["responses"]["CreatePost"];
-                500: components["responses"]["Error"];
-            };
-        };
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: components["requestBodies"]["PatchPost"];
-            responses: {
-                201: components["responses"]["PatchPost"];
-            };
-        };
-        trace?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/comment": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/blogposts/{post_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                post_id: string;
-            };
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: {
-                    version?: number;
-                    format?: string;
-                };
-                header?: never;
-                path: {
-                    post_id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                200: components["responses"]["PostGet"];
-                404: components["responses"]["Error"];
-                500: components["responses"]["Error"];
-            };
-        };
-        put?: never;
-        post?: never;
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    post_id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                200: components["responses"]["PostDelete"];
-                500: components["responses"]["Error"];
-            };
-        };
-        options?: never;
-        head?: never;
-        patch: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    post_id: string;
-                };
-                cookie?: never;
-            };
-            requestBody: components["requestBodies"]["PatchPost"];
-            responses: {
-                200: components["responses"]["PatchPost"];
-                404: components["responses"]["Error"];
-                500: components["responses"]["Error"];
-            };
-        };
-        trace?: never;
+    get?: never;
+    put: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody: components["requestBodies"]["CreateReply"];
+      responses: {
+        201: components["responses"]["CreateReply"];
+        500: components["responses"]["Error"];
+      };
     };
-    "/blogposts-optional": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: components["requestBodies"]["CreatePostOptional"];
-            responses: {
-                201: components["responses"]["CreatePost"];
-                500: components["responses"]["Error"];
-            };
-        };
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/blogposts": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/blogposts-optional-inline": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get: {
+      parameters: {
+        query?: {
+          tags?: string[];
+          published?: boolean;
         };
-        get?: never;
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["Post"];
-                };
-            };
-            responses: {
-                201: components["responses"]["CreatePost"];
-                500: components["responses"]["Error"];
-            };
-        };
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        200: components["responses"]["AllPostsGet"];
+        500: components["responses"]["Error"];
+      };
     };
-    "/header-params": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: operations["getHeaderParams"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    put: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody: components["requestBodies"]["CreatePost"];
+      responses: {
+        201: components["responses"]["CreatePost"];
+        500: components["responses"]["Error"];
+      };
     };
-    "/media": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        /** Format: blob */
-                        media: string;
-                        name: string;
-                    };
-                };
-            };
-            responses: {
-                "2XX": {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: string;
-                        };
-                    };
-                };
-                "4XX": components["responses"]["Error"];
-            };
-        };
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody: components["requestBodies"]["PatchPost"];
+      responses: {
+        201: components["responses"]["PatchPost"];
+      };
     };
-    "/mismatched-data": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                200: components["responses"]["User"];
-                201: components["responses"]["PostGet"];
-                500: components["responses"]["Error"];
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    trace?: never;
+  };
+  "/blogposts/{post_id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        post_id: string;
+      };
+      cookie?: never;
     };
-    "/mismatched-errors": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get: {
+      parameters: {
+        query?: {
+          version?: number;
+          format?: string;
         };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                200: components["responses"]["User"];
-                401: components["responses"]["EmptyError"];
-                500: components["responses"]["Error"];
-            };
+        header?: never;
+        path: {
+          post_id: string;
         };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        200: components["responses"]["PostGet"];
+        404: components["responses"]["Error"];
+        500: components["responses"]["Error"];
+      };
     };
-    "/self": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    put?: never;
+    post?: never;
+    delete: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          post_id: string;
         };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                200: components["responses"]["User"];
-                404: components["responses"]["Error"];
-                500: components["responses"]["Error"];
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        200: components["responses"]["PostDelete"];
+        500: components["responses"]["Error"];
+      };
     };
-    "/string-array": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    options?: never;
+    head?: never;
+    patch: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          post_id: string;
         };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                200: components["responses"]["StringArray"];
-                500: components["responses"]["Error"];
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+        cookie?: never;
+      };
+      requestBody: components["requestBodies"]["PatchPost"];
+      responses: {
+        200: components["responses"]["PatchPost"];
+        404: components["responses"]["Error"];
+        500: components["responses"]["Error"];
+      };
     };
-    "/tag/{name}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                name: string;
-            };
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    name: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                200: components["responses"]["Tag"];
-                500: components["responses"]["Error"];
-            };
-        };
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    name: string;
-                };
-                cookie?: never;
-            };
-            requestBody: components["requestBodies"]["CreateTag"];
-            responses: {
-                201: components["responses"]["CreateTag"];
-                500: components["responses"]["Error"];
-            };
-        };
-        post?: never;
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    name: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description No Content */
-                204: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                500: components["responses"]["Error"];
-            };
-        };
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    trace?: never;
+  };
+  "/blogposts-optional": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/query-params": {
-        parameters: {
-            query?: {
-                string?: string;
-                number?: number;
-                boolean?: boolean;
-                array?: string[];
-                object?: {
-                    foo: string;
-                    bar: string;
-                };
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: {
-                    string?: string;
-                    number?: number;
-                    boolean?: boolean;
-                    array?: string[];
-                    object?: {
-                        foo: string;
-                        bar: string;
-                    };
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: string;
-                        };
-                    };
-                };
-                default: components["responses"]["Error"];
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: components["requestBodies"]["CreatePostOptional"];
+      responses: {
+        201: components["responses"]["CreatePost"];
+        500: components["responses"]["Error"];
+      };
     };
-    "/path-params/{simple_primitive}/{simple_obj_flat}/{simple_arr_flat}/{simple_obj_explode*}/{simple_arr_explode*}/{.label_primitive}/{.label_obj_flat}/{.label_arr_flat}/{.label_obj_explode*}/{.label_arr_explode*}/{;matrix_primitive}/{;matrix_obj_flat}/{;matrix_arr_flat}/{;matrix_obj_explode*}/{;matrix_arr_explode*}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                simple_primitive: string;
-                simple_obj_flat: {
-                    a: string;
-                    c: string;
-                };
-                simple_arr_flat: number[];
-                simple_obj_explode: {
-                    e: string;
-                    g: string;
-                };
-                simple_arr_explode: number[];
-                label_primitive: string;
-                label_obj_flat: {
-                    a: string;
-                    c: string;
-                };
-                label_arr_flat: number[];
-                label_obj_explode: {
-                    e: string;
-                    g: string;
-                };
-                label_arr_explode: number[];
-                matrix_primitive: string;
-                matrix_obj_flat: {
-                    a: string;
-                    c: string;
-                };
-                matrix_arr_flat: number[];
-                matrix_obj_explode: {
-                    e: string;
-                    g: string;
-                };
-                matrix_arr_explode: number[];
-            };
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    simple_primitive: string;
-                    simple_obj_flat: {
-                        a: string;
-                        c: string;
-                    };
-                    simple_arr_flat: number[];
-                    simple_obj_explode: {
-                        e: string;
-                        g: string;
-                    };
-                    simple_arr_explode: number[];
-                    label_primitive: string;
-                    label_obj_flat: {
-                        a: string;
-                        c: string;
-                    };
-                    label_arr_flat: number[];
-                    label_obj_explode: {
-                        e: string;
-                        g: string;
-                    };
-                    label_arr_explode: number[];
-                    matrix_primitive: string;
-                    matrix_obj_flat: {
-                        a: string;
-                        c: string;
-                    };
-                    matrix_arr_flat: number[];
-                    matrix_obj_explode: {
-                        e: string;
-                        g: string;
-                    };
-                    matrix_arr_explode: number[];
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: string;
-                        };
-                    };
-                };
-                default: components["responses"]["Error"];
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/blogposts-optional-inline": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/default-as-error": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["Post"];
         };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                default: components["responses"]["Error"];
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
+      responses: {
+        201: components["responses"]["CreatePost"];
+        500: components["responses"]["Error"];
+      };
     };
-    "/anyMethod": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                200: components["responses"]["User"];
-                404: components["responses"]["Error"];
-                500: components["responses"]["Error"];
-            };
-        };
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                200: components["responses"]["User"];
-                404: components["responses"]["Error"];
-                500: components["responses"]["Error"];
-            };
-        };
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                200: components["responses"]["User"];
-                404: components["responses"]["Error"];
-                500: components["responses"]["Error"];
-            };
-        };
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                200: components["responses"]["User"];
-                404: components["responses"]["Error"];
-                500: components["responses"]["Error"];
-            };
-        };
-        options: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                200: components["responses"]["User"];
-                404: components["responses"]["Error"];
-                500: components["responses"]["Error"];
-            };
-        };
-        head: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                200: components["responses"]["User"];
-                404: components["responses"]["Error"];
-                500: components["responses"]["Error"];
-            };
-        };
-        patch: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                200: components["responses"]["User"];
-                404: components["responses"]["Error"];
-                500: components["responses"]["Error"];
-            };
-        };
-        trace: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                200: components["responses"]["User"];
-                404: components["responses"]["Error"];
-                500: components["responses"]["Error"];
-            };
-        };
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/header-params": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/contact": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: components["requestBodies"]["Contact"];
-            responses: {
-                200: components["responses"]["Contact"];
-            };
-        };
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get: operations["getHeaderParams"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/media": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/multiple-response-content": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody: {
+        content: {
+          "application/json": {
+            /** Format: blob */
+            media: string;
+            name: string;
+          };
         };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
+      };
+      responses: {
+        "2XX": {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": {
+              status: string;
             };
-            requestBody?: never;
-            responses: {
-                200: components["responses"]["MultipleResponse"];
-            };
+          };
         };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+        "4XX": components["responses"]["Error"];
+      };
     };
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/mismatched-data": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        200: components["responses"]["User"];
+        201: components["responses"]["PostGet"];
+        500: components["responses"]["Error"];
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/mismatched-errors": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        200: components["responses"]["User"];
+        401: components["responses"]["EmptyError"];
+        500: components["responses"]["Error"];
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/self": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        200: components["responses"]["User"];
+        404: components["responses"]["Error"];
+        500: components["responses"]["Error"];
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/string-array": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        200: components["responses"]["StringArray"];
+        500: components["responses"]["Error"];
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/tag/{name}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        name: string;
+      };
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          name: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        200: components["responses"]["Tag"];
+        500: components["responses"]["Error"];
+      };
+    };
+    put: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          name: string;
+        };
+        cookie?: never;
+      };
+      requestBody: components["requestBodies"]["CreateTag"];
+      responses: {
+        201: components["responses"]["CreateTag"];
+        500: components["responses"]["Error"];
+      };
+    };
+    post?: never;
+    delete: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          name: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description No Content */
+        204: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        500: components["responses"]["Error"];
+      };
+    };
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/query-params": {
+    parameters: {
+      query?: {
+        string?: string;
+        number?: number;
+        boolean?: boolean;
+        array?: string[];
+        object?: {
+          foo: string;
+          bar: string;
+        };
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: {
+          string?: string;
+          number?: number;
+          boolean?: boolean;
+          array?: string[];
+          object?: {
+            foo: string;
+            bar: string;
+          };
+        };
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": {
+              status: string;
+            };
+          };
+        };
+        default: components["responses"]["Error"];
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/path-params/{simple_primitive}/{simple_obj_flat}/{simple_arr_flat}/{simple_obj_explode*}/{simple_arr_explode*}/{.label_primitive}/{.label_obj_flat}/{.label_arr_flat}/{.label_obj_explode*}/{.label_arr_explode*}/{;matrix_primitive}/{;matrix_obj_flat}/{;matrix_arr_flat}/{;matrix_obj_explode*}/{;matrix_arr_explode*}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        simple_primitive: string;
+        simple_obj_flat: {
+          a: string;
+          c: string;
+        };
+        simple_arr_flat: number[];
+        simple_obj_explode: {
+          e: string;
+          g: string;
+        };
+        simple_arr_explode: number[];
+        label_primitive: string;
+        label_obj_flat: {
+          a: string;
+          c: string;
+        };
+        label_arr_flat: number[];
+        label_obj_explode: {
+          e: string;
+          g: string;
+        };
+        label_arr_explode: number[];
+        matrix_primitive: string;
+        matrix_obj_flat: {
+          a: string;
+          c: string;
+        };
+        matrix_arr_flat: number[];
+        matrix_obj_explode: {
+          e: string;
+          g: string;
+        };
+        matrix_arr_explode: number[];
+      };
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          simple_primitive: string;
+          simple_obj_flat: {
+            a: string;
+            c: string;
+          };
+          simple_arr_flat: number[];
+          simple_obj_explode: {
+            e: string;
+            g: string;
+          };
+          simple_arr_explode: number[];
+          label_primitive: string;
+          label_obj_flat: {
+            a: string;
+            c: string;
+          };
+          label_arr_flat: number[];
+          label_obj_explode: {
+            e: string;
+            g: string;
+          };
+          label_arr_explode: number[];
+          matrix_primitive: string;
+          matrix_obj_flat: {
+            a: string;
+            c: string;
+          };
+          matrix_arr_flat: number[];
+          matrix_obj_explode: {
+            e: string;
+            g: string;
+          };
+          matrix_arr_explode: number[];
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": {
+              status: string;
+            };
+          };
+        };
+        default: components["responses"]["Error"];
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/default-as-error": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        default: components["responses"]["Error"];
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/anyMethod": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        200: components["responses"]["User"];
+        404: components["responses"]["Error"];
+        500: components["responses"]["Error"];
+      };
+    };
+    put: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        200: components["responses"]["User"];
+        404: components["responses"]["Error"];
+        500: components["responses"]["Error"];
+      };
+    };
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        200: components["responses"]["User"];
+        404: components["responses"]["Error"];
+        500: components["responses"]["Error"];
+      };
+    };
+    delete: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        200: components["responses"]["User"];
+        404: components["responses"]["Error"];
+        500: components["responses"]["Error"];
+      };
+    };
+    options: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        200: components["responses"]["User"];
+        404: components["responses"]["Error"];
+        500: components["responses"]["Error"];
+      };
+    };
+    head: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        200: components["responses"]["User"];
+        404: components["responses"]["Error"];
+        500: components["responses"]["Error"];
+      };
+    };
+    patch: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        200: components["responses"]["User"];
+        404: components["responses"]["Error"];
+        500: components["responses"]["Error"];
+      };
+    };
+    trace: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        200: components["responses"]["User"];
+        404: components["responses"]["Error"];
+        500: components["responses"]["Error"];
+      };
+    };
+  };
+  "/contact": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody: components["requestBodies"]["Contact"];
+      responses: {
+        200: components["responses"]["Contact"];
+      };
+    };
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/multiple-response-content": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        200: components["responses"]["MultipleResponse"];
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-    schemas: {
-        Post: {
-            title: string;
-            body: string;
-            publish_date?: number;
-        };
-        StringArray: string[];
-        User: {
-            email: string;
-            age?: number;
-            avatar?: string;
-            /** Format: date */
-            created_at: number;
-            /** Format: date */
-            updated_at: number;
-        };
+  schemas: {
+    Post: {
+      title: string;
+      body: string;
+      publish_date?: number;
     };
-    responses: {
-        AllPostsGet: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json": components["schemas"]["Post"][];
-            };
-        };
-        CreatePost: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json": {
-                    status: string;
-                };
-            };
-        };
-        CreateTag: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json": {
-                    status: string;
-                };
-            };
-        };
-        CreateReply: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json;charset=utf-8": {
-                    message: string;
-                };
-            };
-        };
-        Contact: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "text/html": string;
-            };
-        };
-        EmptyError: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content?: never;
-        };
-        Error: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json": {
-                    code: number;
-                    message: string;
-                };
-            };
-        };
-        PatchPost: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json": {
-                    status: string;
-                };
-            };
-        };
-        PostDelete: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json": {
-                    status: string;
-                };
-            };
-        };
-        PostGet: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json": components["schemas"]["Post"];
-            };
-        };
-        StringArray: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json": components["schemas"]["StringArray"];
-            };
-        };
-        Tag: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json": string;
-            };
-        };
-        User: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json": components["schemas"]["User"];
-            };
-        };
-        MultipleResponse: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json": {
-                    id: string;
-                    email: string;
-                    name?: string;
-                };
-                "application/ld+json": {
-                    "@id": string;
-                    email: string;
-                    name?: string;
-                };
-            };
-        };
+    StringArray: string[];
+    User: {
+      email: string;
+      age?: number;
+      avatar?: string;
+      /** Format: date */
+      created_at: number;
+      /** Format: date */
+      updated_at: number;
     };
-    parameters: never;
-    requestBodies: {
-        CreatePost: {
-            content: {
-                "application/json": {
-                    title: string;
-                    body: string;
-                    publish_date: number;
-                };
-            };
-        };
-        CreatePostOptional: {
-            content: {
-                "application/json": {
-                    title: string;
-                    body: string;
-                    publish_date: number;
-                };
-            };
-        };
-        CreateTag: {
-            content: {
-                "application/json": {
-                    description?: string;
-                };
-            };
-        };
-        CreateReply: {
-            content: {
-                "application/json;charset=utf-8": {
-                    message: string;
-                    replied_at: number;
-                };
-            };
-        };
-        Contact: {
-            content: {
-                "multipart/form-data": {
-                    name: string;
-                    email: string;
-                    subject: string;
-                    message: string;
-                };
-            };
-        };
-        PatchPost: {
-            content: {
-                "application/json": {
-                    title?: string;
-                    body?: string;
-                    publish_date?: number;
-                };
-            };
-        };
+  };
+  responses: {
+    AllPostsGet: {
+      headers: {
+        [name: string]: unknown;
+      };
+      content: {
+        "application/json": components["schemas"]["Post"][];
+      };
     };
-    headers: never;
-    pathItems: never;
+    CreatePost: {
+      headers: {
+        [name: string]: unknown;
+      };
+      content: {
+        "application/json": {
+          status: string;
+        };
+      };
+    };
+    CreateTag: {
+      headers: {
+        [name: string]: unknown;
+      };
+      content: {
+        "application/json": {
+          status: string;
+        };
+      };
+    };
+    CreateReply: {
+      headers: {
+        [name: string]: unknown;
+      };
+      content: {
+        "application/json;charset=utf-8": {
+          message: string;
+        };
+      };
+    };
+    Contact: {
+      headers: {
+        [name: string]: unknown;
+      };
+      content: {
+        "text/html": string;
+      };
+    };
+    EmptyError: {
+      headers: {
+        [name: string]: unknown;
+      };
+      content?: never;
+    };
+    Error: {
+      headers: {
+        [name: string]: unknown;
+      };
+      content: {
+        "application/json": {
+          code: number;
+          message: string;
+        };
+      };
+    };
+    PatchPost: {
+      headers: {
+        [name: string]: unknown;
+      };
+      content: {
+        "application/json": {
+          status: string;
+        };
+      };
+    };
+    PostDelete: {
+      headers: {
+        [name: string]: unknown;
+      };
+      content: {
+        "application/json": {
+          status: string;
+        };
+      };
+    };
+    PostGet: {
+      headers: {
+        [name: string]: unknown;
+      };
+      content: {
+        "application/json": components["schemas"]["Post"];
+      };
+    };
+    StringArray: {
+      headers: {
+        [name: string]: unknown;
+      };
+      content: {
+        "application/json": components["schemas"]["StringArray"];
+      };
+    };
+    Tag: {
+      headers: {
+        [name: string]: unknown;
+      };
+      content: {
+        "application/json": string;
+      };
+    };
+    User: {
+      headers: {
+        [name: string]: unknown;
+      };
+      content: {
+        "application/json": components["schemas"]["User"];
+      };
+    };
+    MultipleResponse: {
+      headers: {
+        [name: string]: unknown;
+      };
+      content: {
+        "application/json": {
+          id: string;
+          email: string;
+          name?: string;
+        };
+        "application/ld+json": {
+          "@id": string;
+          email: string;
+          name?: string;
+        };
+      };
+    };
+  };
+  parameters: never;
+  requestBodies: {
+    CreatePost: {
+      content: {
+        "application/json": {
+          title: string;
+          body: string;
+          publish_date: number;
+        };
+      };
+    };
+    CreatePostOptional: {
+      content: {
+        "application/json": {
+          title: string;
+          body: string;
+          publish_date: number;
+        };
+      };
+    };
+    CreateTag: {
+      content: {
+        "application/json": {
+          description?: string;
+        };
+      };
+    };
+    CreateReply: {
+      content: {
+        "application/json;charset=utf-8": {
+          message: string;
+          replied_at: number;
+        };
+      };
+    };
+    Contact: {
+      content: {
+        "multipart/form-data": {
+          name: string;
+          email: string;
+          subject: string;
+          message: string;
+        };
+      };
+    };
+    PatchPost: {
+      content: {
+        "application/json": {
+          title?: string;
+          body?: string;
+          publish_date?: number;
+        };
+      };
+    };
+  };
+  headers: never;
+  pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    getHeaderParams: {
-        parameters: {
-            query?: never;
-            header: {
-                "x-required-header": string;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        status: string;
-                    };
-                };
-            };
-            500: components["responses"]["Error"];
-        };
+  getHeaderParams: {
+    parameters: {
+      query?: never;
+      header: {
+        "x-required-header": string;
+      };
+      path?: never;
+      cookie?: never;
     };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            status: string;
+          };
+        };
+      };
+      500: components["responses"]["Error"];
+    };
+  };
 }

--- a/packages/openapi-vue-query/test/fixtures/openapi-typescript-codegen.min.js
+++ b/packages/openapi-vue-query/test/fixtures/openapi-typescript-codegen.min.js
@@ -3,8 +3,14723 @@
  * openapi-typescript-codegen@0.25.0
  * on 2023-08-06
  */
-var J=class extends Error{url;status;statusText;body;request;constructor(r,e,n){super(n),this.name="ApiError",this.url=e.url,this.status=e.status,this.statusText=e.statusText,this.body=e.body,this.request=r}};var tr=class extends Error{constructor(r){super(r),this.name="CancelError"}get isCancelled(){return!0}},rr=class{#e;#t;#r;#n;#s;#o;#i;constructor(r){this.#e=!1,this.#t=!1,this.#r=!1,this.#n=[],this.#s=new Promise((e,n)=>{this.#o=e,this.#i=n;let s=m=>{this.#e||this.#t||this.#r||(this.#e=!0,this.#o?.(m))},u=m=>{this.#e||this.#t||this.#r||(this.#t=!0,this.#i?.(m))},_=m=>{this.#e||this.#t||this.#r||this.#n.push(m)};return Object.defineProperty(_,"isResolved",{get:()=>this.#e}),Object.defineProperty(_,"isRejected",{get:()=>this.#t}),Object.defineProperty(_,"isCancelled",{get:()=>this.#r}),r(s,u,_)})}get[Symbol.toStringTag](){return"Cancellable Promise"}then(r,e){return this.#s.then(r,e)}catch(r){return this.#s.catch(r)}finally(r){return this.#s.finally(r)}cancel(){if(!(this.#e||this.#t||this.#r)){if(this.#r=!0,this.#n.length)try{for(let r of this.#n)r()}catch(r){console.warn("Cancellation threw an error",r);return}this.#n.length=0,this.#i?.(new tr("Request aborted"))}}get isCancelled(){return this.#r}};var i={BASE:"https://api.github.com",VERSION:"1.1.4",WITH_CREDENTIALS:!1,CREDENTIALS:"include",TOKEN:void 0,USERNAME:void 0,PASSWORD:void 0,HEADERS:void 0,ENCODE_PATH:void 0};var Br;(r=>{let l;(I=>(I.AUTH="auth",I.ERROR="error",I.NONE="none",I.DETECTING="detecting",I.CHOOSE="choose",I.AUTH_FAILED="auth_failed",I.IMPORTING="importing",I.MAPPING="mapping",I.WAITING_TO_PUSH="waiting_to_push",I.PUSHING="pushing",I.COMPLETE="complete",I.SETUP="setup",I.UNKNOWN="unknown",I.DETECTION_FOUND_MULTIPLE="detection_found_multiple",I.DETECTION_FOUND_NOTHING="detection_found_nothing",I.DETECTION_NEEDS_AUTH="detection_needs_auth"))(l=r.status||={})})(Br||={});var Wr;(e=>{let l;(d=>(d.NPM="npm",d.MAVEN="maven",d.RUBYGEMS="rubygems",d.DOCKER="docker",d.NUGET="nuget",d.CONTAINER="container"))(l=e.package_type||={});let r;(u=>(u.PRIVATE="private",u.PUBLIC="public"))(r=e.visibility||={})})(Wr||={});var Fr=(n=>(n.CREATED_AT="created_at",n.LAST_ACCESSED_AT="last_accessed_at",n.SIZE_IN_BYTES="size_in_bytes",n))(Fr||{});var jr=(e=>(e.READ="read",e.WRITE="write",e))(jr||{});var Vr;(r=>{let l;(u=>(u.NONE="none",u.USER="user",u.ORGANIZATION="organization"))(l=r.access_level||={})})(Vr||={});var Hr;(r=>{let l;(c=>(c.PUSH="push",c.FORCE_PUSH="force_push",c.BRANCH_DELETION="branch_deletion",c.BRANCH_CREATION="branch_creation",c.PR_MERGE="pr_merge",c.MERGE_QUEUE_MERGE="merge_queue_merge"))(l=r.activity_type||={})})(Hr||={});var Qr=(n=>(n.ALL="all",n.LOCAL_ONLY="local_only",n.SELECTED="selected",n))(Qr||{});var Kr;(z=>{let l;(x=>(x.READ="read",x.WRITE="write"))(l=z.actions||={});let r;(x=>(x.READ="read",x.WRITE="write"))(r=z.administration||={});let e;(x=>(x.READ="read",x.WRITE="write"))(e=z.checks||={});let n;(x=>(x.READ="read",x.WRITE="write"))(n=z.contents||={});let s;(x=>(x.READ="read",x.WRITE="write"))(s=z.deployments||={});let u;(x=>(x.READ="read",x.WRITE="write"))(u=z.environments||={});let _;(x=>(x.READ="read",x.WRITE="write"))(_=z.issues||={});let m;(x=>(x.READ="read",x.WRITE="write"))(m=z.metadata||={});let c;(x=>(x.READ="read",x.WRITE="write"))(c=z.packages||={});let d;(x=>(x.READ="read",x.WRITE="write"))(d=z.pages||={});let v;(x=>(x.READ="read",x.WRITE="write"))(v=z.pull_requests||={});let h;(x=>(x.READ="read",x.WRITE="write"))(h=z.repository_hooks||={});let R;(q=>(q.READ="read",q.WRITE="write",q.ADMIN="admin"))(R=z.repository_projects||={});let k;(x=>(x.READ="read",x.WRITE="write"))(k=z.secret_scanning_alerts||={});let b;(x=>(x.READ="read",x.WRITE="write"))(b=z.secrets||={});let p;(x=>(x.READ="read",x.WRITE="write"))(p=z.security_events||={});let f;(x=>(x.READ="read",x.WRITE="write"))(f=z.single_file||={});let O;(x=>(x.READ="read",x.WRITE="write"))(O=z.statuses||={});let I;(x=>(x.READ="read",x.WRITE="write"))(I=z.vulnerability_alerts||={});let P;(S=>S.WRITE="write")(P=z.workflows||={});let E;(x=>(x.READ="read",x.WRITE="write"))(E=z.members||={});let D;(x=>(x.READ="read",x.WRITE="write"))(D=z.organization_administration||={});let L;(x=>(x.READ="read",x.WRITE="write"))(L=z.organization_custom_roles||={});let C;(x=>(x.READ="read",x.WRITE="write"))(C=z.organization_announcement_banners||={});let U;(x=>(x.READ="read",x.WRITE="write"))(U=z.organization_hooks||={});let M;(x=>(x.READ="read",x.WRITE="write"))(M=z.organization_personal_access_tokens||={});let G;(x=>(x.READ="read",x.WRITE="write"))(G=z.organization_personal_access_token_requests||={});let B;(S=>S.READ="read")(B=z.organization_plan||={});let W;(q=>(q.READ="read",q.WRITE="write",q.ADMIN="admin"))(W=z.organization_projects||={});let F;(x=>(x.READ="read",x.WRITE="write"))(F=z.organization_packages||={});let j;(x=>(x.READ="read",x.WRITE="write"))(j=z.organization_secrets||={});let V;(x=>(x.READ="read",x.WRITE="write"))(V=z.organization_self_hosted_runners||={});let H;(x=>(x.READ="read",x.WRITE="write"))(H=z.organization_user_blocking||={});let Q;(x=>(x.READ="read",x.WRITE="write"))(Q=z.team_discussions||={})})(Kr||={});var Yr;(r=>{let l;(s=>(s.ALL="all",s.SELECTED="selected"))(l=r.repository_selection||={})})(Yr||={});var Zr=(c=>(c.COLLABORATOR="COLLABORATOR",c.CONTRIBUTOR="CONTRIBUTOR",c.FIRST_TIMER="FIRST_TIMER",c.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",c.MANNEQUIN="MANNEQUIN",c.MEMBER="MEMBER",c.NONE="NONE",c.OWNER="OWNER",c))(Zr||{});var Xr;(r=>{let l;(u=>(u.MERGE="merge",u.SQUASH="squash",u.REBASE="rebase"))(l=r.merge_method||={})})(Xr||={});var $r;(e=>{let l;(_=>(_.QUEUED="queued",_.IN_PROGRESS="in_progress",_.COMPLETED="completed"))(l=e.status||={});let r;(v=>(v.SUCCESS="success",v.FAILURE="failure",v.NEUTRAL="neutral",v.CANCELLED="cancelled",v.SKIPPED="skipped",v.TIMED_OUT="timed_out",v.ACTION_REQUIRED="action_required"))(r=e.conclusion||={})})($r||={});var Jr;(e=>{let l;(b=>(b.WAITING="waiting",b.PENDING="pending",b.STARTUP_FAILURE="startup_failure",b.STALE="stale",b.SUCCESS="success",b.FAILURE="failure",b.NEUTRAL="neutral",b.CANCELLED="cancelled",b.SKIPPED="skipped",b.TIMED_OUT="timed_out",b.ACTION_REQUIRED="action_required"))(l=e.conclusion||={});let r;(m=>(m.QUEUED="queued",m.IN_PROGRESS="in_progress",m.COMPLETED="completed",m.PENDING="pending"))(r=e.status||={})})(Jr||={});var re;(e=>{let l;(_=>(_.QUEUED="queued",_.IN_PROGRESS="in_progress",_.COMPLETED="completed"))(l=e.status||={});let r;(R=>(R.SUCCESS="success",R.FAILURE="failure",R.NEUTRAL="neutral",R.CANCELLED="cancelled",R.SKIPPED="skipped",R.TIMED_OUT="timed_out",R.ACTION_REQUIRED="action_required",R.STARTUP_FAILURE="startup_failure",R.STALE="stale"))(r=e.conclusion||={})})(re||={});var ee=(s=>(s.SOURCE="source",s.GENERATED="generated",s.TEST="test",s.LIBRARY="library",s))(ee||{});var te=(n=>(n.FALSE_POSITIVE="false positive",n.WON_T_FIX="won't fix",n.USED_IN_TESTS="used in tests",n))(te||{});var ne;(e=>{let l;(m=>(m.NONE="none",m.NOTE="note",m.WARNING="warning",m.ERROR="error"))(l=e.severity||={});let r;(m=>(m.LOW="low",m.MEDIUM="medium",m.HIGH="high",m.CRITICAL="critical"))(r=e.security_severity_level||={})})(ne||={});var se;(r=>{let l;(_=>(_.NONE="none",_.NOTE="note",_.WARNING="warning",_.ERROR="error"))(l=r.severity||={})})(se||={});var ie=(e=>(e.OPEN="open",e.DISMISSED="dismissed",e))(ie||{});var oe=(m=>(m.CRITICAL="critical",m.HIGH="high",m.MEDIUM="medium",m.LOW="low",m.WARNING="warning",m.NOTE="note",m.ERROR="error",m))(oe||{});var le=(n=>(n.OPEN="open",n.DISMISSED="dismissed",n.FIXED="fixed",n))(le||{});var ae=(s=>(s.OPEN="open",s.CLOSED="closed",s.DISMISSED="dismissed",s.FIXED="fixed",s))(ae||{});var ue;(e=>{let l;(u=>(u.CONFIGURED="configured",u.NOT_CONFIGURED="not-configured"))(l=e.state||={});let r;(u=>(u.DEFAULT="default",u.EXTENDED="extended"))(r=e.query_suite||={})})(ue||={});var _e;(e=>{let l;(u=>(u.CONFIGURED="configured",u.NOT_CONFIGURED="not-configured"))(l=e.state||={});let r;(u=>(u.DEFAULT="default",u.EXTENDED="extended"))(r=e.query_suite||={})})(_e||={});var ge;(r=>{let l;(u=>(u.PENDING="pending",u.COMPLETE="complete",u.FAILED="failed"))(l=r.processing_status||={})})(ge||={});var me;(e=>{let l;(E=>(E.UNKNOWN="Unknown",E.CREATED="Created",E.QUEUED="Queued",E.PROVISIONING="Provisioning",E.AVAILABLE="Available",E.AWAITING="Awaiting",E.UNAVAILABLE="Unavailable",E.DELETED="Deleted",E.MOVED="Moved",E.SHUTDOWN="Shutdown",E.ARCHIVED="Archived",E.STARTING="Starting",E.SHUTTING_DOWN="ShuttingDown",E.FAILED="Failed",E.EXPORTING="Exporting",E.UPDATING="Updating",E.REBUILDING="Rebuilding"))(l=e.state||={});let r;(m=>(m.EAST_US="EastUs",m.SOUTH_EAST_ASIA="SouthEastAsia",m.WEST_EUROPE="WestEurope",m.WEST_US2="WestUs2"))(r=e.location||={})})(me||={});var pe;(r=>{let l;(u=>(u.NONE="none",u.READY="ready",u.IN_PROGRESS="in_progress"))(l=r.prebuild_availability||={})})(pe||={});var de;(e=>{let l;(E=>(E.UNKNOWN="Unknown",E.CREATED="Created",E.QUEUED="Queued",E.PROVISIONING="Provisioning",E.AVAILABLE="Available",E.AWAITING="Awaiting",E.UNAVAILABLE="Unavailable",E.DELETED="Deleted",E.MOVED="Moved",E.SHUTDOWN="Shutdown",E.ARCHIVED="Archived",E.STARTING="Starting",E.SHUTTING_DOWN="ShuttingDown",E.FAILED="Failed",E.EXPORTING="Exporting",E.UPDATING="Updating",E.REBUILDING="Rebuilding"))(l=e.state||={});let r;(m=>(m.EAST_US="EastUs",m.SOUTH_EAST_ASIA="SouthEastAsia",m.WEST_EUROPE="WestEurope",m.WEST_US2="WestUs2"))(r=e.location||={})})(de||={});var ce;(r=>{let l;(u=>(u.ALL="all",u.PRIVATE="private",u.SELECTED="selected"))(l=r.visibility||={})})(ce||={});var be;(r=>{let l;(u=>(u.ALL="all",u.PRIVATE="private",u.SELECTED="selected"))(l=r.visibility||={})})(be||={});var he;(r=>{let l;(_=>(_.DIVERGED="diverged",_.AHEAD="ahead",_.BEHIND="behind",_.IDENTICAL="identical"))(l=r.status||={})})(he||={});var ye;(r=>{let l;(n=>n.FILE="file")(l=r.type||={})})(ye||={});var fe;(r=>{let l;(n=>n.SUBMODULE="submodule")(l=r.type||={})})(fe||={});var we;(r=>{let l;(n=>n.SYMLINK="symlink")(l=r.type||={})})(we||={});var Ee;(n=>{let l;(c=>(c.AUTO_DISMISSED="auto_dismissed",c.DISMISSED="dismissed",c.FIXED="fixed",c.OPEN="open"))(l=n.state||={});let r;(_=>(_.DEVELOPMENT="development",_.RUNTIME="runtime"))(r=n.scope||={});let e;(d=>(d.FIX_STARTED="fix_started",d.INACCURATE="inaccurate",d.NO_BANDWIDTH="no_bandwidth",d.NOT_USED="not_used",d.TOLERABLE_RISK="tolerable_risk"))(e=n.dismissed_reason||={})})(Ee||={});var ve=(e=>(e.DEVELOPMENT="development",e.RUNTIME="runtime",e))(ve||{});var Re;(r=>{let l;(_=>(_.LOW="low",_.MEDIUM="medium",_.HIGH="high",_.CRITICAL="critical"))(l=r.severity||={})})(Re||={});var Te;(r=>{let l;(_=>(_.LOW="low",_.MEDIUM="medium",_.HIGH="high",_.CRITICAL="critical"))(l=r.severity||={})})(Te||={});var Ae=(e=>(e.CREATED="created",e.UPDATED="updated",e))(Ae||{});var ke;(n=>{let l;(c=>(c.AUTO_DISMISSED="auto_dismissed",c.DISMISSED="dismissed",c.FIXED="fixed",c.OPEN="open"))(l=n.state||={});let r;(_=>(_.DEVELOPMENT="development",_.RUNTIME="runtime"))(r=n.scope||={});let e;(d=>(d.FIX_STARTED="fix_started",d.INACCURATE="inaccurate",d.NO_BANDWIDTH="no_bandwidth",d.NOT_USED="not_used",d.TOLERABLE_RISK="tolerable_risk"))(e=n.dismissed_reason||={})})(ke||={});var xe;(e=>{let l;(u=>(u.DIRECT="direct",u.INDIRECT="indirect"))(l=e.relationship||={});let r;(u=>(u.RUNTIME="runtime",u.DEVELOPMENT="development"))(r=e.scope||={})})(xe||={});var Ie=(e=>(e.USER="User",e.TEAM="Team",e))(Ie||{});var Oe;(r=>{let l;(d=>(d.ERROR="error",d.FAILURE="failure",d.INACTIVE="inactive",d.PENDING="pending",d.SUCCESS="success",d.QUEUED="queued",d.IN_PROGRESS="in_progress"))(l=r.state||={})})(Oe||={});var Ne;(r=>{let l;(d=>(d.ADDED="added",d.REMOVED="removed",d.MODIFIED="modified",d.RENAMED="renamed",d.COPIED="copied",d.CHANGED="changed",d.UNCHANGED="unchanged"))(l=r.status||={})})(Ne||={});var ze=(e=>(e.ASC="asc",e.DESC="desc",e))(ze||{});var Pe;(s=>{let l;(c=>(c.BOT="Bot",c.USER="User",c.ORGANIZATION="Organization"))(l=s.type||={});let r;(k=>(k.COLLABORATOR="COLLABORATOR",k.CONTRIBUTOR="CONTRIBUTOR",k.FIRST_TIMER="FIRST_TIMER",k.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",k.MANNEQUIN="MANNEQUIN",k.MEMBER="MEMBER",k.NONE="NONE",k.OWNER="OWNER"))(r=s.author_association||={});let e;(v=>(v.OPEN="open",v.CLOSED="closed",v.LOCKED="locked",v.CONVERTING="converting",v.TRANSFERRING="transferring"))(e=s.state||={});let n;(d=>(d.RESOLVED="resolved",d.OUTDATED="outdated",d.DUPLICATE="duplicate",d.REOPENED="reopened"))(n=s.state_reason||={})})(Pe||={});var Ce=(n=>(n.ALL="all",n.NONE="none",n.SELECTED="selected",n))(Ce||{});var De;(r=>{let l;(u=>(u.APPROVED="approved",u.REJECTED="rejected",u.PENDING="pending"))(l=r.state||={})})(De||={});var qe;(s=>{let l;(m=>(m.PR_TITLE="PR_TITLE",m.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(l=s.squash_merge_commit_title||={});let r;(c=>(c.PR_BODY="PR_BODY",c.COMMIT_MESSAGES="COMMIT_MESSAGES",c.BLANK="BLANK"))(r=s.squash_merge_commit_message||={});let e;(m=>(m.PR_TITLE="PR_TITLE",m.MERGE_MESSAGE="MERGE_MESSAGE"))(e=s.merge_commit_title||={});let n;(c=>(c.PR_BODY="PR_BODY",c.PR_TITLE="PR_TITLE",c.BLANK="BLANK"))(n=s.merge_commit_message||={})})(qe||={});var Se;(e=>{let l;(_=>(_.REVIEWED="reviewed",_.UNREVIEWED="unreviewed",_.MALWARE="malware"))(l=e.type||={});let r;(c=>(c.CRITICAL="critical",c.HIGH="high",c.MEDIUM="medium",c.LOW="low",c.UNKNOWN="unknown"))(r=e.severity||={})})(Se||={});var Le;(r=>{let l;(s=>(s.ALL="all",s.SELECTED="selected"))(l=r.repository_selection||={})})(Le||={});var Ue;(r=>{let l;(s=>(s.ALL="all",s.SELECTED="selected"))(l=r.repository_selection||={})})(Ue||={});var Me=(u=>(u.ONE_DAY="one_day",u.THREE_DAYS="three_days",u.ONE_WEEK="one_week",u.ONE_MONTH="one_month",u.SIX_MONTHS="six_months",u))(Me||{});var Ge=(n=>(n.EXISTING_USERS="existing_users",n.CONTRIBUTORS_ONLY="contributors_only",n.COLLABORATORS_ONLY="collaborators_only",n))(Ge||{});var Be;(r=>{let l;(u=>(u.COMPLETED="completed",u.REOPENED="reopened",u.NOT_PLANNED="not_planned"))(l=r.state_reason||={})})(Be||={});var We;(e=>{let l;(_=>(_.QUEUED="queued",_.IN_PROGRESS="in_progress",_.COMPLETED="completed"))(l=e.status||={});let r;(v=>(v.SUCCESS="success",v.FAILURE="failure",v.NEUTRAL="neutral",v.CANCELLED="cancelled",v.SKIPPED="skipped",v.TIMED_OUT="timed_out",v.ACTION_REQUIRED="action_required"))(r=e.conclusion||={})})(We||={});var Fe;(r=>{let l;(u=>(u.FREE="FREE",u.FLAT_RATE="FLAT_RATE",u.PER_UNIT="PER_UNIT"))(l=r.price_model||={})})(Fe||={});var je;(r=>{let l;(u=>(u.MERGE="merge",u.FAST_FORWARD="fast-forward",u.NONE="none"))(l=r.merge_type||={})})(je||={});var Ve;(r=>{let l;(s=>(s.OPEN="open",s.CLOSED="closed"))(l=r.state||={})})(Ve||={});var He;(r=>{let l;(u=>(u.NONE="none",u.READY="ready",u.IN_PROGRESS="in_progress"))(l=r.prebuild_availability||={})})(He||={});var Qe;(r=>{let l;(u=>(u.COMPLETED="completed",u.REOPENED="reopened",u.NOT_PLANNED="not_planned"))(l=r.state_reason||={})})(Qe||={});var Ke;(r=>{let l;(s=>(s.OPEN="open",s.CLOSED="closed"))(l=r.state||={})})(Ke||={});var Ye;(s=>{let l;(m=>(m.PR_TITLE="PR_TITLE",m.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(l=s.squash_merge_commit_title||={});let r;(c=>(c.PR_BODY="PR_BODY",c.COMMIT_MESSAGES="COMMIT_MESSAGES",c.BLANK="BLANK"))(r=s.squash_merge_commit_message||={});let e;(m=>(m.PR_TITLE="PR_TITLE",m.MERGE_MESSAGE="MERGE_MESSAGE"))(e=s.merge_commit_title||={});let n;(c=>(c.PR_BODY="PR_BODY",c.PR_TITLE="PR_TITLE",c.BLANK="BLANK"))(n=s.merge_commit_message||={})})(Ye||={});var Ze;(r=>{let l;(s=>(s.ALL="all",s.SELECTED="selected"))(l=r.repository_selection||={})})(Ze||={});var Xe=(e=>(e.DESC="desc",e.ASC="asc",e))(Xe||{});var $e;(e=>{let l;(u=>(u.ACTIVE="active",u.PENDING="pending"))(l=e.state||={});let r;(_=>(_.ADMIN="admin",_.MEMBER="member",_.BILLING_MANAGER="billing_manager"))(r=e.role||={})})($e||={});var Je=(e=>(e.ENABLE_ALL="enable_all",e.DISABLE_ALL="disable_all",e))(Je||{});var rt;(r=>{let l;(u=>(u.ALL="all",u.PRIVATE="private",u.SELECTED="selected"))(l=r.visibility||={})})(rt||={});var et;(r=>{let l;(u=>(u.ALL="all",u.PRIVATE="private",u.SELECTED="selected"))(l=r.visibility||={})})(et||={});var tt;(r=>{let l;(u=>(u.ALL="all",u.PRIVATE="private",u.SELECTED="selected"))(l=r.visibility||={})})(tt||={});var nt;(r=>{let l;(u=>(u.NONE="none",u.ALL="all",u.SUBSET="subset"))(l=r.repository_selection||={})})(nt||={});var st;(r=>{let l;(u=>(u.NONE="none",u.ALL="all",u.SUBSET="subset"))(l=r.repository_selection||={})})(st||={});var it=(_=>(_.NPM="npm",_.MAVEN="maven",_.RUBYGEMS="rubygems",_.DOCKER="docker",_.NUGET="nuget",_.CONTAINER="container",_))(it||{});var ot;(r=>{let l;(c=>(c.NPM="npm",c.MAVEN="maven",c.RUBYGEMS="rubygems",c.DOCKER="docker",c.NUGET="nuget",c.CONTAINER="container"))(l=r.package_type||={})})(ot||={});var lt=(n=>(n.PUBLIC="public",n.PRIVATE="private",n.INTERNAL="internal",n))(lt||{});var at;(r=>{let l;(b=>(b.NEW="new",b.AUTHORIZATION_CREATED="authorization_created",b.AUTHORIZATION_PENDING="authorization_pending",b.AUTHORIZED="authorized",b.AUTHORIZATION_REVOKED="authorization_revoked",b.ISSUED="issued",b.UPLOADED="uploaded",b.APPROVED="approved",b.ERRORED="errored",b.BAD_AUTHZ="bad_authz",b.DESTROY_PENDING="destroy_pending",b.DNS_CHANGED="dns_changed"))(l=r.state||={})})(at||={});var ut=(e=>(e.DAY="day",e.WEEK="week",e))(ut||{});var _t;(r=>{let l;(u=>(u.NONE="none",u.ALL="all",u.SUBSET="subset"))(l=r.repository_selection||={})})(_t||={});var gt=(r=>(r.CREATED_AT="created_at",r))(gt||{});var mt;(r=>{let l;(_=>(_.CRITICAL="critical",_.HIGH="high",_.MEDIUM="medium",_.LOW="low"))(l=r.severity||={})})(mt||={});var pt;(r=>{let l;(_=>(_.READ="read",_.WRITE="write",_.ADMIN="admin",_.NONE="none"))(l=r.organization_permission||={})})(pt||={});var dt=(n=>(n.ISSUE="Issue",n.PULL_REQUEST="PullRequest",n.DRAFT_ISSUE="DraftIssue",n))(dt||{});var ct;(r=>{let l;(s=>(s.OPEN="open",s.CLOSED="closed"))(l=r.state||={})})(ct||={});var bt;(n=>{let l;(_=>(_.LEFT="LEFT",_.RIGHT="RIGHT"))(l=n.start_side||={});let r;(_=>(_.LEFT="LEFT",_.RIGHT="RIGHT"))(r=n.side||={});let e;(_=>(_.LINE="line",_.FILE="file"))(e=n.subject_type||={})})(bt||={});var ht;(r=>{let l;(d=>(d._1="-1",d.LAUGH="laugh",d.CONFUSED="confused",d.HEART="heart",d.HOORAY="hooray",d.ROCKET="rocket",d.EYES="eyes"))(l=r.content||={})})(ht||={});var yt;(r=>{let l;(s=>(s.UPLOADED="uploaded",s.OPEN="open"))(l=r.state||={})})(yt||={});var ft;(s=>{let l;(m=>(m.PR_TITLE="PR_TITLE",m.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(l=s.squash_merge_commit_title||={});let r;(c=>(c.PR_BODY="PR_BODY",c.COMMIT_MESSAGES="COMMIT_MESSAGES",c.BLANK="BLANK"))(r=s.squash_merge_commit_message||={});let e;(m=>(m.PR_TITLE="PR_TITLE",m.MERGE_MESSAGE="MERGE_MESSAGE"))(e=s.merge_commit_title||={});let n;(c=>(c.PR_BODY="PR_BODY",c.PR_TITLE="PR_TITLE",c.BLANK="BLANK"))(n=s.merge_commit_message||={})})(ft||={});var wt;(e=>{let l;(m=>(m.CRITICAL="critical",m.HIGH="high",m.MEDIUM="medium",m.LOW="low"))(l=e.severity||={});let r;(c=>(c.PUBLISHED="published",c.CLOSED="closed",c.WITHDRAWN="withdrawn",c.DRAFT="draft",c.TRIAGE="triage"))(r=e.state||={})})(wt||={});var Et;(r=>{let l;(_=>(_.CRITICAL="critical",_.HIGH="high",_.MEDIUM="medium",_.LOW="low"))(l=r.severity||={})})(Et||={});var vt;(r=>{let l;(u=>(u.ACCEPTED="accepted",u.DECLINED="declined",u.PENDING="pending"))(l=r.state||={})})(vt||={});var Rt;(e=>{let l;(m=>(m.CRITICAL="critical",m.HIGH="high",m.MEDIUM="medium",m.LOW="low"))(l=e.severity||={});let r;(_=>(_.PUBLISHED="published",_.CLOSED="closed",_.DRAFT="draft"))(r=e.state||={})})(Rt||={});var Tt;(r=>{let l;(m=>(m.READ="read",m.WRITE="write",m.ADMIN="admin",m.TRIAGE="triage",m.MAINTAIN="maintain"))(l=r.permissions||={})})(Tt||={});var At;(e=>{let l;(s=>s.BRANCH_NAME_PATTERN="branch_name_pattern")(l=e.type||={});let r;(m=>(m.STARTS_WITH="starts_with",m.ENDS_WITH="ends_with",m.CONTAINS="contains",m.REGEX="regex"))(r=e.operator||={})})(At||={});var kt;(e=>{let l;(s=>s.COMMIT_AUTHOR_EMAIL_PATTERN="commit_author_email_pattern")(l=e.type||={});let r;(m=>(m.STARTS_WITH="starts_with",m.ENDS_WITH="ends_with",m.CONTAINS="contains",m.REGEX="regex"))(r=e.operator||={})})(kt||={});var xt;(e=>{let l;(s=>s.COMMIT_MESSAGE_PATTERN="commit_message_pattern")(l=e.type||={});let r;(m=>(m.STARTS_WITH="starts_with",m.ENDS_WITH="ends_with",m.CONTAINS="contains",m.REGEX="regex"))(r=e.operator||={})})(xt||={});var It;(e=>{let l;(s=>s.COMMITTER_EMAIL_PATTERN="committer_email_pattern")(l=e.type||={});let r;(m=>(m.STARTS_WITH="starts_with",m.ENDS_WITH="ends_with",m.CONTAINS="contains",m.REGEX="regex"))(r=e.operator||={})})(It||={});var Ot;(r=>{let l;(n=>n.CREATION="creation")(l=r.type||={})})(Ot||={});var Nt;(r=>{let l;(n=>n.DELETION="deletion")(l=r.type||={})})(Nt||={});var zt=(n=>(n.DISABLED="disabled",n.ACTIVE="active",n.EVALUATE="evaluate",n))(zt||{});var Pt;(r=>{let l;(n=>n.NON_FAST_FORWARD="non_fast_forward")(l=r.type||={})})(Pt||={});var Ct;(r=>{let l;(n=>n.PULL_REQUEST="pull_request")(l=r.type||={})})(Ct||={});var Dt;(r=>{let l;(n=>n.REQUIRED_DEPLOYMENTS="required_deployments")(l=r.type||={})})(Dt||={});var qt;(r=>{let l;(n=>n.REQUIRED_LINEAR_HISTORY="required_linear_history")(l=r.type||={})})(qt||={});var St;(r=>{let l;(n=>n.REQUIRED_SIGNATURES="required_signatures")(l=r.type||={})})(St||={});var Lt;(r=>{let l;(n=>n.REQUIRED_STATUS_CHECKS="required_status_checks")(l=r.type||={})})(Lt||={});var Ut;(e=>{let l;(s=>s.TAG_NAME_PATTERN="tag_name_pattern")(l=e.type||={});let r;(m=>(m.STARTS_WITH="starts_with",m.ENDS_WITH="ends_with",m.CONTAINS="contains",m.REGEX="regex"))(r=e.operator||={})})(Ut||={});var Mt;(r=>{let l;(n=>n.UPDATE="update")(l=r.type||={})})(Mt||={});var Gt;(n=>{let l;(_=>(_.BRANCH="branch",_.TAG="tag"))(l=n.target||={});let r;(_=>(_.REPOSITORY="Repository",_.ORGANIZATION="Organization"))(r=n.source_type||={});let e;(m=>(m.ALWAYS="always",m.PULL_REQUESTS_ONLY="pull_requests_only",m.NEVER="never"))(e=n.current_user_can_bypass||={})})(Gt||={});var Bt;(e=>{let l;(m=>(m.REPOSITORY_ROLE="RepositoryRole",m.TEAM="Team",m.INTEGRATION="Integration",m.ORGANIZATION_ADMIN="OrganizationAdmin"))(l=e.actor_type||={});let r;(u=>(u.ALWAYS="always",u.PULL_REQUEST="pull_request"))(r=e.bypass_mode||={})})(Bt||={});var Wt;(e=>{let l;(u=>(u.LEFT="LEFT",u.RIGHT="RIGHT"))(l=e.side||={});let r;(u=>(u.LEFT="LEFT",u.RIGHT="RIGHT"))(r=e.start_side||={})})(Wt||={});var Ft;(r=>{let l;(s=>(s.APPROVED="approved",s.REJECTED="rejected"))(l=r.state||={})})(Ft||={});var jt;(r=>{let l;(s=>(s.READ_ONLY="read-only",s.CUSTOM="custom"))(l=r.type||={})})(jt||={});var Vt=(_=>(_.FALSE_POSITIVE="false_positive",_.WONT_FIX="wont_fix",_.REVOKED="revoked",_.USED_IN_TESTS="used_in_tests",_.PATTERN_DELETED="pattern_deleted",_.PATTERN_EDITED="pattern_edited",_))(Vt||{});var Ht=(e=>(e.CREATED="created",e.UPDATED="updated",e))(Ht||{});var Qt=(e=>(e.OPEN="open",e.RESOLVED="resolved",e))(Qt||{});var Kt;(r=>{let l;(_=>(_.COMMIT="commit",_.ISSUE_TITLE="issue_title",_.ISSUE_BODY="issue_body",_.ISSUE_COMMENT="issue_comment"))(l=r.type||={})})(Kt||={});var Yt=(v=>(v.ANALYST="analyst",v.FINDER="finder",v.REPORTER="reporter",v.COORDINATOR="coordinator",v.REMEDIATION_DEVELOPER="remediation_developer",v.REMEDIATION_REVIEWER="remediation_reviewer",v.REMEDIATION_VERIFIER="remediation_verifier",v.TOOL="tool",v.SPONSOR="sponsor",v.OTHER="other",v))(Yt||{});var Zt=(k=>(k.RUBYGEMS="rubygems",k.NPM="npm",k.PIP="pip",k.MAVEN="maven",k.NUGET="nuget",k.COMPOSER="composer",k.GO="go",k.RUST="rust",k.ERLANG="erlang",k.ACTIONS="actions",k.PUB="pub",k.OTHER="other",k.SWIFT="swift",k))(Zt||{});var Xt;(r=>{let l;(s=>(s.ENABLED="enabled",s.DISABLED="disabled"))(l=r.status||={})})(Xt||={});var $t=(m=>(m.DEPENDENCY_GRAPH="dependency_graph",m.DEPENDABOT_ALERTS="dependabot_alerts",m.DEPENDABOT_SECURITY_UPDATES="dependabot_security_updates",m.ADVANCED_SECURITY="advanced_security",m.CODE_SCANNING_DEFAULT_SETUP="code_scanning_default_setup",m.SECRET_SCANNING="secret_scanning",m.SECRET_SCANNING_PUSH_PROTECTION="secret_scanning_push_protection",m))($t||{});var Jt;(e=>{let l;(R=>(R.SUCCESS="success",R.FAILURE="failure",R.NEUTRAL="neutral",R.CANCELLED="cancelled",R.SKIPPED="skipped",R.TIMED_OUT="timed_out",R.ACTION_REQUIRED="action_required",R.STALE="stale",R.STARTUP_FAILURE="startup_failure"))(l=e.conclusion||={});let r;(c=>(c.QUEUED="queued",c.IN_PROGRESS="in_progress",c.COMPLETED="completed",c.PENDING="pending",c.WAITING="waiting"))(r=e.status||={})})(Jt||={});var rn=(e=>(e.CREATED="created",e.UPDATED="updated",e))(rn||{});var en=(e=>(e.CREATED="created",e.UPDATED="updated",e))(en||{});var tn=(n=>(n.QUEUED="queued",n.IN_PROGRESS="in_progress",n.COMPLETED="completed",n))(tn||{});var nn;(e=>{let l;(u=>(u.CLOSED="closed",u.SECRET="secret"))(l=e.privacy||={});let r;(u=>(u.NOTIFICATIONS_ENABLED="notifications_enabled",u.NOTIFICATIONS_DISABLED="notifications_disabled"))(r=e.notification_setting||={})})(nn||={});var sn;(e=>{let l;(u=>(u.MEMBER="member",u.MAINTAINER="maintainer"))(l=e.role||={});let r;(u=>(u.ACTIVE="active",u.PENDING="pending"))(r=e.state||={})})(sn||={});var on;(v=>{let l;(R=>R.CREATED="created")(l=v.action||={});let r;(b=>(b.OFF="off",b.NON_ADMINS="non_admins",b.EVERYONE="everyone"))(r=v.allow_deletions_enforcement_level||={});let e;(b=>(b.OFF="off",b.NON_ADMINS="non_admins",b.EVERYONE="everyone"))(e=v.allow_force_pushes_enforcement_level||={});let n;(b=>(b.OFF="off",b.NON_ADMINS="non_admins",b.EVERYONE="everyone"))(n=v.linear_history_requirement_enforcement_level||={});let s;(b=>(b.OFF="off",b.NON_ADMINS="non_admins",b.EVERYONE="everyone"))(s=v.merge_queue_enforcement_level||={});let u;(b=>(b.OFF="off",b.NON_ADMINS="non_admins",b.EVERYONE="everyone"))(u=v.pull_request_reviews_enforcement_level||={});let _;(b=>(b.OFF="off",b.NON_ADMINS="non_admins",b.EVERYONE="everyone"))(_=v.required_conversation_resolution_level||={});let m;(b=>(b.OFF="off",b.NON_ADMINS="non_admins",b.EVERYONE="everyone"))(m=v.required_deployments_enforcement_level||={});let c;(b=>(b.OFF="off",b.NON_ADMINS="non_admins",b.EVERYONE="everyone"))(c=v.required_status_checks_enforcement_level||={});let d;(b=>(b.OFF="off",b.NON_ADMINS="non_admins",b.EVERYONE="everyone"))(d=v.signature_requirement_enforcement_level||={})})(on||={});var ln;(v=>{let l;(R=>R.DELETED="deleted")(l=v.action||={});let r;(b=>(b.OFF="off",b.NON_ADMINS="non_admins",b.EVERYONE="everyone"))(r=v.allow_deletions_enforcement_level||={});let e;(b=>(b.OFF="off",b.NON_ADMINS="non_admins",b.EVERYONE="everyone"))(e=v.allow_force_pushes_enforcement_level||={});let n;(b=>(b.OFF="off",b.NON_ADMINS="non_admins",b.EVERYONE="everyone"))(n=v.linear_history_requirement_enforcement_level||={});let s;(b=>(b.OFF="off",b.NON_ADMINS="non_admins",b.EVERYONE="everyone"))(s=v.merge_queue_enforcement_level||={});let u;(b=>(b.OFF="off",b.NON_ADMINS="non_admins",b.EVERYONE="everyone"))(u=v.pull_request_reviews_enforcement_level||={});let _;(b=>(b.OFF="off",b.NON_ADMINS="non_admins",b.EVERYONE="everyone"))(_=v.required_conversation_resolution_level||={});let m;(b=>(b.OFF="off",b.NON_ADMINS="non_admins",b.EVERYONE="everyone"))(m=v.required_deployments_enforcement_level||={});let c;(b=>(b.OFF="off",b.NON_ADMINS="non_admins",b.EVERYONE="everyone"))(c=v.required_status_checks_enforcement_level||={});let d;(b=>(b.OFF="off",b.NON_ADMINS="non_admins",b.EVERYONE="everyone"))(d=v.signature_requirement_enforcement_level||={})})(ln||={});var an;(h=>{let l;(k=>k.EDITED="edited")(l=h.action||={});let r;(p=>(p.OFF="off",p.NON_ADMINS="non_admins",p.EVERYONE="everyone"))(r=h.from||={});let e;(p=>(p.OFF="off",p.NON_ADMINS="non_admins",p.EVERYONE="everyone"))(e=h.allow_deletions_enforcement_level||={});let n;(p=>(p.OFF="off",p.NON_ADMINS="non_admins",p.EVERYONE="everyone"))(n=h.allow_force_pushes_enforcement_level||={});let s;(p=>(p.OFF="off",p.NON_ADMINS="non_admins",p.EVERYONE="everyone"))(s=h.linear_history_requirement_enforcement_level||={});let u;(p=>(p.OFF="off",p.NON_ADMINS="non_admins",p.EVERYONE="everyone"))(u=h.merge_queue_enforcement_level||={});let _;(p=>(p.OFF="off",p.NON_ADMINS="non_admins",p.EVERYONE="everyone"))(_=h.pull_request_reviews_enforcement_level||={});let m;(p=>(p.OFF="off",p.NON_ADMINS="non_admins",p.EVERYONE="everyone"))(m=h.required_conversation_resolution_level||={});let c;(p=>(p.OFF="off",p.NON_ADMINS="non_admins",p.EVERYONE="everyone"))(c=h.required_deployments_enforcement_level||={});let d;(p=>(p.OFF="off",p.NON_ADMINS="non_admins",p.EVERYONE="everyone"))(d=h.required_status_checks_enforcement_level||={});let v;(p=>(p.OFF="off",p.NON_ADMINS="non_admins",p.EVERYONE="everyone"))(v=h.signature_requirement_enforcement_level||={})})(an||={});var un;(r=>{let l;(n=>n.COMPLETED="completed")(l=r.action||={})})(un||={});var _n;(r=>{let l;(n=>n.CREATED="created")(l=r.action||={})})(_n||={});var gn;(r=>{let l;(n=>n.REQUESTED_ACTION="requested_action")(l=r.action||={})})(gn||={});var mn;(r=>{let l;(n=>n.REREQUESTED="rerequested")(l=r.action||={})})(mn||={});var pn;(w=>{let l;(N=>N.COMPLETED="completed")(l=w.action||={});let r;(t=>(t.BOT="Bot",t.USER="User",t.ORGANIZATION="Organization"))(r=w.type||={});let e;(g=>(g.READ="read",g.WRITE="write"))(e=w.actions||={});let n;(g=>(g.READ="read",g.WRITE="write"))(n=w.administration||={});let s;(g=>(g.READ="read",g.WRITE="write"))(s=w.checks||={});let u;(g=>(g.READ="read",g.WRITE="write"))(u=w.content_references||={});let _;(g=>(g.READ="read",g.WRITE="write"))(_=w.contents||={});let m;(g=>(g.READ="read",g.WRITE="write"))(m=w.deployments||={});let c;(g=>(g.READ="read",g.WRITE="write"))(c=w.discussions||={});let d;(g=>(g.READ="read",g.WRITE="write"))(d=w.emails||={});let v;(g=>(g.READ="read",g.WRITE="write"))(v=w.environments||={});let h;(g=>(g.READ="read",g.WRITE="write"))(h=w.issues||={});let R;(g=>(g.READ="read",g.WRITE="write"))(R=w.keys||={});let k;(g=>(g.READ="read",g.WRITE="write"))(k=w.members||={});let b;(g=>(g.READ="read",g.WRITE="write"))(b=w.metadata||={});let p;(g=>(g.READ="read",g.WRITE="write"))(p=w.organization_administration||={});let f;(g=>(g.READ="read",g.WRITE="write"))(f=w.organization_hooks||={});let O;(g=>(g.READ="read",g.WRITE="write"))(O=w.organization_packages||={});let I;(g=>(g.READ="read",g.WRITE="write"))(I=w.organization_plan||={});let P;(t=>(t.READ="read",t.WRITE="write",t.ADMIN="admin"))(P=w.organization_projects||={});let E;(g=>(g.READ="read",g.WRITE="write"))(E=w.organization_secrets||={});let D;(g=>(g.READ="read",g.WRITE="write"))(D=w.organization_self_hosted_runners||={});let L;(g=>(g.READ="read",g.WRITE="write"))(L=w.organization_user_blocking||={});let C;(g=>(g.READ="read",g.WRITE="write"))(C=w.packages||={});let U;(g=>(g.READ="read",g.WRITE="write"))(U=w.pages||={});let M;(g=>(g.READ="read",g.WRITE="write"))(M=w.pull_requests||={});let G;(g=>(g.READ="read",g.WRITE="write"))(G=w.repository_hooks||={});let B;(t=>(t.READ="read",t.WRITE="write",t.ADMIN="admin"))(B=w.repository_projects||={});let W;(g=>(g.READ="read",g.WRITE="write"))(W=w.secret_scanning_alerts||={});let F;(g=>(g.READ="read",g.WRITE="write"))(F=w.secrets||={});let j;(g=>(g.READ="read",g.WRITE="write"))(j=w.security_events||={});let V;(g=>(g.READ="read",g.WRITE="write"))(V=w.security_scanning_alert||={});let H;(g=>(g.READ="read",g.WRITE="write"))(H=w.single_file||={});let Q;(g=>(g.READ="read",g.WRITE="write"))(Q=w.statuses||={});let z;(g=>(g.READ="read",g.WRITE="write"))(z=w.team_discussions||={});let K;(g=>(g.READ="read",g.WRITE="write"))(K=w.vulnerability_alerts||={});let S;(g=>(g.READ="read",g.WRITE="write"))(S=w.workflows||={});let x;(T=>(T.SUCCESS="success",T.FAILURE="failure",T.NEUTRAL="neutral",T.CANCELLED="cancelled",T.TIMED_OUT="timed_out",T.ACTION_REQUIRED="action_required",T.STALE="stale",T.SKIPPED="skipped",T.STARTUP_FAILURE="startup_failure"))(x=w.conclusion||={});let q;(A=>(A.REQUESTED="requested",A.IN_PROGRESS="in_progress",A.COMPLETED="completed",A.QUEUED="queued",A.PENDING="pending"))(q=w.status||={})})(pn||={});var dn;(w=>{let l;(N=>N.REQUESTED="requested")(l=w.action||={});let r;(t=>(t.BOT="Bot",t.USER="User",t.ORGANIZATION="Organization"))(r=w.type||={});let e;(g=>(g.READ="read",g.WRITE="write"))(e=w.actions||={});let n;(g=>(g.READ="read",g.WRITE="write"))(n=w.administration||={});let s;(g=>(g.READ="read",g.WRITE="write"))(s=w.checks||={});let u;(g=>(g.READ="read",g.WRITE="write"))(u=w.content_references||={});let _;(g=>(g.READ="read",g.WRITE="write"))(_=w.contents||={});let m;(g=>(g.READ="read",g.WRITE="write"))(m=w.deployments||={});let c;(g=>(g.READ="read",g.WRITE="write"))(c=w.discussions||={});let d;(g=>(g.READ="read",g.WRITE="write"))(d=w.emails||={});let v;(g=>(g.READ="read",g.WRITE="write"))(v=w.environments||={});let h;(g=>(g.READ="read",g.WRITE="write"))(h=w.issues||={});let R;(g=>(g.READ="read",g.WRITE="write"))(R=w.keys||={});let k;(g=>(g.READ="read",g.WRITE="write"))(k=w.members||={});let b;(g=>(g.READ="read",g.WRITE="write"))(b=w.metadata||={});let p;(g=>(g.READ="read",g.WRITE="write"))(p=w.organization_administration||={});let f;(g=>(g.READ="read",g.WRITE="write"))(f=w.organization_hooks||={});let O;(g=>(g.READ="read",g.WRITE="write"))(O=w.organization_packages||={});let I;(g=>(g.READ="read",g.WRITE="write"))(I=w.organization_plan||={});let P;(t=>(t.READ="read",t.WRITE="write",t.ADMIN="admin"))(P=w.organization_projects||={});let E;(g=>(g.READ="read",g.WRITE="write"))(E=w.organization_secrets||={});let D;(g=>(g.READ="read",g.WRITE="write"))(D=w.organization_self_hosted_runners||={});let L;(g=>(g.READ="read",g.WRITE="write"))(L=w.organization_user_blocking||={});let C;(g=>(g.READ="read",g.WRITE="write"))(C=w.packages||={});let U;(g=>(g.READ="read",g.WRITE="write"))(U=w.pages||={});let M;(g=>(g.READ="read",g.WRITE="write"))(M=w.pull_requests||={});let G;(g=>(g.READ="read",g.WRITE="write"))(G=w.repository_hooks||={});let B;(t=>(t.READ="read",t.WRITE="write",t.ADMIN="admin"))(B=w.repository_projects||={});let W;(g=>(g.READ="read",g.WRITE="write"))(W=w.secret_scanning_alerts||={});let F;(g=>(g.READ="read",g.WRITE="write"))(F=w.secrets||={});let j;(g=>(g.READ="read",g.WRITE="write"))(j=w.security_events||={});let V;(g=>(g.READ="read",g.WRITE="write"))(V=w.security_scanning_alert||={});let H;(g=>(g.READ="read",g.WRITE="write"))(H=w.single_file||={});let Q;(g=>(g.READ="read",g.WRITE="write"))(Q=w.statuses||={});let z;(g=>(g.READ="read",g.WRITE="write"))(z=w.team_discussions||={});let K;(g=>(g.READ="read",g.WRITE="write"))(K=w.vulnerability_alerts||={});let S;(g=>(g.READ="read",g.WRITE="write"))(S=w.workflows||={});let x;(Y=>(Y.SUCCESS="success",Y.FAILURE="failure",Y.NEUTRAL="neutral",Y.CANCELLED="cancelled",Y.TIMED_OUT="timed_out",Y.ACTION_REQUIRED="action_required",Y.STALE="stale",Y.SKIPPED="skipped"))(x=w.conclusion||={});let q;(y=>(y.REQUESTED="requested",y.IN_PROGRESS="in_progress",y.COMPLETED="completed",y.QUEUED="queued"))(q=w.status||={})})(dn||={});var cn;(w=>{let l;(N=>N.REREQUESTED="rerequested")(l=w.action||={});let r;(t=>(t.BOT="Bot",t.USER="User",t.ORGANIZATION="Organization"))(r=w.type||={});let e;(g=>(g.READ="read",g.WRITE="write"))(e=w.actions||={});let n;(g=>(g.READ="read",g.WRITE="write"))(n=w.administration||={});let s;(g=>(g.READ="read",g.WRITE="write"))(s=w.checks||={});let u;(g=>(g.READ="read",g.WRITE="write"))(u=w.content_references||={});let _;(g=>(g.READ="read",g.WRITE="write"))(_=w.contents||={});let m;(g=>(g.READ="read",g.WRITE="write"))(m=w.deployments||={});let c;(g=>(g.READ="read",g.WRITE="write"))(c=w.discussions||={});let d;(g=>(g.READ="read",g.WRITE="write"))(d=w.emails||={});let v;(g=>(g.READ="read",g.WRITE="write"))(v=w.environments||={});let h;(g=>(g.READ="read",g.WRITE="write"))(h=w.issues||={});let R;(g=>(g.READ="read",g.WRITE="write"))(R=w.keys||={});let k;(g=>(g.READ="read",g.WRITE="write"))(k=w.members||={});let b;(g=>(g.READ="read",g.WRITE="write"))(b=w.metadata||={});let p;(g=>(g.READ="read",g.WRITE="write"))(p=w.organization_administration||={});let f;(g=>(g.READ="read",g.WRITE="write"))(f=w.organization_hooks||={});let O;(g=>(g.READ="read",g.WRITE="write"))(O=w.organization_packages||={});let I;(g=>(g.READ="read",g.WRITE="write"))(I=w.organization_plan||={});let P;(t=>(t.READ="read",t.WRITE="write",t.ADMIN="admin"))(P=w.organization_projects||={});let E;(g=>(g.READ="read",g.WRITE="write"))(E=w.organization_secrets||={});let D;(g=>(g.READ="read",g.WRITE="write"))(D=w.organization_self_hosted_runners||={});let L;(g=>(g.READ="read",g.WRITE="write"))(L=w.organization_user_blocking||={});let C;(g=>(g.READ="read",g.WRITE="write"))(C=w.packages||={});let U;(g=>(g.READ="read",g.WRITE="write"))(U=w.pages||={});let M;(g=>(g.READ="read",g.WRITE="write"))(M=w.pull_requests||={});let G;(g=>(g.READ="read",g.WRITE="write"))(G=w.repository_hooks||={});let B;(t=>(t.READ="read",t.WRITE="write",t.ADMIN="admin"))(B=w.repository_projects||={});let W;(g=>(g.READ="read",g.WRITE="write"))(W=w.secret_scanning_alerts||={});let F;(g=>(g.READ="read",g.WRITE="write"))(F=w.secrets||={});let j;(g=>(g.READ="read",g.WRITE="write"))(j=w.security_events||={});let V;(g=>(g.READ="read",g.WRITE="write"))(V=w.security_scanning_alert||={});let H;(g=>(g.READ="read",g.WRITE="write"))(H=w.single_file||={});let Q;(g=>(g.READ="read",g.WRITE="write"))(Q=w.statuses||={});let z;(g=>(g.READ="read",g.WRITE="write"))(z=w.team_discussions||={});let K;(g=>(g.READ="read",g.WRITE="write"))(K=w.vulnerability_alerts||={});let S;(g=>(g.READ="read",g.WRITE="write"))(S=w.workflows||={});let x;($=>($.SUCCESS="success",$.FAILURE="failure",$.NEUTRAL="neutral",$.CANCELLED="cancelled",$.TIMED_OUT="timed_out",$.ACTION_REQUIRED="action_required",$.STALE="stale"))(x=w.conclusion||={});let q;(y=>(y.REQUESTED="requested",y.IN_PROGRESS="in_progress",y.COMPLETED="completed",y.QUEUED="queued"))(q=w.status||={})})(cn||={});var bn;(u=>{let l;(m=>m.APPEARED_IN_BRANCH="appeared_in_branch")(l=u.action||={});let r;(d=>(d.BOT="Bot",d.USER="User",d.ORGANIZATION="Organization"))(r=u.type||={});let e;(d=>(d.FALSE_POSITIVE="false positive",d.WON_T_FIX="won't fix",d.USED_IN_TESTS="used in tests"))(e=u.dismissed_reason||={});let n;(d=>(d.OPEN="open",d.DISMISSED="dismissed",d.FIXED="fixed"))(n=u.state||={});let s;(v=>(v.NONE="none",v.NOTE="note",v.WARNING="warning",v.ERROR="error"))(s=u.severity||={})})(bn||={});var hn;(u=>{let l;(m=>m.CLOSED_BY_USER="closed_by_user")(l=u.action||={});let r;(d=>(d.BOT="Bot",d.USER="User",d.ORGANIZATION="Organization"))(r=u.type||={});let e;(d=>(d.FALSE_POSITIVE="false positive",d.WON_T_FIX="won't fix",d.USED_IN_TESTS="used in tests"))(e=u.dismissed_reason||={});let n;(d=>(d.OPEN="open",d.DISMISSED="dismissed",d.FIXED="fixed"))(n=u.state||={});let s;(v=>(v.NONE="none",v.NOTE="note",v.WARNING="warning",v.ERROR="error"))(s=u.severity||={})})(hn||={});var yn;(n=>{let l;(u=>u.CREATED="created")(l=n.action||={});let r;(m=>(m.OPEN="open",m.DISMISSED="dismissed",m.FIXED="fixed"))(r=n.state||={});let e;(c=>(c.NONE="none",c.NOTE="note",c.WARNING="warning",c.ERROR="error"))(e=n.severity||={})})(yn||={});var fn;(u=>{let l;(m=>m.FIXED="fixed")(l=u.action||={});let r;(d=>(d.BOT="Bot",d.USER="User",d.ORGANIZATION="Organization"))(r=u.type||={});let e;(d=>(d.FALSE_POSITIVE="false positive",d.WON_T_FIX="won't fix",d.USED_IN_TESTS="used in tests"))(e=u.dismissed_reason||={});let n;(d=>(d.OPEN="open",d.DISMISSED="dismissed",d.FIXED="fixed"))(n=u.state||={});let s;(v=>(v.NONE="none",v.NOTE="note",v.WARNING="warning",v.ERROR="error"))(s=u.severity||={})})(fn||={});var wn;(n=>{let l;(u=>u.REOPENED="reopened")(l=n.action||={});let r;(m=>(m.OPEN="open",m.DISMISSED="dismissed",m.FIXED="fixed"))(r=n.state||={});let e;(c=>(c.NONE="none",c.NOTE="note",c.WARNING="warning",c.ERROR="error"))(e=n.severity||={})})(wn||={});var En;(n=>{let l;(u=>u.REOPENED_BY_USER="reopened_by_user")(l=n.action||={});let r;(m=>(m.OPEN="open",m.DISMISSED="dismissed",m.FIXED="fixed"))(r=n.state||={});let e;(c=>(c.NONE="none",c.NOTE="note",c.WARNING="warning",c.ERROR="error"))(e=n.severity||={})})(En||={});var vn;(n=>{let l;(u=>u.CREATED="created")(l=n.action||={});let r;(R=>(R.COLLABORATOR="COLLABORATOR",R.CONTRIBUTOR="CONTRIBUTOR",R.FIRST_TIMER="FIRST_TIMER",R.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",R.MANNEQUIN="MANNEQUIN",R.MEMBER="MEMBER",R.NONE="NONE",R.OWNER="OWNER"))(r=n.author_association||={});let e;(m=>(m.BOT="Bot",m.USER="User",m.ORGANIZATION="Organization"))(e=n.type||={})})(vn||={});var Rn;(r=>{let l;(s=>(s.TAG="tag",s.BRANCH="branch"))(l=r.ref_type||={})})(Rn||={});var Tn;(r=>{let l;(s=>(s.TAG="tag",s.BRANCH="branch"))(l=r.ref_type||={})})(Tn||={});var An;(r=>{let l;(n=>n.AUTO_DISMISSED="auto_dismissed")(l=r.action||={})})(An||={});var kn;(r=>{let l;(n=>n.AUTO_REOPENED="auto_reopened")(l=r.action||={})})(kn||={});var xn;(r=>{let l;(n=>n.CREATED="created")(l=r.action||={})})(xn||={});var In;(r=>{let l;(n=>n.DISMISSED="dismissed")(l=r.action||={})})(In||={});var On;(r=>{let l;(n=>n.FIXED="fixed")(l=r.action||={})})(On||={});var Nn;(r=>{let l;(n=>n.REINTRODUCED="reintroduced")(l=r.action||={})})(Nn||={});var zn;(r=>{let l;(n=>n.REOPENED="reopened")(l=r.action||={})})(zn||={});var Pn;(r=>{let l;(n=>n.CREATED="created")(l=r.action||={})})(Pn||={});var Cn;(r=>{let l;(n=>n.DELETED="deleted")(l=r.action||={})})(Cn||={});var Dn;(w=>{let l;(N=>N.CREATED="created")(l=w.action||={});let r;(t=>(t.BOT="Bot",t.USER="User",t.ORGANIZATION="Organization"))(r=w.type||={});let e;(g=>(g.READ="read",g.WRITE="write"))(e=w.actions||={});let n;(g=>(g.READ="read",g.WRITE="write"))(n=w.administration||={});let s;(g=>(g.READ="read",g.WRITE="write"))(s=w.checks||={});let u;(g=>(g.READ="read",g.WRITE="write"))(u=w.content_references||={});let _;(g=>(g.READ="read",g.WRITE="write"))(_=w.contents||={});let m;(g=>(g.READ="read",g.WRITE="write"))(m=w.deployments||={});let c;(g=>(g.READ="read",g.WRITE="write"))(c=w.discussions||={});let d;(g=>(g.READ="read",g.WRITE="write"))(d=w.emails||={});let v;(g=>(g.READ="read",g.WRITE="write"))(v=w.environments||={});let h;(g=>(g.READ="read",g.WRITE="write"))(h=w.issues||={});let R;(g=>(g.READ="read",g.WRITE="write"))(R=w.keys||={});let k;(g=>(g.READ="read",g.WRITE="write"))(k=w.members||={});let b;(g=>(g.READ="read",g.WRITE="write"))(b=w.metadata||={});let p;(g=>(g.READ="read",g.WRITE="write"))(p=w.organization_administration||={});let f;(g=>(g.READ="read",g.WRITE="write"))(f=w.organization_hooks||={});let O;(g=>(g.READ="read",g.WRITE="write"))(O=w.organization_packages||={});let I;(g=>(g.READ="read",g.WRITE="write"))(I=w.organization_plan||={});let P;(g=>(g.READ="read",g.WRITE="write"))(P=w.organization_projects||={});let E;(g=>(g.READ="read",g.WRITE="write"))(E=w.organization_secrets||={});let D;(g=>(g.READ="read",g.WRITE="write"))(D=w.organization_self_hosted_runners||={});let L;(g=>(g.READ="read",g.WRITE="write"))(L=w.organization_user_blocking||={});let C;(g=>(g.READ="read",g.WRITE="write"))(C=w.packages||={});let U;(g=>(g.READ="read",g.WRITE="write"))(U=w.pages||={});let M;(g=>(g.READ="read",g.WRITE="write"))(M=w.pull_requests||={});let G;(g=>(g.READ="read",g.WRITE="write"))(G=w.repository_hooks||={});let B;(g=>(g.READ="read",g.WRITE="write"))(B=w.repository_projects||={});let W;(g=>(g.READ="read",g.WRITE="write"))(W=w.secret_scanning_alerts||={});let F;(g=>(g.READ="read",g.WRITE="write"))(F=w.secrets||={});let j;(g=>(g.READ="read",g.WRITE="write"))(j=w.security_events||={});let V;(g=>(g.READ="read",g.WRITE="write"))(V=w.security_scanning_alert||={});let H;(g=>(g.READ="read",g.WRITE="write"))(H=w.single_file||={});let Q;(g=>(g.READ="read",g.WRITE="write"))(Q=w.statuses||={});let z;(g=>(g.READ="read",g.WRITE="write"))(z=w.team_discussions||={});let K;(g=>(g.READ="read",g.WRITE="write"))(K=w.vulnerability_alerts||={});let S;(g=>(g.READ="read",g.WRITE="write"))(S=w.workflows||={});let x;($=>($.SUCCESS="success",$.FAILURE="failure",$.NEUTRAL="neutral",$.CANCELLED="cancelled",$.TIMED_OUT="timed_out",$.ACTION_REQUIRED="action_required",$.STALE="stale"))(x=w.conclusion||={});let q;(X=>(X.REQUESTED="requested",X.IN_PROGRESS="in_progress",X.COMPLETED="completed",X.QUEUED="queued",X.WAITING="waiting",X.PENDING="pending"))(q=w.status||={})})(Dn||={});var qn;(r=>{let l;(n=>n.REQUESTED="requested")(l=r.action||={})})(qn||={});var Sn;(w=>{let l;(N=>N.CREATED="created")(l=w.action||={});let r;(Y=>(Y.SUCCESS="success",Y.FAILURE="failure",Y.NEUTRAL="neutral",Y.CANCELLED="cancelled",Y.TIMED_OUT="timed_out",Y.ACTION_REQUIRED="action_required",Y.STALE="stale",Y.SKIPPED="skipped"))(r=w.conclusion||={});let e;(A=>(A.QUEUED="queued",A.IN_PROGRESS="in_progress",A.COMPLETED="completed",A.WAITING="waiting",A.PENDING="pending"))(e=w.status||={});let n;(t=>(t.BOT="Bot",t.USER="User",t.ORGANIZATION="Organization"))(n=w.type||={});let s;(g=>(g.READ="read",g.WRITE="write"))(s=w.actions||={});let u;(g=>(g.READ="read",g.WRITE="write"))(u=w.administration||={});let _;(g=>(g.READ="read",g.WRITE="write"))(_=w.checks||={});let m;(g=>(g.READ="read",g.WRITE="write"))(m=w.content_references||={});let c;(g=>(g.READ="read",g.WRITE="write"))(c=w.contents||={});let d;(g=>(g.READ="read",g.WRITE="write"))(d=w.deployments||={});let v;(g=>(g.READ="read",g.WRITE="write"))(v=w.discussions||={});let h;(g=>(g.READ="read",g.WRITE="write"))(h=w.emails||={});let R;(g=>(g.READ="read",g.WRITE="write"))(R=w.environments||={});let k;(g=>(g.READ="read",g.WRITE="write"))(k=w.issues||={});let b;(g=>(g.READ="read",g.WRITE="write"))(b=w.keys||={});let p;(g=>(g.READ="read",g.WRITE="write"))(p=w.members||={});let f;(g=>(g.READ="read",g.WRITE="write"))(f=w.metadata||={});let O;(g=>(g.READ="read",g.WRITE="write"))(O=w.organization_administration||={});let I;(g=>(g.READ="read",g.WRITE="write"))(I=w.organization_hooks||={});let P;(g=>(g.READ="read",g.WRITE="write"))(P=w.organization_packages||={});let E;(g=>(g.READ="read",g.WRITE="write"))(E=w.organization_plan||={});let D;(g=>(g.READ="read",g.WRITE="write"))(D=w.organization_projects||={});let L;(g=>(g.READ="read",g.WRITE="write"))(L=w.organization_secrets||={});let C;(g=>(g.READ="read",g.WRITE="write"))(C=w.organization_self_hosted_runners||={});let U;(g=>(g.READ="read",g.WRITE="write"))(U=w.organization_user_blocking||={});let M;(g=>(g.READ="read",g.WRITE="write"))(M=w.packages||={});let G;(g=>(g.READ="read",g.WRITE="write"))(G=w.pages||={});let B;(g=>(g.READ="read",g.WRITE="write"))(B=w.pull_requests||={});let W;(g=>(g.READ="read",g.WRITE="write"))(W=w.repository_hooks||={});let F;(g=>(g.READ="read",g.WRITE="write"))(F=w.repository_projects||={});let j;(g=>(g.READ="read",g.WRITE="write"))(j=w.secret_scanning_alerts||={});let V;(g=>(g.READ="read",g.WRITE="write"))(V=w.secrets||={});let H;(g=>(g.READ="read",g.WRITE="write"))(H=w.security_events||={});let Q;(g=>(g.READ="read",g.WRITE="write"))(Q=w.security_scanning_alert||={});let z;(g=>(g.READ="read",g.WRITE="write"))(z=w.single_file||={});let K;(g=>(g.READ="read",g.WRITE="write"))(K=w.statuses||={});let S;(g=>(g.READ="read",g.WRITE="write"))(S=w.team_discussions||={});let x;(g=>(g.READ="read",g.WRITE="write"))(x=w.vulnerability_alerts||={});let q;(g=>(g.READ="read",g.WRITE="write"))(q=w.workflows||={})})(Sn||={});var Ln;(n=>{let l;(u=>u.ANSWERED="answered")(l=n.action||={});let r;(R=>(R.COLLABORATOR="COLLABORATOR",R.CONTRIBUTOR="CONTRIBUTOR",R.FIRST_TIMER="FIRST_TIMER",R.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",R.MANNEQUIN="MANNEQUIN",R.MEMBER="MEMBER",R.NONE="NONE",R.OWNER="OWNER"))(r=n.author_association||={});let e;(m=>(m.BOT="Bot",m.USER="User",m.ORGANIZATION="Organization"))(e=n.type||={})})(Ln||={});var Un;(r=>{let l;(n=>n.CATEGORY_CHANGED="category_changed")(l=r.action||={})})(Un||={});var Mn;(r=>{let l;(n=>n.CLOSED="closed")(l=r.action||={})})(Mn||={});var Gn;(n=>{let l;(u=>u.CREATED="created")(l=n.action||={});let r;(R=>(R.COLLABORATOR="COLLABORATOR",R.CONTRIBUTOR="CONTRIBUTOR",R.FIRST_TIMER="FIRST_TIMER",R.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",R.MANNEQUIN="MANNEQUIN",R.MEMBER="MEMBER",R.NONE="NONE",R.OWNER="OWNER"))(r=n.author_association||={});let e;(m=>(m.BOT="Bot",m.USER="User",m.ORGANIZATION="Organization"))(e=n.type||={})})(Gn||={});var Bn;(n=>{let l;(u=>u.DELETED="deleted")(l=n.action||={});let r;(R=>(R.COLLABORATOR="COLLABORATOR",R.CONTRIBUTOR="CONTRIBUTOR",R.FIRST_TIMER="FIRST_TIMER",R.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",R.MANNEQUIN="MANNEQUIN",R.MEMBER="MEMBER",R.NONE="NONE",R.OWNER="OWNER"))(r=n.author_association||={});let e;(m=>(m.BOT="Bot",m.USER="User",m.ORGANIZATION="Organization"))(e=n.type||={})})(Bn||={});var Wn;(n=>{let l;(u=>u.EDITED="edited")(l=n.action||={});let r;(R=>(R.COLLABORATOR="COLLABORATOR",R.CONTRIBUTOR="CONTRIBUTOR",R.FIRST_TIMER="FIRST_TIMER",R.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",R.MANNEQUIN="MANNEQUIN",R.MEMBER="MEMBER",R.NONE="NONE",R.OWNER="OWNER"))(r=n.author_association||={});let e;(m=>(m.BOT="Bot",m.USER="User",m.ORGANIZATION="Organization"))(e=n.type||={})})(Wn||={});var Fn;(s=>{let l;(_=>_.CREATED="created")(l=s.action||={});let r;(c=>(c.BOT="Bot",c.USER="User",c.ORGANIZATION="Organization"))(r=s.type||={});let e;(k=>(k.COLLABORATOR="COLLABORATOR",k.CONTRIBUTOR="CONTRIBUTOR",k.FIRST_TIMER="FIRST_TIMER",k.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",k.MANNEQUIN="MANNEQUIN",k.MEMBER="MEMBER",k.NONE="NONE",k.OWNER="OWNER"))(e=s.author_association||={});let n;(d=>(d.OPEN="open",d.LOCKED="locked",d.CONVERTING="converting",d.TRANSFERRING="transferring"))(n=s.state||={})})(Fn||={});var jn;(r=>{let l;(n=>n.DELETED="deleted")(l=r.action||={})})(jn||={});var Vn;(r=>{let l;(n=>n.EDITED="edited")(l=r.action||={})})(Vn||={});var Hn;(r=>{let l;(n=>n.LABELED="labeled")(l=r.action||={})})(Hn||={});var Qn;(r=>{let l;(n=>n.LOCKED="locked")(l=r.action||={})})(Qn||={});var Kn;(r=>{let l;(n=>n.PINNED="pinned")(l=r.action||={})})(Kn||={});var Yn;(r=>{let l;(n=>n.REOPENED="reopened")(l=r.action||={})})(Yn||={});var Zn;(r=>{let l;(n=>n.TRANSFERRED="transferred")(l=r.action||={})})(Zn||={});var Xn;(n=>{let l;(u=>u.UNANSWERED="unanswered")(l=n.action||={});let r;(R=>(R.COLLABORATOR="COLLABORATOR",R.CONTRIBUTOR="CONTRIBUTOR",R.FIRST_TIMER="FIRST_TIMER",R.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",R.MANNEQUIN="MANNEQUIN",R.MEMBER="MEMBER",R.NONE="NONE",R.OWNER="OWNER"))(r=n.author_association||={});let e;(m=>(m.BOT="Bot",m.USER="User",m.ORGANIZATION="Organization"))(e=n.type||={})})(Xn||={});var $n;(r=>{let l;(n=>n.UNLABELED="unlabeled")(l=r.action||={})})($n||={});var Jn;(r=>{let l;(n=>n.UNLOCKED="unlocked")(l=r.action||={})})(Jn||={});var rs;(r=>{let l;(n=>n.UNPINNED="unpinned")(l=r.action||={})})(rs||={});var es;(e=>{let l;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(l=e.type||={});let r;(_=>(_.PUBLIC="public",_.PRIVATE="private",_.INTERNAL="internal"))(r=e.visibility||={})})(es||={});var ts;(r=>{let l;(n=>n.REVOKED="revoked")(l=r.action||={})})(ts||={});var ns;(e=>{let l;(s=>s.CREATED="created")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(ns||={});var ss;(r=>{let l;(n=>n.DELETED="deleted")(l=r.action||={})})(ss||={});var is;(r=>{let l;(n=>n.NEW_PERMISSIONS_ACCEPTED="new_permissions_accepted")(l=r.action||={})})(is||={});var os;(n=>{let l;(u=>u.ADDED="added")(l=n.action||={});let r;(_=>(_.ALL="all",_.SELECTED="selected"))(r=n.repository_selection||={});let e;(m=>(m.BOT="Bot",m.USER="User",m.ORGANIZATION="Organization"))(e=n.type||={})})(os||={});var ls;(n=>{let l;(u=>u.REMOVED="removed")(l=n.action||={});let r;(_=>(_.ALL="all",_.SELECTED="selected"))(r=n.repository_selection||={});let e;(m=>(m.BOT="Bot",m.USER="User",m.ORGANIZATION="Organization"))(e=n.type||={})})(ls||={});var as;(r=>{let l;(n=>n.SUSPEND="suspend")(l=r.action||={})})(as||={});var us;(r=>{let l;(n=>n.UNSUSPEND="unsuspend")(l=r.action||={})})(us||={});var _s;(a=>{let l;(g=>g.CREATED="created")(l=a.action||={});let r;(T=>(T.COLLABORATOR="COLLABORATOR",T.CONTRIBUTOR="CONTRIBUTOR",T.FIRST_TIMER="FIRST_TIMER",T.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",T.MANNEQUIN="MANNEQUIN",T.MEMBER="MEMBER",T.NONE="NONE",T.OWNER="OWNER"))(r=a.author_association||={});let e;(y=>(y.BOT="Bot",y.USER="User",y.ORGANIZATION="Organization"))(e=a.type||={});let n;(A=>(A.RESOLVED="resolved",A.OFF_TOPIC="off-topic",A.TOO_HEATED="too heated",A.SPAM="spam"))(n=a.active_lock_reason||={});let s;(t=>(t.OPEN="open",t.CLOSED="closed"))(s=a.state||={});let u;(t=>(t.READ="read",t.WRITE="write"))(u=a.actions||={});let _;(t=>(t.READ="read",t.WRITE="write"))(_=a.administration||={});let m;(t=>(t.READ="read",t.WRITE="write"))(m=a.checks||={});let c;(t=>(t.READ="read",t.WRITE="write"))(c=a.content_references||={});let d;(t=>(t.READ="read",t.WRITE="write"))(d=a.contents||={});let v;(t=>(t.READ="read",t.WRITE="write"))(v=a.deployments||={});let h;(t=>(t.READ="read",t.WRITE="write"))(h=a.discussions||={});let R;(t=>(t.READ="read",t.WRITE="write"))(R=a.emails||={});let k;(t=>(t.READ="read",t.WRITE="write"))(k=a.environments||={});let b;(t=>(t.READ="read",t.WRITE="write"))(b=a.issues||={});let p;(t=>(t.READ="read",t.WRITE="write"))(p=a.keys||={});let f;(t=>(t.READ="read",t.WRITE="write"))(f=a.members||={});let O;(t=>(t.READ="read",t.WRITE="write"))(O=a.metadata||={});let I;(t=>(t.READ="read",t.WRITE="write"))(I=a.organization_administration||={});let P;(t=>(t.READ="read",t.WRITE="write"))(P=a.organization_hooks||={});let E;(t=>(t.READ="read",t.WRITE="write"))(E=a.organization_packages||={});let D;(t=>(t.READ="read",t.WRITE="write"))(D=a.organization_plan||={});let L;(y=>(y.READ="read",y.WRITE="write",y.ADMIN="admin"))(L=a.organization_projects||={});let C;(t=>(t.READ="read",t.WRITE="write"))(C=a.organization_secrets||={});let U;(t=>(t.READ="read",t.WRITE="write"))(U=a.organization_self_hosted_runners||={});let M;(t=>(t.READ="read",t.WRITE="write"))(M=a.organization_user_blocking||={});let G;(t=>(t.READ="read",t.WRITE="write"))(G=a.packages||={});let B;(t=>(t.READ="read",t.WRITE="write"))(B=a.pages||={});let W;(t=>(t.READ="read",t.WRITE="write"))(W=a.pull_requests||={});let F;(t=>(t.READ="read",t.WRITE="write"))(F=a.repository_hooks||={});let j;(y=>(y.READ="read",y.WRITE="write",y.ADMIN="admin"))(j=a.repository_projects||={});let V;(t=>(t.READ="read",t.WRITE="write"))(V=a.secret_scanning_alerts||={});let H;(t=>(t.READ="read",t.WRITE="write"))(H=a.secrets||={});let Q;(t=>(t.READ="read",t.WRITE="write"))(Q=a.security_events||={});let z;(t=>(t.READ="read",t.WRITE="write"))(z=a.security_scanning_alert||={});let K;(t=>(t.READ="read",t.WRITE="write"))(K=a.single_file||={});let S;(t=>(t.READ="read",t.WRITE="write"))(S=a.statuses||={});let x;(t=>(t.READ="read",t.WRITE="write"))(x=a.team_discussions||={});let q;(t=>(t.READ="read",t.WRITE="write"))(q=a.vulnerability_alerts||={});let w;(t=>(t.READ="read",t.WRITE="write"))(w=a.workflows||={})})(_s||={});var gs;(a=>{let l;(g=>g.DELETED="deleted")(l=a.action||={});let r;(T=>(T.COLLABORATOR="COLLABORATOR",T.CONTRIBUTOR="CONTRIBUTOR",T.FIRST_TIMER="FIRST_TIMER",T.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",T.MANNEQUIN="MANNEQUIN",T.MEMBER="MEMBER",T.NONE="NONE",T.OWNER="OWNER"))(r=a.author_association||={});let e;(A=>(A.BOT="Bot",A.USER="User",A.ORGANIZATION="Organization",A.MANNEQUIN="Mannequin"))(e=a.type||={});let n;(A=>(A.RESOLVED="resolved",A.OFF_TOPIC="off-topic",A.TOO_HEATED="too heated",A.SPAM="spam"))(n=a.active_lock_reason||={});let s;(t=>(t.OPEN="open",t.CLOSED="closed"))(s=a.state||={});let u;(t=>(t.READ="read",t.WRITE="write"))(u=a.actions||={});let _;(t=>(t.READ="read",t.WRITE="write"))(_=a.administration||={});let m;(t=>(t.READ="read",t.WRITE="write"))(m=a.checks||={});let c;(t=>(t.READ="read",t.WRITE="write"))(c=a.content_references||={});let d;(t=>(t.READ="read",t.WRITE="write"))(d=a.contents||={});let v;(t=>(t.READ="read",t.WRITE="write"))(v=a.deployments||={});let h;(t=>(t.READ="read",t.WRITE="write"))(h=a.discussions||={});let R;(t=>(t.READ="read",t.WRITE="write"))(R=a.emails||={});let k;(t=>(t.READ="read",t.WRITE="write"))(k=a.environments||={});let b;(t=>(t.READ="read",t.WRITE="write"))(b=a.issues||={});let p;(t=>(t.READ="read",t.WRITE="write"))(p=a.keys||={});let f;(t=>(t.READ="read",t.WRITE="write"))(f=a.members||={});let O;(t=>(t.READ="read",t.WRITE="write"))(O=a.metadata||={});let I;(t=>(t.READ="read",t.WRITE="write"))(I=a.organization_administration||={});let P;(t=>(t.READ="read",t.WRITE="write"))(P=a.organization_hooks||={});let E;(t=>(t.READ="read",t.WRITE="write"))(E=a.organization_packages||={});let D;(t=>(t.READ="read",t.WRITE="write"))(D=a.organization_plan||={});let L;(t=>(t.READ="read",t.WRITE="write"))(L=a.organization_projects||={});let C;(t=>(t.READ="read",t.WRITE="write"))(C=a.organization_secrets||={});let U;(t=>(t.READ="read",t.WRITE="write"))(U=a.organization_self_hosted_runners||={});let M;(t=>(t.READ="read",t.WRITE="write"))(M=a.organization_user_blocking||={});let G;(t=>(t.READ="read",t.WRITE="write"))(G=a.packages||={});let B;(t=>(t.READ="read",t.WRITE="write"))(B=a.pages||={});let W;(t=>(t.READ="read",t.WRITE="write"))(W=a.pull_requests||={});let F;(t=>(t.READ="read",t.WRITE="write"))(F=a.repository_hooks||={});let j;(t=>(t.READ="read",t.WRITE="write"))(j=a.repository_projects||={});let V;(t=>(t.READ="read",t.WRITE="write"))(V=a.secret_scanning_alerts||={});let H;(t=>(t.READ="read",t.WRITE="write"))(H=a.secrets||={});let Q;(t=>(t.READ="read",t.WRITE="write"))(Q=a.security_events||={});let z;(t=>(t.READ="read",t.WRITE="write"))(z=a.security_scanning_alert||={});let K;(t=>(t.READ="read",t.WRITE="write"))(K=a.single_file||={});let S;(t=>(t.READ="read",t.WRITE="write"))(S=a.statuses||={});let x;(t=>(t.READ="read",t.WRITE="write"))(x=a.team_discussions||={});let q;(t=>(t.READ="read",t.WRITE="write"))(q=a.vulnerability_alerts||={});let w;(t=>(t.READ="read",t.WRITE="write"))(w=a.workflows||={})})(gs||={});var ms;(a=>{let l;(g=>g.EDITED="edited")(l=a.action||={});let r;(T=>(T.COLLABORATOR="COLLABORATOR",T.CONTRIBUTOR="CONTRIBUTOR",T.FIRST_TIMER="FIRST_TIMER",T.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",T.MANNEQUIN="MANNEQUIN",T.MEMBER="MEMBER",T.NONE="NONE",T.OWNER="OWNER"))(r=a.author_association||={});let e;(A=>(A.BOT="Bot",A.USER="User",A.ORGANIZATION="Organization",A.MANNEQUIN="Mannequin"))(e=a.type||={});let n;(A=>(A.RESOLVED="resolved",A.OFF_TOPIC="off-topic",A.TOO_HEATED="too heated",A.SPAM="spam"))(n=a.active_lock_reason||={});let s;(t=>(t.OPEN="open",t.CLOSED="closed"))(s=a.state||={});let u;(t=>(t.READ="read",t.WRITE="write"))(u=a.actions||={});let _;(t=>(t.READ="read",t.WRITE="write"))(_=a.administration||={});let m;(t=>(t.READ="read",t.WRITE="write"))(m=a.checks||={});let c;(t=>(t.READ="read",t.WRITE="write"))(c=a.content_references||={});let d;(t=>(t.READ="read",t.WRITE="write"))(d=a.contents||={});let v;(t=>(t.READ="read",t.WRITE="write"))(v=a.deployments||={});let h;(t=>(t.READ="read",t.WRITE="write"))(h=a.discussions||={});let R;(t=>(t.READ="read",t.WRITE="write"))(R=a.emails||={});let k;(t=>(t.READ="read",t.WRITE="write"))(k=a.environments||={});let b;(t=>(t.READ="read",t.WRITE="write"))(b=a.issues||={});let p;(t=>(t.READ="read",t.WRITE="write"))(p=a.keys||={});let f;(t=>(t.READ="read",t.WRITE="write"))(f=a.members||={});let O;(t=>(t.READ="read",t.WRITE="write"))(O=a.metadata||={});let I;(t=>(t.READ="read",t.WRITE="write"))(I=a.organization_administration||={});let P;(t=>(t.READ="read",t.WRITE="write"))(P=a.organization_hooks||={});let E;(t=>(t.READ="read",t.WRITE="write"))(E=a.organization_packages||={});let D;(t=>(t.READ="read",t.WRITE="write"))(D=a.organization_plan||={});let L;(y=>(y.READ="read",y.WRITE="write",y.ADMIN="admin"))(L=a.organization_projects||={});let C;(t=>(t.READ="read",t.WRITE="write"))(C=a.organization_secrets||={});let U;(t=>(t.READ="read",t.WRITE="write"))(U=a.organization_self_hosted_runners||={});let M;(t=>(t.READ="read",t.WRITE="write"))(M=a.organization_user_blocking||={});let G;(t=>(t.READ="read",t.WRITE="write"))(G=a.packages||={});let B;(t=>(t.READ="read",t.WRITE="write"))(B=a.pages||={});let W;(t=>(t.READ="read",t.WRITE="write"))(W=a.pull_requests||={});let F;(t=>(t.READ="read",t.WRITE="write"))(F=a.repository_hooks||={});let j;(t=>(t.READ="read",t.WRITE="write"))(j=a.repository_projects||={});let V;(t=>(t.READ="read",t.WRITE="write"))(V=a.secret_scanning_alerts||={});let H;(t=>(t.READ="read",t.WRITE="write"))(H=a.secrets||={});let Q;(t=>(t.READ="read",t.WRITE="write"))(Q=a.security_events||={});let z;(t=>(t.READ="read",t.WRITE="write"))(z=a.security_scanning_alert||={});let K;(t=>(t.READ="read",t.WRITE="write"))(K=a.single_file||={});let S;(t=>(t.READ="read",t.WRITE="write"))(S=a.statuses||={});let x;(t=>(t.READ="read",t.WRITE="write"))(x=a.team_discussions||={});let q;(t=>(t.READ="read",t.WRITE="write"))(q=a.vulnerability_alerts||={});let w;(t=>(t.READ="read",t.WRITE="write"))(w=a.workflows||={})})(ms||={});var ps;(a=>{let l;(g=>g.ASSIGNED="assigned")(l=a.action||={});let r;(y=>(y.BOT="Bot",y.USER="User",y.ORGANIZATION="Organization"))(r=a.type||={});let e;(A=>(A.RESOLVED="resolved",A.OFF_TOPIC="off-topic",A.TOO_HEATED="too heated",A.SPAM="spam"))(e=a.active_lock_reason||={});let n;(T=>(T.COLLABORATOR="COLLABORATOR",T.CONTRIBUTOR="CONTRIBUTOR",T.FIRST_TIMER="FIRST_TIMER",T.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",T.MANNEQUIN="MANNEQUIN",T.MEMBER="MEMBER",T.NONE="NONE",T.OWNER="OWNER"))(n=a.author_association||={});let s;(t=>(t.OPEN="open",t.CLOSED="closed"))(s=a.state||={});let u;(t=>(t.READ="read",t.WRITE="write"))(u=a.actions||={});let _;(t=>(t.READ="read",t.WRITE="write"))(_=a.administration||={});let m;(t=>(t.READ="read",t.WRITE="write"))(m=a.checks||={});let c;(t=>(t.READ="read",t.WRITE="write"))(c=a.content_references||={});let d;(t=>(t.READ="read",t.WRITE="write"))(d=a.contents||={});let v;(t=>(t.READ="read",t.WRITE="write"))(v=a.deployments||={});let h;(t=>(t.READ="read",t.WRITE="write"))(h=a.discussions||={});let R;(t=>(t.READ="read",t.WRITE="write"))(R=a.emails||={});let k;(t=>(t.READ="read",t.WRITE="write"))(k=a.environments||={});let b;(t=>(t.READ="read",t.WRITE="write"))(b=a.issues||={});let p;(t=>(t.READ="read",t.WRITE="write"))(p=a.keys||={});let f;(t=>(t.READ="read",t.WRITE="write"))(f=a.members||={});let O;(t=>(t.READ="read",t.WRITE="write"))(O=a.metadata||={});let I;(t=>(t.READ="read",t.WRITE="write"))(I=a.organization_administration||={});let P;(t=>(t.READ="read",t.WRITE="write"))(P=a.organization_hooks||={});let E;(t=>(t.READ="read",t.WRITE="write"))(E=a.organization_packages||={});let D;(t=>(t.READ="read",t.WRITE="write"))(D=a.organization_plan||={});let L;(y=>(y.READ="read",y.WRITE="write",y.ADMIN="admin"))(L=a.organization_projects||={});let C;(t=>(t.READ="read",t.WRITE="write"))(C=a.organization_secrets||={});let U;(t=>(t.READ="read",t.WRITE="write"))(U=a.organization_self_hosted_runners||={});let M;(t=>(t.READ="read",t.WRITE="write"))(M=a.organization_user_blocking||={});let G;(t=>(t.READ="read",t.WRITE="write"))(G=a.packages||={});let B;(t=>(t.READ="read",t.WRITE="write"))(B=a.pages||={});let W;(t=>(t.READ="read",t.WRITE="write"))(W=a.pull_requests||={});let F;(t=>(t.READ="read",t.WRITE="write"))(F=a.repository_hooks||={});let j;(t=>(t.READ="read",t.WRITE="write"))(j=a.repository_projects||={});let V;(t=>(t.READ="read",t.WRITE="write"))(V=a.secret_scanning_alerts||={});let H;(t=>(t.READ="read",t.WRITE="write"))(H=a.secrets||={});let Q;(t=>(t.READ="read",t.WRITE="write"))(Q=a.security_events||={});let z;(t=>(t.READ="read",t.WRITE="write"))(z=a.security_scanning_alert||={});let K;(t=>(t.READ="read",t.WRITE="write"))(K=a.single_file||={});let S;(t=>(t.READ="read",t.WRITE="write"))(S=a.statuses||={});let x;(t=>(t.READ="read",t.WRITE="write"))(x=a.team_discussions||={});let q;(t=>(t.READ="read",t.WRITE="write"))(q=a.vulnerability_alerts||={});let w;(t=>(t.READ="read",t.WRITE="write"))(w=a.workflows||={})})(ps||={});var ds;(a=>{let l;(g=>g.CLOSED="closed")(l=a.action||={});let r;(A=>(A.RESOLVED="resolved",A.OFF_TOPIC="off-topic",A.TOO_HEATED="too heated",A.SPAM="spam"))(r=a.active_lock_reason||={});let e;(A=>(A.BOT="Bot",A.USER="User",A.ORGANIZATION="Organization",A.MANNEQUIN="Mannequin"))(e=a.type||={});let n;(T=>(T.COLLABORATOR="COLLABORATOR",T.CONTRIBUTOR="CONTRIBUTOR",T.FIRST_TIMER="FIRST_TIMER",T.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",T.MANNEQUIN="MANNEQUIN",T.MEMBER="MEMBER",T.NONE="NONE",T.OWNER="OWNER"))(n=a.author_association||={});let s;(t=>(t.OPEN="open",t.CLOSED="closed"))(s=a.state||={});let u;(t=>(t.READ="read",t.WRITE="write"))(u=a.actions||={});let _;(t=>(t.READ="read",t.WRITE="write"))(_=a.administration||={});let m;(t=>(t.READ="read",t.WRITE="write"))(m=a.checks||={});let c;(t=>(t.READ="read",t.WRITE="write"))(c=a.content_references||={});let d;(t=>(t.READ="read",t.WRITE="write"))(d=a.contents||={});let v;(t=>(t.READ="read",t.WRITE="write"))(v=a.deployments||={});let h;(t=>(t.READ="read",t.WRITE="write"))(h=a.discussions||={});let R;(t=>(t.READ="read",t.WRITE="write"))(R=a.emails||={});let k;(t=>(t.READ="read",t.WRITE="write"))(k=a.environments||={});let b;(t=>(t.READ="read",t.WRITE="write"))(b=a.issues||={});let p;(t=>(t.READ="read",t.WRITE="write"))(p=a.keys||={});let f;(t=>(t.READ="read",t.WRITE="write"))(f=a.members||={});let O;(t=>(t.READ="read",t.WRITE="write"))(O=a.metadata||={});let I;(t=>(t.READ="read",t.WRITE="write"))(I=a.organization_administration||={});let P;(t=>(t.READ="read",t.WRITE="write"))(P=a.organization_hooks||={});let E;(t=>(t.READ="read",t.WRITE="write"))(E=a.organization_packages||={});let D;(t=>(t.READ="read",t.WRITE="write"))(D=a.organization_plan||={});let L;(y=>(y.READ="read",y.WRITE="write",y.ADMIN="admin"))(L=a.organization_projects||={});let C;(t=>(t.READ="read",t.WRITE="write"))(C=a.organization_secrets||={});let U;(t=>(t.READ="read",t.WRITE="write"))(U=a.organization_self_hosted_runners||={});let M;(t=>(t.READ="read",t.WRITE="write"))(M=a.organization_user_blocking||={});let G;(t=>(t.READ="read",t.WRITE="write"))(G=a.packages||={});let B;(t=>(t.READ="read",t.WRITE="write"))(B=a.pages||={});let W;(t=>(t.READ="read",t.WRITE="write"))(W=a.pull_requests||={});let F;(t=>(t.READ="read",t.WRITE="write"))(F=a.repository_hooks||={});let j;(t=>(t.READ="read",t.WRITE="write"))(j=a.repository_projects||={});let V;(t=>(t.READ="read",t.WRITE="write"))(V=a.secret_scanning_alerts||={});let H;(t=>(t.READ="read",t.WRITE="write"))(H=a.secrets||={});let Q;(t=>(t.READ="read",t.WRITE="write"))(Q=a.security_events||={});let z;(t=>(t.READ="read",t.WRITE="write"))(z=a.security_scanning_alert||={});let K;(t=>(t.READ="read",t.WRITE="write"))(K=a.single_file||={});let S;(t=>(t.READ="read",t.WRITE="write"))(S=a.statuses||={});let x;(t=>(t.READ="read",t.WRITE="write"))(x=a.team_discussions||={});let q;(t=>(t.READ="read",t.WRITE="write"))(q=a.vulnerability_alerts||={});let w;(t=>(t.READ="read",t.WRITE="write"))(w=a.workflows||={})})(ds||={});var cs;(a=>{let l;(g=>g.DELETED="deleted")(l=a.action||={});let r;(A=>(A.RESOLVED="resolved",A.OFF_TOPIC="off-topic",A.TOO_HEATED="too heated",A.SPAM="spam"))(r=a.active_lock_reason||={});let e;(y=>(y.BOT="Bot",y.USER="User",y.ORGANIZATION="Organization"))(e=a.type||={});let n;(T=>(T.COLLABORATOR="COLLABORATOR",T.CONTRIBUTOR="CONTRIBUTOR",T.FIRST_TIMER="FIRST_TIMER",T.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",T.MANNEQUIN="MANNEQUIN",T.MEMBER="MEMBER",T.NONE="NONE",T.OWNER="OWNER"))(n=a.author_association||={});let s;(t=>(t.OPEN="open",t.CLOSED="closed"))(s=a.state||={});let u;(t=>(t.READ="read",t.WRITE="write"))(u=a.actions||={});let _;(t=>(t.READ="read",t.WRITE="write"))(_=a.administration||={});let m;(t=>(t.READ="read",t.WRITE="write"))(m=a.checks||={});let c;(t=>(t.READ="read",t.WRITE="write"))(c=a.content_references||={});let d;(t=>(t.READ="read",t.WRITE="write"))(d=a.contents||={});let v;(t=>(t.READ="read",t.WRITE="write"))(v=a.deployments||={});let h;(t=>(t.READ="read",t.WRITE="write"))(h=a.discussions||={});let R;(t=>(t.READ="read",t.WRITE="write"))(R=a.emails||={});let k;(t=>(t.READ="read",t.WRITE="write"))(k=a.environments||={});let b;(t=>(t.READ="read",t.WRITE="write"))(b=a.issues||={});let p;(t=>(t.READ="read",t.WRITE="write"))(p=a.keys||={});let f;(t=>(t.READ="read",t.WRITE="write"))(f=a.members||={});let O;(t=>(t.READ="read",t.WRITE="write"))(O=a.metadata||={});let I;(t=>(t.READ="read",t.WRITE="write"))(I=a.organization_administration||={});let P;(t=>(t.READ="read",t.WRITE="write"))(P=a.organization_hooks||={});let E;(t=>(t.READ="read",t.WRITE="write"))(E=a.organization_packages||={});let D;(t=>(t.READ="read",t.WRITE="write"))(D=a.organization_plan||={});let L;(t=>(t.READ="read",t.WRITE="write"))(L=a.organization_projects||={});let C;(t=>(t.READ="read",t.WRITE="write"))(C=a.organization_secrets||={});let U;(t=>(t.READ="read",t.WRITE="write"))(U=a.organization_self_hosted_runners||={});let M;(t=>(t.READ="read",t.WRITE="write"))(M=a.organization_user_blocking||={});let G;(t=>(t.READ="read",t.WRITE="write"))(G=a.packages||={});let B;(t=>(t.READ="read",t.WRITE="write"))(B=a.pages||={});let W;(t=>(t.READ="read",t.WRITE="write"))(W=a.pull_requests||={});let F;(t=>(t.READ="read",t.WRITE="write"))(F=a.repository_hooks||={});let j;(t=>(t.READ="read",t.WRITE="write"))(j=a.repository_projects||={});let V;(t=>(t.READ="read",t.WRITE="write"))(V=a.secret_scanning_alerts||={});let H;(t=>(t.READ="read",t.WRITE="write"))(H=a.secrets||={});let Q;(t=>(t.READ="read",t.WRITE="write"))(Q=a.security_events||={});let z;(t=>(t.READ="read",t.WRITE="write"))(z=a.security_scanning_alert||={});let K;(t=>(t.READ="read",t.WRITE="write"))(K=a.single_file||={});let S;(t=>(t.READ="read",t.WRITE="write"))(S=a.statuses||={});let x;(t=>(t.READ="read",t.WRITE="write"))(x=a.team_discussions||={});let q;(t=>(t.READ="read",t.WRITE="write"))(q=a.vulnerability_alerts||={});let w;(t=>(t.READ="read",t.WRITE="write"))(w=a.workflows||={})})(cs||={});var bs;(a=>{let l;(g=>g.DEMILESTONED="demilestoned")(l=a.action||={});let r;(A=>(A.RESOLVED="resolved",A.OFF_TOPIC="off-topic",A.TOO_HEATED="too heated",A.SPAM="spam"))(r=a.active_lock_reason||={});let e;(A=>(A.BOT="Bot",A.USER="User",A.ORGANIZATION="Organization",A.MANNEQUIN="Mannequin"))(e=a.type||={});let n;(T=>(T.COLLABORATOR="COLLABORATOR",T.CONTRIBUTOR="CONTRIBUTOR",T.FIRST_TIMER="FIRST_TIMER",T.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",T.MANNEQUIN="MANNEQUIN",T.MEMBER="MEMBER",T.NONE="NONE",T.OWNER="OWNER"))(n=a.author_association||={});let s;(t=>(t.OPEN="open",t.CLOSED="closed"))(s=a.state||={});let u;(t=>(t.READ="read",t.WRITE="write"))(u=a.actions||={});let _;(t=>(t.READ="read",t.WRITE="write"))(_=a.administration||={});let m;(t=>(t.READ="read",t.WRITE="write"))(m=a.checks||={});let c;(t=>(t.READ="read",t.WRITE="write"))(c=a.content_references||={});let d;(t=>(t.READ="read",t.WRITE="write"))(d=a.contents||={});let v;(t=>(t.READ="read",t.WRITE="write"))(v=a.deployments||={});let h;(t=>(t.READ="read",t.WRITE="write"))(h=a.discussions||={});let R;(t=>(t.READ="read",t.WRITE="write"))(R=a.emails||={});let k;(t=>(t.READ="read",t.WRITE="write"))(k=a.environments||={});let b;(t=>(t.READ="read",t.WRITE="write"))(b=a.issues||={});let p;(t=>(t.READ="read",t.WRITE="write"))(p=a.keys||={});let f;(t=>(t.READ="read",t.WRITE="write"))(f=a.members||={});let O;(t=>(t.READ="read",t.WRITE="write"))(O=a.metadata||={});let I;(t=>(t.READ="read",t.WRITE="write"))(I=a.organization_administration||={});let P;(t=>(t.READ="read",t.WRITE="write"))(P=a.organization_hooks||={});let E;(t=>(t.READ="read",t.WRITE="write"))(E=a.organization_packages||={});let D;(t=>(t.READ="read",t.WRITE="write"))(D=a.organization_plan||={});let L;(y=>(y.READ="read",y.WRITE="write",y.ADMIN="admin"))(L=a.organization_projects||={});let C;(t=>(t.READ="read",t.WRITE="write"))(C=a.organization_secrets||={});let U;(t=>(t.READ="read",t.WRITE="write"))(U=a.organization_self_hosted_runners||={});let M;(t=>(t.READ="read",t.WRITE="write"))(M=a.organization_user_blocking||={});let G;(t=>(t.READ="read",t.WRITE="write"))(G=a.packages||={});let B;(t=>(t.READ="read",t.WRITE="write"))(B=a.pages||={});let W;(t=>(t.READ="read",t.WRITE="write"))(W=a.pull_requests||={});let F;(t=>(t.READ="read",t.WRITE="write"))(F=a.repository_hooks||={});let j;(t=>(t.READ="read",t.WRITE="write"))(j=a.repository_projects||={});let V;(t=>(t.READ="read",t.WRITE="write"))(V=a.secret_scanning_alerts||={});let H;(t=>(t.READ="read",t.WRITE="write"))(H=a.secrets||={});let Q;(t=>(t.READ="read",t.WRITE="write"))(Q=a.security_events||={});let z;(t=>(t.READ="read",t.WRITE="write"))(z=a.security_scanning_alert||={});let K;(t=>(t.READ="read",t.WRITE="write"))(K=a.single_file||={});let S;(t=>(t.READ="read",t.WRITE="write"))(S=a.statuses||={});let x;(t=>(t.READ="read",t.WRITE="write"))(x=a.team_discussions||={});let q;(t=>(t.READ="read",t.WRITE="write"))(q=a.vulnerability_alerts||={});let w;(t=>(t.READ="read",t.WRITE="write"))(w=a.workflows||={})})(bs||={});var hs;(a=>{let l;(g=>g.EDITED="edited")(l=a.action||={});let r;(A=>(A.RESOLVED="resolved",A.OFF_TOPIC="off-topic",A.TOO_HEATED="too heated",A.SPAM="spam"))(r=a.active_lock_reason||={});let e;(A=>(A.BOT="Bot",A.USER="User",A.ORGANIZATION="Organization",A.MANNEQUIN="Mannequin"))(e=a.type||={});let n;(T=>(T.COLLABORATOR="COLLABORATOR",T.CONTRIBUTOR="CONTRIBUTOR",T.FIRST_TIMER="FIRST_TIMER",T.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",T.MANNEQUIN="MANNEQUIN",T.MEMBER="MEMBER",T.NONE="NONE",T.OWNER="OWNER"))(n=a.author_association||={});let s;(t=>(t.OPEN="open",t.CLOSED="closed"))(s=a.state||={});let u;(t=>(t.READ="read",t.WRITE="write"))(u=a.actions||={});let _;(t=>(t.READ="read",t.WRITE="write"))(_=a.administration||={});let m;(t=>(t.READ="read",t.WRITE="write"))(m=a.checks||={});let c;(t=>(t.READ="read",t.WRITE="write"))(c=a.content_references||={});let d;(t=>(t.READ="read",t.WRITE="write"))(d=a.contents||={});let v;(t=>(t.READ="read",t.WRITE="write"))(v=a.deployments||={});let h;(t=>(t.READ="read",t.WRITE="write"))(h=a.discussions||={});let R;(t=>(t.READ="read",t.WRITE="write"))(R=a.emails||={});let k;(t=>(t.READ="read",t.WRITE="write"))(k=a.environments||={});let b;(t=>(t.READ="read",t.WRITE="write"))(b=a.issues||={});let p;(t=>(t.READ="read",t.WRITE="write"))(p=a.keys||={});let f;(t=>(t.READ="read",t.WRITE="write"))(f=a.members||={});let O;(t=>(t.READ="read",t.WRITE="write"))(O=a.metadata||={});let I;(t=>(t.READ="read",t.WRITE="write"))(I=a.organization_administration||={});let P;(t=>(t.READ="read",t.WRITE="write"))(P=a.organization_hooks||={});let E;(t=>(t.READ="read",t.WRITE="write"))(E=a.organization_packages||={});let D;(t=>(t.READ="read",t.WRITE="write"))(D=a.organization_plan||={});let L;(y=>(y.READ="read",y.WRITE="write",y.ADMIN="admin"))(L=a.organization_projects||={});let C;(t=>(t.READ="read",t.WRITE="write"))(C=a.organization_secrets||={});let U;(t=>(t.READ="read",t.WRITE="write"))(U=a.organization_self_hosted_runners||={});let M;(t=>(t.READ="read",t.WRITE="write"))(M=a.organization_user_blocking||={});let G;(t=>(t.READ="read",t.WRITE="write"))(G=a.packages||={});let B;(t=>(t.READ="read",t.WRITE="write"))(B=a.pages||={});let W;(t=>(t.READ="read",t.WRITE="write"))(W=a.pull_requests||={});let F;(t=>(t.READ="read",t.WRITE="write"))(F=a.repository_hooks||={});let j;(t=>(t.READ="read",t.WRITE="write"))(j=a.repository_projects||={});let V;(t=>(t.READ="read",t.WRITE="write"))(V=a.secret_scanning_alerts||={});let H;(t=>(t.READ="read",t.WRITE="write"))(H=a.secrets||={});let Q;(t=>(t.READ="read",t.WRITE="write"))(Q=a.security_events||={});let z;(t=>(t.READ="read",t.WRITE="write"))(z=a.security_scanning_alert||={});let K;(t=>(t.READ="read",t.WRITE="write"))(K=a.single_file||={});let S;(t=>(t.READ="read",t.WRITE="write"))(S=a.statuses||={});let x;(t=>(t.READ="read",t.WRITE="write"))(x=a.team_discussions||={});let q;(t=>(t.READ="read",t.WRITE="write"))(q=a.vulnerability_alerts||={});let w;(t=>(t.READ="read",t.WRITE="write"))(w=a.workflows||={})})(hs||={});var ys;(a=>{let l;(g=>g.LABELED="labeled")(l=a.action||={});let r;(A=>(A.RESOLVED="resolved",A.OFF_TOPIC="off-topic",A.TOO_HEATED="too heated",A.SPAM="spam"))(r=a.active_lock_reason||={});let e;(A=>(A.BOT="Bot",A.USER="User",A.ORGANIZATION="Organization",A.MANNEQUIN="Mannequin"))(e=a.type||={});let n;(T=>(T.COLLABORATOR="COLLABORATOR",T.CONTRIBUTOR="CONTRIBUTOR",T.FIRST_TIMER="FIRST_TIMER",T.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",T.MANNEQUIN="MANNEQUIN",T.MEMBER="MEMBER",T.NONE="NONE",T.OWNER="OWNER"))(n=a.author_association||={});let s;(t=>(t.OPEN="open",t.CLOSED="closed"))(s=a.state||={});let u;(t=>(t.READ="read",t.WRITE="write"))(u=a.actions||={});let _;(t=>(t.READ="read",t.WRITE="write"))(_=a.administration||={});let m;(t=>(t.READ="read",t.WRITE="write"))(m=a.checks||={});let c;(t=>(t.READ="read",t.WRITE="write"))(c=a.content_references||={});let d;(t=>(t.READ="read",t.WRITE="write"))(d=a.contents||={});let v;(t=>(t.READ="read",t.WRITE="write"))(v=a.deployments||={});let h;(t=>(t.READ="read",t.WRITE="write"))(h=a.discussions||={});let R;(t=>(t.READ="read",t.WRITE="write"))(R=a.emails||={});let k;(t=>(t.READ="read",t.WRITE="write"))(k=a.environments||={});let b;(t=>(t.READ="read",t.WRITE="write"))(b=a.issues||={});let p;(t=>(t.READ="read",t.WRITE="write"))(p=a.keys||={});let f;(t=>(t.READ="read",t.WRITE="write"))(f=a.members||={});let O;(t=>(t.READ="read",t.WRITE="write"))(O=a.metadata||={});let I;(t=>(t.READ="read",t.WRITE="write"))(I=a.organization_administration||={});let P;(t=>(t.READ="read",t.WRITE="write"))(P=a.organization_hooks||={});let E;(t=>(t.READ="read",t.WRITE="write"))(E=a.organization_packages||={});let D;(t=>(t.READ="read",t.WRITE="write"))(D=a.organization_plan||={});let L;(y=>(y.READ="read",y.WRITE="write",y.ADMIN="admin"))(L=a.organization_projects||={});let C;(t=>(t.READ="read",t.WRITE="write"))(C=a.organization_secrets||={});let U;(t=>(t.READ="read",t.WRITE="write"))(U=a.organization_self_hosted_runners||={});let M;(t=>(t.READ="read",t.WRITE="write"))(M=a.organization_user_blocking||={});let G;(t=>(t.READ="read",t.WRITE="write"))(G=a.packages||={});let B;(t=>(t.READ="read",t.WRITE="write"))(B=a.pages||={});let W;(t=>(t.READ="read",t.WRITE="write"))(W=a.pull_requests||={});let F;(t=>(t.READ="read",t.WRITE="write"))(F=a.repository_hooks||={});let j;(t=>(t.READ="read",t.WRITE="write"))(j=a.repository_projects||={});let V;(t=>(t.READ="read",t.WRITE="write"))(V=a.secret_scanning_alerts||={});let H;(t=>(t.READ="read",t.WRITE="write"))(H=a.secrets||={});let Q;(t=>(t.READ="read",t.WRITE="write"))(Q=a.security_events||={});let z;(t=>(t.READ="read",t.WRITE="write"))(z=a.security_scanning_alert||={});let K;(t=>(t.READ="read",t.WRITE="write"))(K=a.single_file||={});let S;(t=>(t.READ="read",t.WRITE="write"))(S=a.statuses||={});let x;(t=>(t.READ="read",t.WRITE="write"))(x=a.team_discussions||={});let q;(t=>(t.READ="read",t.WRITE="write"))(q=a.vulnerability_alerts||={});let w;(t=>(t.READ="read",t.WRITE="write"))(w=a.workflows||={})})(ys||={});var fs;(a=>{let l;(g=>g.LOCKED="locked")(l=a.action||={});let r;(A=>(A.RESOLVED="resolved",A.OFF_TOPIC="off-topic",A.TOO_HEATED="too heated",A.SPAM="spam"))(r=a.active_lock_reason||={});let e;(y=>(y.BOT="Bot",y.USER="User",y.ORGANIZATION="Organization"))(e=a.type||={});let n;(T=>(T.COLLABORATOR="COLLABORATOR",T.CONTRIBUTOR="CONTRIBUTOR",T.FIRST_TIMER="FIRST_TIMER",T.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",T.MANNEQUIN="MANNEQUIN",T.MEMBER="MEMBER",T.NONE="NONE",T.OWNER="OWNER"))(n=a.author_association||={});let s;(t=>(t.OPEN="open",t.CLOSED="closed"))(s=a.state||={});let u;(t=>(t.READ="read",t.WRITE="write"))(u=a.actions||={});let _;(t=>(t.READ="read",t.WRITE="write"))(_=a.administration||={});let m;(t=>(t.READ="read",t.WRITE="write"))(m=a.checks||={});let c;(t=>(t.READ="read",t.WRITE="write"))(c=a.content_references||={});let d;(t=>(t.READ="read",t.WRITE="write"))(d=a.contents||={});let v;(t=>(t.READ="read",t.WRITE="write"))(v=a.deployments||={});let h;(t=>(t.READ="read",t.WRITE="write"))(h=a.discussions||={});let R;(t=>(t.READ="read",t.WRITE="write"))(R=a.emails||={});let k;(t=>(t.READ="read",t.WRITE="write"))(k=a.environments||={});let b;(t=>(t.READ="read",t.WRITE="write"))(b=a.issues||={});let p;(t=>(t.READ="read",t.WRITE="write"))(p=a.keys||={});let f;(t=>(t.READ="read",t.WRITE="write"))(f=a.members||={});let O;(t=>(t.READ="read",t.WRITE="write"))(O=a.metadata||={});let I;(t=>(t.READ="read",t.WRITE="write"))(I=a.organization_administration||={});let P;(t=>(t.READ="read",t.WRITE="write"))(P=a.organization_hooks||={});let E;(t=>(t.READ="read",t.WRITE="write"))(E=a.organization_packages||={});let D;(t=>(t.READ="read",t.WRITE="write"))(D=a.organization_plan||={});let L;(t=>(t.READ="read",t.WRITE="write"))(L=a.organization_projects||={});let C;(t=>(t.READ="read",t.WRITE="write"))(C=a.organization_secrets||={});let U;(t=>(t.READ="read",t.WRITE="write"))(U=a.organization_self_hosted_runners||={});let M;(t=>(t.READ="read",t.WRITE="write"))(M=a.organization_user_blocking||={});let G;(t=>(t.READ="read",t.WRITE="write"))(G=a.packages||={});let B;(t=>(t.READ="read",t.WRITE="write"))(B=a.pages||={});let W;(t=>(t.READ="read",t.WRITE="write"))(W=a.pull_requests||={});let F;(t=>(t.READ="read",t.WRITE="write"))(F=a.repository_hooks||={});let j;(t=>(t.READ="read",t.WRITE="write"))(j=a.repository_projects||={});let V;(t=>(t.READ="read",t.WRITE="write"))(V=a.secret_scanning_alerts||={});let H;(t=>(t.READ="read",t.WRITE="write"))(H=a.secrets||={});let Q;(t=>(t.READ="read",t.WRITE="write"))(Q=a.security_events||={});let z;(t=>(t.READ="read",t.WRITE="write"))(z=a.security_scanning_alert||={});let K;(t=>(t.READ="read",t.WRITE="write"))(K=a.single_file||={});let S;(t=>(t.READ="read",t.WRITE="write"))(S=a.statuses||={});let x;(t=>(t.READ="read",t.WRITE="write"))(x=a.team_discussions||={});let q;(t=>(t.READ="read",t.WRITE="write"))(q=a.vulnerability_alerts||={});let w;(t=>(t.READ="read",t.WRITE="write"))(w=a.workflows||={})})(fs||={});var ws;(a=>{let l;(g=>g.MILESTONED="milestoned")(l=a.action||={});let r;(A=>(A.RESOLVED="resolved",A.OFF_TOPIC="off-topic",A.TOO_HEATED="too heated",A.SPAM="spam"))(r=a.active_lock_reason||={});let e;(y=>(y.BOT="Bot",y.USER="User",y.ORGANIZATION="Organization"))(e=a.type||={});let n;(T=>(T.COLLABORATOR="COLLABORATOR",T.CONTRIBUTOR="CONTRIBUTOR",T.FIRST_TIMER="FIRST_TIMER",T.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",T.MANNEQUIN="MANNEQUIN",T.MEMBER="MEMBER",T.NONE="NONE",T.OWNER="OWNER"))(n=a.author_association||={});let s;(t=>(t.OPEN="open",t.CLOSED="closed"))(s=a.state||={});let u;(t=>(t.READ="read",t.WRITE="write"))(u=a.actions||={});let _;(t=>(t.READ="read",t.WRITE="write"))(_=a.administration||={});let m;(t=>(t.READ="read",t.WRITE="write"))(m=a.checks||={});let c;(t=>(t.READ="read",t.WRITE="write"))(c=a.content_references||={});let d;(t=>(t.READ="read",t.WRITE="write"))(d=a.contents||={});let v;(t=>(t.READ="read",t.WRITE="write"))(v=a.deployments||={});let h;(t=>(t.READ="read",t.WRITE="write"))(h=a.discussions||={});let R;(t=>(t.READ="read",t.WRITE="write"))(R=a.emails||={});let k;(t=>(t.READ="read",t.WRITE="write"))(k=a.environments||={});let b;(t=>(t.READ="read",t.WRITE="write"))(b=a.issues||={});let p;(t=>(t.READ="read",t.WRITE="write"))(p=a.keys||={});let f;(t=>(t.READ="read",t.WRITE="write"))(f=a.members||={});let O;(t=>(t.READ="read",t.WRITE="write"))(O=a.metadata||={});let I;(t=>(t.READ="read",t.WRITE="write"))(I=a.organization_administration||={});let P;(t=>(t.READ="read",t.WRITE="write"))(P=a.organization_hooks||={});let E;(t=>(t.READ="read",t.WRITE="write"))(E=a.organization_packages||={});let D;(t=>(t.READ="read",t.WRITE="write"))(D=a.organization_plan||={});let L;(y=>(y.READ="read",y.WRITE="write",y.ADMIN="admin"))(L=a.organization_projects||={});let C;(t=>(t.READ="read",t.WRITE="write"))(C=a.organization_secrets||={});let U;(t=>(t.READ="read",t.WRITE="write"))(U=a.organization_self_hosted_runners||={});let M;(t=>(t.READ="read",t.WRITE="write"))(M=a.organization_user_blocking||={});let G;(t=>(t.READ="read",t.WRITE="write"))(G=a.packages||={});let B;(t=>(t.READ="read",t.WRITE="write"))(B=a.pages||={});let W;(t=>(t.READ="read",t.WRITE="write"))(W=a.pull_requests||={});let F;(t=>(t.READ="read",t.WRITE="write"))(F=a.repository_hooks||={});let j;(t=>(t.READ="read",t.WRITE="write"))(j=a.repository_projects||={});let V;(t=>(t.READ="read",t.WRITE="write"))(V=a.secret_scanning_alerts||={});let H;(t=>(t.READ="read",t.WRITE="write"))(H=a.secrets||={});let Q;(t=>(t.READ="read",t.WRITE="write"))(Q=a.security_events||={});let z;(t=>(t.READ="read",t.WRITE="write"))(z=a.security_scanning_alert||={});let K;(t=>(t.READ="read",t.WRITE="write"))(K=a.single_file||={});let S;(t=>(t.READ="read",t.WRITE="write"))(S=a.statuses||={});let x;(t=>(t.READ="read",t.WRITE="write"))(x=a.team_discussions||={});let q;(t=>(t.READ="read",t.WRITE="write"))(q=a.vulnerability_alerts||={});let w;(t=>(t.READ="read",t.WRITE="write"))(w=a.workflows||={})})(ws||={});var Es;(N=>{let l;(t=>t.OPENED="opened")(l=N.action||={});let r;(X=>(X.RESOLVED="resolved",X.OFF_TOPIC="off-topic",X.TOO_HEATED="too heated",X.SPAM="spam"))(r=N.active_lock_reason||={});let e;(A=>(A.BOT="Bot",A.USER="User",A.ORGANIZATION="Organization"))(e=N.type||={});let n;(Z=>(Z.COLLABORATOR="COLLABORATOR",Z.CONTRIBUTOR="CONTRIBUTOR",Z.FIRST_TIMER="FIRST_TIMER",Z.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",Z.MANNEQUIN="MANNEQUIN",Z.MEMBER="MEMBER",Z.NONE="NONE",Z.OWNER="OWNER"))(n=N.author_association||={});let s;(y=>(y.OPEN="open",y.CLOSED="closed"))(s=N.state||={});let u;(y=>(y.READ="read",y.WRITE="write"))(u=N.actions||={});let _;(y=>(y.READ="read",y.WRITE="write"))(_=N.administration||={});let m;(y=>(y.READ="read",y.WRITE="write"))(m=N.checks||={});let c;(y=>(y.READ="read",y.WRITE="write"))(c=N.content_references||={});let d;(y=>(y.READ="read",y.WRITE="write"))(d=N.contents||={});let v;(y=>(y.READ="read",y.WRITE="write"))(v=N.deployments||={});let h;(y=>(y.READ="read",y.WRITE="write"))(h=N.discussions||={});let R;(y=>(y.READ="read",y.WRITE="write"))(R=N.emails||={});let k;(y=>(y.READ="read",y.WRITE="write"))(k=N.environments||={});let b;(y=>(y.READ="read",y.WRITE="write"))(b=N.issues||={});let p;(y=>(y.READ="read",y.WRITE="write"))(p=N.keys||={});let f;(y=>(y.READ="read",y.WRITE="write"))(f=N.members||={});let O;(y=>(y.READ="read",y.WRITE="write"))(O=N.metadata||={});let I;(y=>(y.READ="read",y.WRITE="write"))(I=N.organization_administration||={});let P;(y=>(y.READ="read",y.WRITE="write"))(P=N.organization_hooks||={});let E;(y=>(y.READ="read",y.WRITE="write"))(E=N.organization_packages||={});let D;(y=>(y.READ="read",y.WRITE="write"))(D=N.organization_plan||={});let L;(y=>(y.READ="read",y.WRITE="write"))(L=N.organization_projects||={});let C;(y=>(y.READ="read",y.WRITE="write"))(C=N.organization_secrets||={});let U;(y=>(y.READ="read",y.WRITE="write"))(U=N.organization_self_hosted_runners||={});let M;(y=>(y.READ="read",y.WRITE="write"))(M=N.organization_user_blocking||={});let G;(y=>(y.READ="read",y.WRITE="write"))(G=N.packages||={});let B;(y=>(y.READ="read",y.WRITE="write"))(B=N.pages||={});let W;(y=>(y.READ="read",y.WRITE="write"))(W=N.pull_requests||={});let F;(y=>(y.READ="read",y.WRITE="write"))(F=N.repository_hooks||={});let j;(y=>(y.READ="read",y.WRITE="write"))(j=N.repository_projects||={});let V;(y=>(y.READ="read",y.WRITE="write"))(V=N.secret_scanning_alerts||={});let H;(y=>(y.READ="read",y.WRITE="write"))(H=N.secrets||={});let Q;(y=>(y.READ="read",y.WRITE="write"))(Q=N.security_events||={});let z;(y=>(y.READ="read",y.WRITE="write"))(z=N.security_scanning_alert||={});let K;(y=>(y.READ="read",y.WRITE="write"))(K=N.single_file||={});let S;(y=>(y.READ="read",y.WRITE="write"))(S=N.statuses||={});let x;(y=>(y.READ="read",y.WRITE="write"))(x=N.team_discussions||={});let q;(y=>(y.READ="read",y.WRITE="write"))(q=N.vulnerability_alerts||={});let w;(y=>(y.READ="read",y.WRITE="write"))(w=N.workflows||={});let a;(A=>(A.PUBLIC="public",A.PRIVATE="private",A.INTERNAL="internal"))(a=N.visibility||={})})(Es||={});var vs;(a=>{let l;(g=>g.PINNED="pinned")(l=a.action||={});let r;(A=>(A.RESOLVED="resolved",A.OFF_TOPIC="off-topic",A.TOO_HEATED="too heated",A.SPAM="spam"))(r=a.active_lock_reason||={});let e;(y=>(y.BOT="Bot",y.USER="User",y.ORGANIZATION="Organization"))(e=a.type||={});let n;(T=>(T.COLLABORATOR="COLLABORATOR",T.CONTRIBUTOR="CONTRIBUTOR",T.FIRST_TIMER="FIRST_TIMER",T.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",T.MANNEQUIN="MANNEQUIN",T.MEMBER="MEMBER",T.NONE="NONE",T.OWNER="OWNER"))(n=a.author_association||={});let s;(t=>(t.OPEN="open",t.CLOSED="closed"))(s=a.state||={});let u;(t=>(t.READ="read",t.WRITE="write"))(u=a.actions||={});let _;(t=>(t.READ="read",t.WRITE="write"))(_=a.administration||={});let m;(t=>(t.READ="read",t.WRITE="write"))(m=a.checks||={});let c;(t=>(t.READ="read",t.WRITE="write"))(c=a.content_references||={});let d;(t=>(t.READ="read",t.WRITE="write"))(d=a.contents||={});let v;(t=>(t.READ="read",t.WRITE="write"))(v=a.deployments||={});let h;(t=>(t.READ="read",t.WRITE="write"))(h=a.discussions||={});let R;(t=>(t.READ="read",t.WRITE="write"))(R=a.emails||={});let k;(t=>(t.READ="read",t.WRITE="write"))(k=a.environments||={});let b;(t=>(t.READ="read",t.WRITE="write"))(b=a.issues||={});let p;(t=>(t.READ="read",t.WRITE="write"))(p=a.keys||={});let f;(t=>(t.READ="read",t.WRITE="write"))(f=a.members||={});let O;(t=>(t.READ="read",t.WRITE="write"))(O=a.metadata||={});let I;(t=>(t.READ="read",t.WRITE="write"))(I=a.organization_administration||={});let P;(t=>(t.READ="read",t.WRITE="write"))(P=a.organization_hooks||={});let E;(t=>(t.READ="read",t.WRITE="write"))(E=a.organization_packages||={});let D;(t=>(t.READ="read",t.WRITE="write"))(D=a.organization_plan||={});let L;(t=>(t.READ="read",t.WRITE="write"))(L=a.organization_projects||={});let C;(t=>(t.READ="read",t.WRITE="write"))(C=a.organization_secrets||={});let U;(t=>(t.READ="read",t.WRITE="write"))(U=a.organization_self_hosted_runners||={});let M;(t=>(t.READ="read",t.WRITE="write"))(M=a.organization_user_blocking||={});let G;(t=>(t.READ="read",t.WRITE="write"))(G=a.packages||={});let B;(t=>(t.READ="read",t.WRITE="write"))(B=a.pages||={});let W;(t=>(t.READ="read",t.WRITE="write"))(W=a.pull_requests||={});let F;(t=>(t.READ="read",t.WRITE="write"))(F=a.repository_hooks||={});let j;(t=>(t.READ="read",t.WRITE="write"))(j=a.repository_projects||={});let V;(t=>(t.READ="read",t.WRITE="write"))(V=a.secret_scanning_alerts||={});let H;(t=>(t.READ="read",t.WRITE="write"))(H=a.secrets||={});let Q;(t=>(t.READ="read",t.WRITE="write"))(Q=a.security_events||={});let z;(t=>(t.READ="read",t.WRITE="write"))(z=a.security_scanning_alert||={});let K;(t=>(t.READ="read",t.WRITE="write"))(K=a.single_file||={});let S;(t=>(t.READ="read",t.WRITE="write"))(S=a.statuses||={});let x;(t=>(t.READ="read",t.WRITE="write"))(x=a.team_discussions||={});let q;(t=>(t.READ="read",t.WRITE="write"))(q=a.vulnerability_alerts||={});let w;(t=>(t.READ="read",t.WRITE="write"))(w=a.workflows||={})})(vs||={});var Rs;(a=>{let l;(g=>g.REOPENED="reopened")(l=a.action||={});let r;(A=>(A.RESOLVED="resolved",A.OFF_TOPIC="off-topic",A.TOO_HEATED="too heated",A.SPAM="spam"))(r=a.active_lock_reason||={});let e;(y=>(y.BOT="Bot",y.USER="User",y.ORGANIZATION="Organization"))(e=a.type||={});let n;(T=>(T.COLLABORATOR="COLLABORATOR",T.CONTRIBUTOR="CONTRIBUTOR",T.FIRST_TIMER="FIRST_TIMER",T.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",T.MANNEQUIN="MANNEQUIN",T.MEMBER="MEMBER",T.NONE="NONE",T.OWNER="OWNER"))(n=a.author_association||={});let s;(t=>(t.OPEN="open",t.CLOSED="closed"))(s=a.state||={});let u;(t=>(t.READ="read",t.WRITE="write"))(u=a.actions||={});let _;(t=>(t.READ="read",t.WRITE="write"))(_=a.administration||={});let m;(t=>(t.READ="read",t.WRITE="write"))(m=a.checks||={});let c;(t=>(t.READ="read",t.WRITE="write"))(c=a.content_references||={});let d;(t=>(t.READ="read",t.WRITE="write"))(d=a.contents||={});let v;(t=>(t.READ="read",t.WRITE="write"))(v=a.deployments||={});let h;(t=>(t.READ="read",t.WRITE="write"))(h=a.discussions||={});let R;(t=>(t.READ="read",t.WRITE="write"))(R=a.emails||={});let k;(t=>(t.READ="read",t.WRITE="write"))(k=a.environments||={});let b;(t=>(t.READ="read",t.WRITE="write"))(b=a.issues||={});let p;(t=>(t.READ="read",t.WRITE="write"))(p=a.keys||={});let f;(t=>(t.READ="read",t.WRITE="write"))(f=a.members||={});let O;(t=>(t.READ="read",t.WRITE="write"))(O=a.metadata||={});let I;(t=>(t.READ="read",t.WRITE="write"))(I=a.organization_administration||={});let P;(t=>(t.READ="read",t.WRITE="write"))(P=a.organization_hooks||={});let E;(t=>(t.READ="read",t.WRITE="write"))(E=a.organization_packages||={});let D;(t=>(t.READ="read",t.WRITE="write"))(D=a.organization_plan||={});let L;(y=>(y.READ="read",y.WRITE="write",y.ADMIN="admin"))(L=a.organization_projects||={});let C;(t=>(t.READ="read",t.WRITE="write"))(C=a.organization_secrets||={});let U;(t=>(t.READ="read",t.WRITE="write"))(U=a.organization_self_hosted_runners||={});let M;(t=>(t.READ="read",t.WRITE="write"))(M=a.organization_user_blocking||={});let G;(t=>(t.READ="read",t.WRITE="write"))(G=a.packages||={});let B;(t=>(t.READ="read",t.WRITE="write"))(B=a.pages||={});let W;(t=>(t.READ="read",t.WRITE="write"))(W=a.pull_requests||={});let F;(t=>(t.READ="read",t.WRITE="write"))(F=a.repository_hooks||={});let j;(y=>(y.READ="read",y.WRITE="write",y.ADMIN="admin"))(j=a.repository_projects||={});let V;(t=>(t.READ="read",t.WRITE="write"))(V=a.secret_scanning_alerts||={});let H;(t=>(t.READ="read",t.WRITE="write"))(H=a.secrets||={});let Q;(t=>(t.READ="read",t.WRITE="write"))(Q=a.security_events||={});let z;(t=>(t.READ="read",t.WRITE="write"))(z=a.security_scanning_alert||={});let K;(t=>(t.READ="read",t.WRITE="write"))(K=a.single_file||={});let S;(t=>(t.READ="read",t.WRITE="write"))(S=a.statuses||={});let x;(t=>(t.READ="read",t.WRITE="write"))(x=a.team_discussions||={});let q;(t=>(t.READ="read",t.WRITE="write"))(q=a.vulnerability_alerts||={});let w;(t=>(t.READ="read",t.WRITE="write"))(w=a.workflows||={})})(Rs||={});var Ts;(N=>{let l;(t=>t.TRANSFERRED="transferred")(l=N.action||={});let r;(X=>(X.RESOLVED="resolved",X.OFF_TOPIC="off-topic",X.TOO_HEATED="too heated",X.SPAM="spam"))(r=N.active_lock_reason||={});let e;(A=>(A.BOT="Bot",A.USER="User",A.ORGANIZATION="Organization"))(e=N.type||={});let n;(Z=>(Z.COLLABORATOR="COLLABORATOR",Z.CONTRIBUTOR="CONTRIBUTOR",Z.FIRST_TIMER="FIRST_TIMER",Z.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",Z.MANNEQUIN="MANNEQUIN",Z.MEMBER="MEMBER",Z.NONE="NONE",Z.OWNER="OWNER"))(n=N.author_association||={});let s;(y=>(y.OPEN="open",y.CLOSED="closed"))(s=N.state||={});let u;(y=>(y.READ="read",y.WRITE="write"))(u=N.actions||={});let _;(y=>(y.READ="read",y.WRITE="write"))(_=N.administration||={});let m;(y=>(y.READ="read",y.WRITE="write"))(m=N.checks||={});let c;(y=>(y.READ="read",y.WRITE="write"))(c=N.content_references||={});let d;(y=>(y.READ="read",y.WRITE="write"))(d=N.contents||={});let v;(y=>(y.READ="read",y.WRITE="write"))(v=N.deployments||={});let h;(y=>(y.READ="read",y.WRITE="write"))(h=N.discussions||={});let R;(y=>(y.READ="read",y.WRITE="write"))(R=N.emails||={});let k;(y=>(y.READ="read",y.WRITE="write"))(k=N.environments||={});let b;(y=>(y.READ="read",y.WRITE="write"))(b=N.issues||={});let p;(y=>(y.READ="read",y.WRITE="write"))(p=N.keys||={});let f;(y=>(y.READ="read",y.WRITE="write"))(f=N.members||={});let O;(y=>(y.READ="read",y.WRITE="write"))(O=N.metadata||={});let I;(y=>(y.READ="read",y.WRITE="write"))(I=N.organization_administration||={});let P;(y=>(y.READ="read",y.WRITE="write"))(P=N.organization_hooks||={});let E;(y=>(y.READ="read",y.WRITE="write"))(E=N.organization_packages||={});let D;(y=>(y.READ="read",y.WRITE="write"))(D=N.organization_plan||={});let L;(y=>(y.READ="read",y.WRITE="write"))(L=N.organization_projects||={});let C;(y=>(y.READ="read",y.WRITE="write"))(C=N.organization_secrets||={});let U;(y=>(y.READ="read",y.WRITE="write"))(U=N.organization_self_hosted_runners||={});let M;(y=>(y.READ="read",y.WRITE="write"))(M=N.organization_user_blocking||={});let G;(y=>(y.READ="read",y.WRITE="write"))(G=N.packages||={});let B;(y=>(y.READ="read",y.WRITE="write"))(B=N.pages||={});let W;(y=>(y.READ="read",y.WRITE="write"))(W=N.pull_requests||={});let F;(y=>(y.READ="read",y.WRITE="write"))(F=N.repository_hooks||={});let j;(y=>(y.READ="read",y.WRITE="write"))(j=N.repository_projects||={});let V;(y=>(y.READ="read",y.WRITE="write"))(V=N.secret_scanning_alerts||={});let H;(y=>(y.READ="read",y.WRITE="write"))(H=N.secrets||={});let Q;(y=>(y.READ="read",y.WRITE="write"))(Q=N.security_events||={});let z;(y=>(y.READ="read",y.WRITE="write"))(z=N.security_scanning_alert||={});let K;(y=>(y.READ="read",y.WRITE="write"))(K=N.single_file||={});let S;(y=>(y.READ="read",y.WRITE="write"))(S=N.statuses||={});let x;(y=>(y.READ="read",y.WRITE="write"))(x=N.team_discussions||={});let q;(y=>(y.READ="read",y.WRITE="write"))(q=N.vulnerability_alerts||={});let w;(y=>(y.READ="read",y.WRITE="write"))(w=N.workflows||={});let a;(A=>(A.PUBLIC="public",A.PRIVATE="private",A.INTERNAL="internal"))(a=N.visibility||={})})(Ts||={});var As;(a=>{let l;(g=>g.UNASSIGNED="unassigned")(l=a.action||={});let r;(A=>(A.BOT="Bot",A.USER="User",A.ORGANIZATION="Organization",A.MANNEQUIN="Mannequin"))(r=a.type||={});let e;(A=>(A.RESOLVED="resolved",A.OFF_TOPIC="off-topic",A.TOO_HEATED="too heated",A.SPAM="spam"))(e=a.active_lock_reason||={});let n;(T=>(T.COLLABORATOR="COLLABORATOR",T.CONTRIBUTOR="CONTRIBUTOR",T.FIRST_TIMER="FIRST_TIMER",T.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",T.MANNEQUIN="MANNEQUIN",T.MEMBER="MEMBER",T.NONE="NONE",T.OWNER="OWNER"))(n=a.author_association||={});let s;(t=>(t.OPEN="open",t.CLOSED="closed"))(s=a.state||={});let u;(t=>(t.READ="read",t.WRITE="write"))(u=a.actions||={});let _;(t=>(t.READ="read",t.WRITE="write"))(_=a.administration||={});let m;(t=>(t.READ="read",t.WRITE="write"))(m=a.checks||={});let c;(t=>(t.READ="read",t.WRITE="write"))(c=a.content_references||={});let d;(t=>(t.READ="read",t.WRITE="write"))(d=a.contents||={});let v;(t=>(t.READ="read",t.WRITE="write"))(v=a.deployments||={});let h;(t=>(t.READ="read",t.WRITE="write"))(h=a.discussions||={});let R;(t=>(t.READ="read",t.WRITE="write"))(R=a.emails||={});let k;(t=>(t.READ="read",t.WRITE="write"))(k=a.environments||={});let b;(t=>(t.READ="read",t.WRITE="write"))(b=a.issues||={});let p;(t=>(t.READ="read",t.WRITE="write"))(p=a.keys||={});let f;(t=>(t.READ="read",t.WRITE="write"))(f=a.members||={});let O;(t=>(t.READ="read",t.WRITE="write"))(O=a.metadata||={});let I;(t=>(t.READ="read",t.WRITE="write"))(I=a.organization_administration||={});let P;(t=>(t.READ="read",t.WRITE="write"))(P=a.organization_hooks||={});let E;(t=>(t.READ="read",t.WRITE="write"))(E=a.organization_packages||={});let D;(t=>(t.READ="read",t.WRITE="write"))(D=a.organization_plan||={});let L;(y=>(y.READ="read",y.WRITE="write",y.ADMIN="admin"))(L=a.organization_projects||={});let C;(t=>(t.READ="read",t.WRITE="write"))(C=a.organization_secrets||={});let U;(t=>(t.READ="read",t.WRITE="write"))(U=a.organization_self_hosted_runners||={});let M;(t=>(t.READ="read",t.WRITE="write"))(M=a.organization_user_blocking||={});let G;(t=>(t.READ="read",t.WRITE="write"))(G=a.packages||={});let B;(t=>(t.READ="read",t.WRITE="write"))(B=a.pages||={});let W;(t=>(t.READ="read",t.WRITE="write"))(W=a.pull_requests||={});let F;(t=>(t.READ="read",t.WRITE="write"))(F=a.repository_hooks||={});let j;(t=>(t.READ="read",t.WRITE="write"))(j=a.repository_projects||={});let V;(t=>(t.READ="read",t.WRITE="write"))(V=a.secret_scanning_alerts||={});let H;(t=>(t.READ="read",t.WRITE="write"))(H=a.secrets||={});let Q;(t=>(t.READ="read",t.WRITE="write"))(Q=a.security_events||={});let z;(t=>(t.READ="read",t.WRITE="write"))(z=a.security_scanning_alert||={});let K;(t=>(t.READ="read",t.WRITE="write"))(K=a.single_file||={});let S;(t=>(t.READ="read",t.WRITE="write"))(S=a.statuses||={});let x;(t=>(t.READ="read",t.WRITE="write"))(x=a.team_discussions||={});let q;(t=>(t.READ="read",t.WRITE="write"))(q=a.vulnerability_alerts||={});let w;(t=>(t.READ="read",t.WRITE="write"))(w=a.workflows||={})})(As||={});var ks;(a=>{let l;(g=>g.UNLABELED="unlabeled")(l=a.action||={});let r;(A=>(A.RESOLVED="resolved",A.OFF_TOPIC="off-topic",A.TOO_HEATED="too heated",A.SPAM="spam"))(r=a.active_lock_reason||={});let e;(A=>(A.BOT="Bot",A.USER="User",A.ORGANIZATION="Organization",A.MANNEQUIN="Mannequin"))(e=a.type||={});let n;(T=>(T.COLLABORATOR="COLLABORATOR",T.CONTRIBUTOR="CONTRIBUTOR",T.FIRST_TIMER="FIRST_TIMER",T.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",T.MANNEQUIN="MANNEQUIN",T.MEMBER="MEMBER",T.NONE="NONE",T.OWNER="OWNER"))(n=a.author_association||={});let s;(t=>(t.OPEN="open",t.CLOSED="closed"))(s=a.state||={});let u;(t=>(t.READ="read",t.WRITE="write"))(u=a.actions||={});let _;(t=>(t.READ="read",t.WRITE="write"))(_=a.administration||={});let m;(t=>(t.READ="read",t.WRITE="write"))(m=a.checks||={});let c;(t=>(t.READ="read",t.WRITE="write"))(c=a.content_references||={});let d;(t=>(t.READ="read",t.WRITE="write"))(d=a.contents||={});let v;(t=>(t.READ="read",t.WRITE="write"))(v=a.deployments||={});let h;(t=>(t.READ="read",t.WRITE="write"))(h=a.discussions||={});let R;(t=>(t.READ="read",t.WRITE="write"))(R=a.emails||={});let k;(t=>(t.READ="read",t.WRITE="write"))(k=a.environments||={});let b;(t=>(t.READ="read",t.WRITE="write"))(b=a.issues||={});let p;(t=>(t.READ="read",t.WRITE="write"))(p=a.keys||={});let f;(t=>(t.READ="read",t.WRITE="write"))(f=a.members||={});let O;(t=>(t.READ="read",t.WRITE="write"))(O=a.metadata||={});let I;(t=>(t.READ="read",t.WRITE="write"))(I=a.organization_administration||={});let P;(t=>(t.READ="read",t.WRITE="write"))(P=a.organization_hooks||={});let E;(t=>(t.READ="read",t.WRITE="write"))(E=a.organization_packages||={});let D;(t=>(t.READ="read",t.WRITE="write"))(D=a.organization_plan||={});let L;(y=>(y.READ="read",y.WRITE="write",y.ADMIN="admin"))(L=a.organization_projects||={});let C;(t=>(t.READ="read",t.WRITE="write"))(C=a.organization_secrets||={});let U;(t=>(t.READ="read",t.WRITE="write"))(U=a.organization_self_hosted_runners||={});let M;(t=>(t.READ="read",t.WRITE="write"))(M=a.organization_user_blocking||={});let G;(t=>(t.READ="read",t.WRITE="write"))(G=a.packages||={});let B;(t=>(t.READ="read",t.WRITE="write"))(B=a.pages||={});let W;(t=>(t.READ="read",t.WRITE="write"))(W=a.pull_requests||={});let F;(t=>(t.READ="read",t.WRITE="write"))(F=a.repository_hooks||={});let j;(t=>(t.READ="read",t.WRITE="write"))(j=a.repository_projects||={});let V;(t=>(t.READ="read",t.WRITE="write"))(V=a.secret_scanning_alerts||={});let H;(t=>(t.READ="read",t.WRITE="write"))(H=a.secrets||={});let Q;(t=>(t.READ="read",t.WRITE="write"))(Q=a.security_events||={});let z;(t=>(t.READ="read",t.WRITE="write"))(z=a.security_scanning_alert||={});let K;(t=>(t.READ="read",t.WRITE="write"))(K=a.single_file||={});let S;(t=>(t.READ="read",t.WRITE="write"))(S=a.statuses||={});let x;(t=>(t.READ="read",t.WRITE="write"))(x=a.team_discussions||={});let q;(t=>(t.READ="read",t.WRITE="write"))(q=a.vulnerability_alerts||={});let w;(t=>(t.READ="read",t.WRITE="write"))(w=a.workflows||={})})(ks||={});var xs;(a=>{let l;(g=>g.UNLOCKED="unlocked")(l=a.action||={});let r;(A=>(A.RESOLVED="resolved",A.OFF_TOPIC="off-topic",A.TOO_HEATED="too heated",A.SPAM="spam"))(r=a.active_lock_reason||={});let e;(y=>(y.BOT="Bot",y.USER="User",y.ORGANIZATION="Organization"))(e=a.type||={});let n;(T=>(T.COLLABORATOR="COLLABORATOR",T.CONTRIBUTOR="CONTRIBUTOR",T.FIRST_TIMER="FIRST_TIMER",T.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",T.MANNEQUIN="MANNEQUIN",T.MEMBER="MEMBER",T.NONE="NONE",T.OWNER="OWNER"))(n=a.author_association||={});let s;(t=>(t.OPEN="open",t.CLOSED="closed"))(s=a.state||={});let u;(t=>(t.READ="read",t.WRITE="write"))(u=a.actions||={});let _;(t=>(t.READ="read",t.WRITE="write"))(_=a.administration||={});let m;(t=>(t.READ="read",t.WRITE="write"))(m=a.checks||={});let c;(t=>(t.READ="read",t.WRITE="write"))(c=a.content_references||={});let d;(t=>(t.READ="read",t.WRITE="write"))(d=a.contents||={});let v;(t=>(t.READ="read",t.WRITE="write"))(v=a.deployments||={});let h;(t=>(t.READ="read",t.WRITE="write"))(h=a.discussions||={});let R;(t=>(t.READ="read",t.WRITE="write"))(R=a.emails||={});let k;(t=>(t.READ="read",t.WRITE="write"))(k=a.environments||={});let b;(t=>(t.READ="read",t.WRITE="write"))(b=a.issues||={});let p;(t=>(t.READ="read",t.WRITE="write"))(p=a.keys||={});let f;(t=>(t.READ="read",t.WRITE="write"))(f=a.members||={});let O;(t=>(t.READ="read",t.WRITE="write"))(O=a.metadata||={});let I;(t=>(t.READ="read",t.WRITE="write"))(I=a.organization_administration||={});let P;(t=>(t.READ="read",t.WRITE="write"))(P=a.organization_hooks||={});let E;(t=>(t.READ="read",t.WRITE="write"))(E=a.organization_packages||={});let D;(t=>(t.READ="read",t.WRITE="write"))(D=a.organization_plan||={});let L;(t=>(t.READ="read",t.WRITE="write"))(L=a.organization_projects||={});let C;(t=>(t.READ="read",t.WRITE="write"))(C=a.organization_secrets||={});let U;(t=>(t.READ="read",t.WRITE="write"))(U=a.organization_self_hosted_runners||={});let M;(t=>(t.READ="read",t.WRITE="write"))(M=a.organization_user_blocking||={});let G;(t=>(t.READ="read",t.WRITE="write"))(G=a.packages||={});let B;(t=>(t.READ="read",t.WRITE="write"))(B=a.pages||={});let W;(t=>(t.READ="read",t.WRITE="write"))(W=a.pull_requests||={});let F;(t=>(t.READ="read",t.WRITE="write"))(F=a.repository_hooks||={});let j;(t=>(t.READ="read",t.WRITE="write"))(j=a.repository_projects||={});let V;(t=>(t.READ="read",t.WRITE="write"))(V=a.secret_scanning_alerts||={});let H;(t=>(t.READ="read",t.WRITE="write"))(H=a.secrets||={});let Q;(t=>(t.READ="read",t.WRITE="write"))(Q=a.security_events||={});let z;(t=>(t.READ="read",t.WRITE="write"))(z=a.security_scanning_alert||={});let K;(t=>(t.READ="read",t.WRITE="write"))(K=a.single_file||={});let S;(t=>(t.READ="read",t.WRITE="write"))(S=a.statuses||={});let x;(t=>(t.READ="read",t.WRITE="write"))(x=a.team_discussions||={});let q;(t=>(t.READ="read",t.WRITE="write"))(q=a.vulnerability_alerts||={});let w;(t=>(t.READ="read",t.WRITE="write"))(w=a.workflows||={})})(xs||={});var Is;(a=>{let l;(g=>g.UNPINNED="unpinned")(l=a.action||={});let r;(A=>(A.RESOLVED="resolved",A.OFF_TOPIC="off-topic",A.TOO_HEATED="too heated",A.SPAM="spam"))(r=a.active_lock_reason||={});let e;(y=>(y.BOT="Bot",y.USER="User",y.ORGANIZATION="Organization"))(e=a.type||={});let n;(T=>(T.COLLABORATOR="COLLABORATOR",T.CONTRIBUTOR="CONTRIBUTOR",T.FIRST_TIMER="FIRST_TIMER",T.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",T.MANNEQUIN="MANNEQUIN",T.MEMBER="MEMBER",T.NONE="NONE",T.OWNER="OWNER"))(n=a.author_association||={});let s;(t=>(t.OPEN="open",t.CLOSED="closed"))(s=a.state||={});let u;(t=>(t.READ="read",t.WRITE="write"))(u=a.actions||={});let _;(t=>(t.READ="read",t.WRITE="write"))(_=a.administration||={});let m;(t=>(t.READ="read",t.WRITE="write"))(m=a.checks||={});let c;(t=>(t.READ="read",t.WRITE="write"))(c=a.content_references||={});let d;(t=>(t.READ="read",t.WRITE="write"))(d=a.contents||={});let v;(t=>(t.READ="read",t.WRITE="write"))(v=a.deployments||={});let h;(t=>(t.READ="read",t.WRITE="write"))(h=a.discussions||={});let R;(t=>(t.READ="read",t.WRITE="write"))(R=a.emails||={});let k;(t=>(t.READ="read",t.WRITE="write"))(k=a.environments||={});let b;(t=>(t.READ="read",t.WRITE="write"))(b=a.issues||={});let p;(t=>(t.READ="read",t.WRITE="write"))(p=a.keys||={});let f;(t=>(t.READ="read",t.WRITE="write"))(f=a.members||={});let O;(t=>(t.READ="read",t.WRITE="write"))(O=a.metadata||={});let I;(t=>(t.READ="read",t.WRITE="write"))(I=a.organization_administration||={});let P;(t=>(t.READ="read",t.WRITE="write"))(P=a.organization_hooks||={});let E;(t=>(t.READ="read",t.WRITE="write"))(E=a.organization_packages||={});let D;(t=>(t.READ="read",t.WRITE="write"))(D=a.organization_plan||={});let L;(t=>(t.READ="read",t.WRITE="write"))(L=a.organization_projects||={});let C;(t=>(t.READ="read",t.WRITE="write"))(C=a.organization_secrets||={});let U;(t=>(t.READ="read",t.WRITE="write"))(U=a.organization_self_hosted_runners||={});let M;(t=>(t.READ="read",t.WRITE="write"))(M=a.organization_user_blocking||={});let G;(t=>(t.READ="read",t.WRITE="write"))(G=a.packages||={});let B;(t=>(t.READ="read",t.WRITE="write"))(B=a.pages||={});let W;(t=>(t.READ="read",t.WRITE="write"))(W=a.pull_requests||={});let F;(t=>(t.READ="read",t.WRITE="write"))(F=a.repository_hooks||={});let j;(t=>(t.READ="read",t.WRITE="write"))(j=a.repository_projects||={});let V;(t=>(t.READ="read",t.WRITE="write"))(V=a.secret_scanning_alerts||={});let H;(t=>(t.READ="read",t.WRITE="write"))(H=a.secrets||={});let Q;(t=>(t.READ="read",t.WRITE="write"))(Q=a.security_events||={});let z;(t=>(t.READ="read",t.WRITE="write"))(z=a.security_scanning_alert||={});let K;(t=>(t.READ="read",t.WRITE="write"))(K=a.single_file||={});let S;(t=>(t.READ="read",t.WRITE="write"))(S=a.statuses||={});let x;(t=>(t.READ="read",t.WRITE="write"))(x=a.team_discussions||={});let q;(t=>(t.READ="read",t.WRITE="write"))(q=a.vulnerability_alerts||={});let w;(t=>(t.READ="read",t.WRITE="write"))(w=a.workflows||={})})(Is||={});var Os;(r=>{let l;(n=>n.CREATED="created")(l=r.action||={})})(Os||={});var Ns;(r=>{let l;(n=>n.DELETED="deleted")(l=r.action||={})})(Ns||={});var zs;(r=>{let l;(n=>n.EDITED="edited")(l=r.action||={})})(zs||={});var Ps;(e=>{let l;(s=>s.CANCELLED="cancelled")(l=e.action||={});let r;(_=>(_.FREE="FREE",_.FLAT_RATE="FLAT_RATE",_.PER_UNIT="PER_UNIT"))(r=e.price_model||={})})(Ps||={});var Cs;(e=>{let l;(s=>s.CHANGED="changed")(l=e.action||={});let r;(_=>(_.FREE="FREE",_.FLAT_RATE="FLAT_RATE",_.PER_UNIT="PER_UNIT"))(r=e.price_model||={})})(Cs||={});var Ds;(e=>{let l;(s=>s.PENDING_CHANGE="pending_change")(l=e.action||={});let r;(_=>(_.FREE="FREE",_.FLAT_RATE="FLAT_RATE",_.PER_UNIT="PER_UNIT"))(r=e.price_model||={})})(Ds||={});var qs;(e=>{let l;(s=>s.PENDING_CHANGE_CANCELLED="pending_change_cancelled")(l=e.action||={});let r;(_=>(_.FREE="FREE",_.FLAT_RATE="FLAT_RATE",_.PER_UNIT="PER_UNIT"))(r=e.price_model||={})})(qs||={});var Ss;(e=>{let l;(s=>s.PURCHASED="purchased")(l=e.action||={});let r;(_=>(_.FREE="FREE",_.FLAT_RATE="FLAT_RATE",_.PER_UNIT="PER_UNIT"))(r=e.price_model||={})})(Ss||={});var Ls;(n=>{let l;(u=>u.ADDED="added")(l=n.action||={});let r;(m=>(m.WRITE="write",m.ADMIN="admin",m.READ="read"))(r=n.to||={});let e;(m=>(m.BOT="Bot",m.USER="User",m.ORGANIZATION="Organization"))(e=n.type||={})})(Ls||={});var Us;(e=>{let l;(s=>s.EDITED="edited")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(Us||={});var Ms;(e=>{let l;(s=>s.REMOVED="removed")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(Ms||={});var Gs;(u=>{let l;(m=>m.ADDED="added")(l=u.action||={});let r;(d=>(d.BOT="Bot",d.USER="User",d.ORGANIZATION="Organization"))(r=u.type||={});let e;(m=>m.TEAM="team")(e=u.scope||={});let n;(d=>(d.OPEN="open",d.CLOSED="closed",d.SECRET="secret"))(n=u.privacy||={});let s;(c=>(c.NOTIFICATIONS_ENABLED="notifications_enabled",c.NOTIFICATIONS_DISABLED="notifications_disabled"))(s=u.notification_setting||={})})(Gs||={});var Bs;(u=>{let l;(m=>m.REMOVED="removed")(l=u.action||={});let r;(d=>(d.BOT="Bot",d.USER="User",d.ORGANIZATION="Organization"))(r=u.type||={});let e;(c=>(c.TEAM="team",c.ORGANIZATION="organization"))(e=u.scope||={});let n;(d=>(d.OPEN="open",d.CLOSED="closed",d.SECRET="secret"))(n=u.privacy||={});let s;(c=>(c.NOTIFICATIONS_ENABLED="notifications_enabled",c.NOTIFICATIONS_DISABLED="notifications_disabled"))(s=u.notification_setting||={})})(Bs||={});var Ws;(r=>{let l;(n=>n.CHECKS_REQUESTED="checks_requested")(l=r.action||={})})(Ws||={});var Fs;(e=>{let l;(s=>s.DESTROYED="destroyed")(l=e.action||={});let r;(_=>(_.MERGED="merged",_.INVALIDATED="invalidated",_.DEQUEUED="dequeued"))(r=e.reason||={})})(Fs||={});var js;(e=>{let l;(s=>s.DELETED="deleted")(l=e.action||={});let r;(u=>(u.JSON="json",u.FORM="form"))(r=e.content_type||={})})(js||={});var Vs;(n=>{let l;(u=>u.CLOSED="closed")(l=n.action||={});let r;(c=>(c.BOT="Bot",c.USER="User",c.ORGANIZATION="Organization",c.MANNEQUIN="Mannequin"))(r=n.type||={});let e;(_=>(_.OPEN="open",_.CLOSED="closed"))(e=n.state||={})})(Vs||={});var Hs;(n=>{let l;(u=>u.CREATED="created")(l=n.action||={});let r;(m=>(m.BOT="Bot",m.USER="User",m.ORGANIZATION="Organization"))(r=n.type||={});let e;(_=>(_.OPEN="open",_.CLOSED="closed"))(e=n.state||={})})(Hs||={});var Qs;(n=>{let l;(u=>u.DELETED="deleted")(l=n.action||={});let r;(c=>(c.BOT="Bot",c.USER="User",c.ORGANIZATION="Organization",c.MANNEQUIN="Mannequin"))(r=n.type||={});let e;(_=>(_.OPEN="open",_.CLOSED="closed"))(e=n.state||={})})(Qs||={});var Ks;(n=>{let l;(u=>u.EDITED="edited")(l=n.action||={});let r;(c=>(c.BOT="Bot",c.USER="User",c.ORGANIZATION="Organization",c.MANNEQUIN="Mannequin"))(r=n.type||={});let e;(_=>(_.OPEN="open",_.CLOSED="closed"))(e=n.state||={})})(Ks||={});var Ys;(n=>{let l;(u=>u.OPENED="opened")(l=n.action||={});let r;(m=>(m.BOT="Bot",m.USER="User",m.ORGANIZATION="Organization"))(r=n.type||={});let e;(_=>(_.OPEN="open",_.CLOSED="closed"))(e=n.state||={})})(Ys||={});var Zs;(e=>{let l;(s=>s.BLOCKED="blocked")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(Zs||={});var Xs;(e=>{let l;(s=>s.UNBLOCKED="unblocked")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(Xs||={});var $s;(e=>{let l;(s=>s.DELETED="deleted")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})($s||={});var Js;(e=>{let l;(s=>s.MEMBER_ADDED="member_added")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(Js||={});var ri;(e=>{let l;(s=>s.MEMBER_INVITED="member_invited")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(ri||={});var ei;(e=>{let l;(s=>s.MEMBER_REMOVED="member_removed")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(ei||={});var ti;(e=>{let l;(s=>s.RENAMED="renamed")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(ti||={});var ni;(e=>{let l;(s=>s.PUBLISHED="published")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(ni||={});var si;(e=>{let l;(s=>s.UPDATED="updated")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(si||={});var ii;(r=>{let l;(u=>(u.BOT="Bot",u.USER="User",u.ORGANIZATION="Organization"))(l=r.type||={})})(ii||={});var oi;(r=>{let l;(n=>n.APPROVED="approved")(l=r.action||={})})(oi||={});var li;(r=>{let l;(n=>n.CANCELLED="cancelled")(l=r.action||={})})(li||={});var ai;(r=>{let l;(n=>n.CREATED="created")(l=r.action||={})})(ai||={});var ui;(r=>{let l;(n=>n.DENIED="denied")(l=r.action||={})})(ui||={});var _i;(r=>{let l;(n=>n.WEB="web")(l=r.name||={})})(_i||={});var gi;(e=>{let l;(s=>s.CONVERTED="converted")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(gi||={});var mi;(e=>{let l;(s=>s.CREATED="created")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(mi||={});var pi;(e=>{let l;(s=>s.DELETED="deleted")(l=e.action||={});let r;(m=>(m.BOT="Bot",m.USER="User",m.ORGANIZATION="Organization",m.MANNEQUIN="Mannequin"))(r=e.type||={})})(pi||={});var di;(e=>{let l;(s=>s.EDITED="edited")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(di||={});var ci;(e=>{let l;(s=>s.MOVED="moved")(l=e.action||={});let r;(m=>(m.BOT="Bot",m.USER="User",m.ORGANIZATION="Organization",m.MANNEQUIN="Mannequin"))(r=e.type||={})})(ci||={});var bi;(n=>{let l;(u=>u.CLOSED="closed")(l=n.action||={});let r;(m=>(m.BOT="Bot",m.USER="User",m.ORGANIZATION="Organization"))(r=n.type||={});let e;(_=>(_.OPEN="open",_.CLOSED="closed"))(e=n.state||={})})(bi||={});var hi;(r=>{let l;(n=>n.CREATED="created")(l=r.action||={})})(hi||={});var yi;(r=>{let l;(n=>n.DELETED="deleted")(l=r.action||={})})(yi||={});var fi;(r=>{let l;(n=>n.EDITED="edited")(l=r.action||={})})(fi||={});var wi;(r=>{let l;(n=>n.MOVED="moved")(l=r.action||={})})(wi||={});var Ei;(n=>{let l;(u=>u.CREATED="created")(l=n.action||={});let r;(m=>(m.BOT="Bot",m.USER="User",m.ORGANIZATION="Organization"))(r=n.type||={});let e;(_=>(_.OPEN="open",_.CLOSED="closed"))(e=n.state||={})})(Ei||={});var vi;(n=>{let l;(u=>u.DELETED="deleted")(l=n.action||={});let r;(m=>(m.BOT="Bot",m.USER="User",m.ORGANIZATION="Organization"))(r=n.type||={});let e;(_=>(_.OPEN="open",_.CLOSED="closed"))(e=n.state||={})})(vi||={});var Ri;(n=>{let l;(u=>u.EDITED="edited")(l=n.action||={});let r;(m=>(m.BOT="Bot",m.USER="User",m.ORGANIZATION="Organization"))(r=n.type||={});let e;(_=>(_.OPEN="open",_.CLOSED="closed"))(e=n.state||={})})(Ri||={});var Ti;(n=>{let l;(u=>u.REOPENED="reopened")(l=n.action||={});let r;(m=>(m.BOT="Bot",m.USER="User",m.ORGANIZATION="Organization"))(r=n.type||={});let e;(_=>(_.OPEN="open",_.CLOSED="closed"))(e=n.state||={})})(Ti||={});var Ai;(r=>{let l;(n=>n.ARCHIVED="archived")(l=r.action||={})})(Ai||={});var ki;(r=>{let l;(n=>n.CONVERTED="converted")(l=r.action||={})})(ki||={});var xi;(r=>{let l;(n=>n.CREATED="created")(l=r.action||={})})(xi||={});var Ii;(r=>{let l;(n=>n.DELETED="deleted")(l=r.action||={})})(Ii||={});var Oi;(r=>{let l;(n=>n.EDITED="edited")(l=r.action||={})})(Oi||={});var Ni;(r=>{let l;(n=>n.REORDERED="reordered")(l=r.action||={})})(Ni||={});var zi;(r=>{let l;(n=>n.RESTORED="restored")(l=r.action||={})})(zi||={});var Pi;(r=>{let l;(n=>n.CLOSED="closed")(l=r.action||={})})(Pi||={});var Ci;(r=>{let l;(n=>n.CREATED="created")(l=r.action||={})})(Ci||={});var Di;(r=>{let l;(n=>n.DELETED="deleted")(l=r.action||={})})(Di||={});var qi;(r=>{let l;(n=>n.EDITED="edited")(l=r.action||={})})(qi||={});var Si;(r=>{let l;(n=>n.REOPENED="reopened")(l=r.action||={})})(Si||={});var Li;(h=>{let l;(k=>k.ASSIGNED="assigned")(l=h.action||={});let r;(p=>(p.BOT="Bot",p.USER="User",p.ORGANIZATION="Organization"))(r=h.type||={});let e;(f=>(f.RESOLVED="resolved",f.OFF_TOPIC="off-topic",f.TOO_HEATED="too heated",f.SPAM="spam"))(e=h.active_lock_reason||={});let n;(E=>(E.COLLABORATOR="COLLABORATOR",E.CONTRIBUTOR="CONTRIBUTOR",E.FIRST_TIMER="FIRST_TIMER",E.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",E.MANNEQUIN="MANNEQUIN",E.MEMBER="MEMBER",E.NONE="NONE",E.OWNER="OWNER"))(n=h.author_association||={});let s;(p=>(p.MERGE="merge",p.SQUASH="squash",p.REBASE="rebase"))(s=h.merge_method||={});let u;(p=>(p.PR_BODY="PR_BODY",p.PR_TITLE="PR_TITLE",p.BLANK="BLANK"))(u=h.merge_commit_message||={});let _;(b=>(b.PR_TITLE="PR_TITLE",b.MERGE_MESSAGE="MERGE_MESSAGE"))(_=h.merge_commit_title||={});let m;(p=>(p.PR_BODY="PR_BODY",p.COMMIT_MESSAGES="COMMIT_MESSAGES",p.BLANK="BLANK"))(m=h.squash_merge_commit_message||={});let c;(b=>(b.PR_TITLE="PR_TITLE",b.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(c=h.squash_merge_commit_title||={});let d;(p=>(p.PUBLIC="public",p.PRIVATE="private",p.INTERNAL="internal"))(d=h.visibility||={});let v;(b=>(b.OPEN="open",b.CLOSED="closed"))(v=h.state||={})})(Li||={});var Ui;(h=>{let l;(k=>k.AUTO_MERGE_DISABLED="auto_merge_disabled")(l=h.action||={});let r;(f=>(f.RESOLVED="resolved",f.OFF_TOPIC="off-topic",f.TOO_HEATED="too heated",f.SPAM="spam"))(r=h.active_lock_reason||={});let e;(p=>(p.BOT="Bot",p.USER="User",p.ORGANIZATION="Organization"))(e=h.type||={});let n;(E=>(E.COLLABORATOR="COLLABORATOR",E.CONTRIBUTOR="CONTRIBUTOR",E.FIRST_TIMER="FIRST_TIMER",E.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",E.MANNEQUIN="MANNEQUIN",E.MEMBER="MEMBER",E.NONE="NONE",E.OWNER="OWNER"))(n=h.author_association||={});let s;(p=>(p.MERGE="merge",p.SQUASH="squash",p.REBASE="rebase"))(s=h.merge_method||={});let u;(p=>(p.PR_BODY="PR_BODY",p.PR_TITLE="PR_TITLE",p.BLANK="BLANK"))(u=h.merge_commit_message||={});let _;(b=>(b.PR_TITLE="PR_TITLE",b.MERGE_MESSAGE="MERGE_MESSAGE"))(_=h.merge_commit_title||={});let m;(p=>(p.PR_BODY="PR_BODY",p.COMMIT_MESSAGES="COMMIT_MESSAGES",p.BLANK="BLANK"))(m=h.squash_merge_commit_message||={});let c;(b=>(b.PR_TITLE="PR_TITLE",b.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(c=h.squash_merge_commit_title||={});let d;(p=>(p.PUBLIC="public",p.PRIVATE="private",p.INTERNAL="internal"))(d=h.visibility||={});let v;(b=>(b.OPEN="open",b.CLOSED="closed"))(v=h.state||={})})(Ui||={});var Mi;(h=>{let l;(k=>k.AUTO_MERGE_ENABLED="auto_merge_enabled")(l=h.action||={});let r;(f=>(f.RESOLVED="resolved",f.OFF_TOPIC="off-topic",f.TOO_HEATED="too heated",f.SPAM="spam"))(r=h.active_lock_reason||={});let e;(p=>(p.BOT="Bot",p.USER="User",p.ORGANIZATION="Organization"))(e=h.type||={});let n;(E=>(E.COLLABORATOR="COLLABORATOR",E.CONTRIBUTOR="CONTRIBUTOR",E.FIRST_TIMER="FIRST_TIMER",E.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",E.MANNEQUIN="MANNEQUIN",E.MEMBER="MEMBER",E.NONE="NONE",E.OWNER="OWNER"))(n=h.author_association||={});let s;(p=>(p.MERGE="merge",p.SQUASH="squash",p.REBASE="rebase"))(s=h.merge_method||={});let u;(p=>(p.PR_BODY="PR_BODY",p.PR_TITLE="PR_TITLE",p.BLANK="BLANK"))(u=h.merge_commit_message||={});let _;(b=>(b.PR_TITLE="PR_TITLE",b.MERGE_MESSAGE="MERGE_MESSAGE"))(_=h.merge_commit_title||={});let m;(p=>(p.PR_BODY="PR_BODY",p.COMMIT_MESSAGES="COMMIT_MESSAGES",p.BLANK="BLANK"))(m=h.squash_merge_commit_message||={});let c;(b=>(b.PR_TITLE="PR_TITLE",b.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(c=h.squash_merge_commit_title||={});let d;(p=>(p.PUBLIC="public",p.PRIVATE="private",p.INTERNAL="internal"))(d=h.visibility||={});let v;(b=>(b.OPEN="open",b.CLOSED="closed"))(v=h.state||={})})(Mi||={});var Gi;(u=>{let l;(m=>m.CLOSED="closed")(l=u.action||={});let r;(d=>(d.PR_BODY="PR_BODY",d.PR_TITLE="PR_TITLE",d.BLANK="BLANK"))(r=u.merge_commit_message||={});let e;(c=>(c.PR_TITLE="PR_TITLE",c.MERGE_MESSAGE="MERGE_MESSAGE"))(e=u.merge_commit_title||={});let n;(d=>(d.PR_BODY="PR_BODY",d.COMMIT_MESSAGES="COMMIT_MESSAGES",d.BLANK="BLANK"))(n=u.squash_merge_commit_message||={});let s;(c=>(c.PR_TITLE="PR_TITLE",c.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(s=u.squash_merge_commit_title||={})})(Gi||={});var Bi;(u=>{let l;(m=>m.CONVERTED_TO_DRAFT="converted_to_draft")(l=u.action||={});let r;(d=>(d.PR_BODY="PR_BODY",d.PR_TITLE="PR_TITLE",d.BLANK="BLANK"))(r=u.merge_commit_message||={});let e;(c=>(c.PR_TITLE="PR_TITLE",c.MERGE_MESSAGE="MERGE_MESSAGE"))(e=u.merge_commit_title||={});let n;(d=>(d.PR_BODY="PR_BODY",d.COMMIT_MESSAGES="COMMIT_MESSAGES",d.BLANK="BLANK"))(n=u.squash_merge_commit_message||={});let s;(c=>(c.PR_TITLE="PR_TITLE",c.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(s=u.squash_merge_commit_title||={})})(Bi||={});var Wi;(h=>{let l;(k=>k.DEMILESTONED="demilestoned")(l=h.action||={});let r;(f=>(f.RESOLVED="resolved",f.OFF_TOPIC="off-topic",f.TOO_HEATED="too heated",f.SPAM="spam"))(r=h.active_lock_reason||={});let e;(f=>(f.BOT="Bot",f.USER="User",f.ORGANIZATION="Organization",f.MANNEQUIN="Mannequin"))(e=h.type||={});let n;(E=>(E.COLLABORATOR="COLLABORATOR",E.CONTRIBUTOR="CONTRIBUTOR",E.FIRST_TIMER="FIRST_TIMER",E.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",E.MANNEQUIN="MANNEQUIN",E.MEMBER="MEMBER",E.NONE="NONE",E.OWNER="OWNER"))(n=h.author_association||={});let s;(p=>(p.MERGE="merge",p.SQUASH="squash",p.REBASE="rebase"))(s=h.merge_method||={});let u;(p=>(p.PR_BODY="PR_BODY",p.PR_TITLE="PR_TITLE",p.BLANK="BLANK"))(u=h.merge_commit_message||={});let _;(b=>(b.PR_TITLE="PR_TITLE",b.MERGE_MESSAGE="MERGE_MESSAGE"))(_=h.merge_commit_title||={});let m;(p=>(p.PR_BODY="PR_BODY",p.COMMIT_MESSAGES="COMMIT_MESSAGES",p.BLANK="BLANK"))(m=h.squash_merge_commit_message||={});let c;(b=>(b.PR_TITLE="PR_TITLE",b.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(c=h.squash_merge_commit_title||={});let d;(p=>(p.PUBLIC="public",p.PRIVATE="private",p.INTERNAL="internal"))(d=h.visibility||={});let v;(b=>(b.OPEN="open",b.CLOSED="closed"))(v=h.state||={})})(Wi||={});var Fi;(h=>{let l;(k=>k.DEQUEUED="dequeued")(l=h.action||={});let r;(f=>(f.RESOLVED="resolved",f.OFF_TOPIC="off-topic",f.TOO_HEATED="too heated",f.SPAM="spam"))(r=h.active_lock_reason||={});let e;(p=>(p.BOT="Bot",p.USER="User",p.ORGANIZATION="Organization"))(e=h.type||={});let n;(E=>(E.COLLABORATOR="COLLABORATOR",E.CONTRIBUTOR="CONTRIBUTOR",E.FIRST_TIMER="FIRST_TIMER",E.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",E.MANNEQUIN="MANNEQUIN",E.MEMBER="MEMBER",E.NONE="NONE",E.OWNER="OWNER"))(n=h.author_association||={});let s;(p=>(p.MERGE="merge",p.SQUASH="squash",p.REBASE="rebase"))(s=h.merge_method||={});let u;(p=>(p.PR_BODY="PR_BODY",p.PR_TITLE="PR_TITLE",p.BLANK="BLANK"))(u=h.merge_commit_message||={});let _;(b=>(b.PR_TITLE="PR_TITLE",b.MERGE_MESSAGE="MERGE_MESSAGE"))(_=h.merge_commit_title||={});let m;(p=>(p.PR_BODY="PR_BODY",p.COMMIT_MESSAGES="COMMIT_MESSAGES",p.BLANK="BLANK"))(m=h.squash_merge_commit_message||={});let c;(b=>(b.PR_TITLE="PR_TITLE",b.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(c=h.squash_merge_commit_title||={});let d;(p=>(p.PUBLIC="public",p.PRIVATE="private",p.INTERNAL="internal"))(d=h.visibility||={});let v;(b=>(b.OPEN="open",b.CLOSED="closed"))(v=h.state||={})})(Fi||={});var ji;(u=>{let l;(m=>m.EDITED="edited")(l=u.action||={});let r;(d=>(d.PR_BODY="PR_BODY",d.PR_TITLE="PR_TITLE",d.BLANK="BLANK"))(r=u.merge_commit_message||={});let e;(c=>(c.PR_TITLE="PR_TITLE",c.MERGE_MESSAGE="MERGE_MESSAGE"))(e=u.merge_commit_title||={});let n;(d=>(d.PR_BODY="PR_BODY",d.COMMIT_MESSAGES="COMMIT_MESSAGES",d.BLANK="BLANK"))(n=u.squash_merge_commit_message||={});let s;(c=>(c.PR_TITLE="PR_TITLE",c.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(s=u.squash_merge_commit_title||={})})(ji||={});var Vi;(h=>{let l;(k=>k.ENQUEUED="enqueued")(l=h.action||={});let r;(f=>(f.RESOLVED="resolved",f.OFF_TOPIC="off-topic",f.TOO_HEATED="too heated",f.SPAM="spam"))(r=h.active_lock_reason||={});let e;(p=>(p.BOT="Bot",p.USER="User",p.ORGANIZATION="Organization"))(e=h.type||={});let n;(E=>(E.COLLABORATOR="COLLABORATOR",E.CONTRIBUTOR="CONTRIBUTOR",E.FIRST_TIMER="FIRST_TIMER",E.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",E.MANNEQUIN="MANNEQUIN",E.MEMBER="MEMBER",E.NONE="NONE",E.OWNER="OWNER"))(n=h.author_association||={});let s;(p=>(p.MERGE="merge",p.SQUASH="squash",p.REBASE="rebase"))(s=h.merge_method||={});let u;(p=>(p.PR_BODY="PR_BODY",p.PR_TITLE="PR_TITLE",p.BLANK="BLANK"))(u=h.merge_commit_message||={});let _;(b=>(b.PR_TITLE="PR_TITLE",b.MERGE_MESSAGE="MERGE_MESSAGE"))(_=h.merge_commit_title||={});let m;(p=>(p.PR_BODY="PR_BODY",p.COMMIT_MESSAGES="COMMIT_MESSAGES",p.BLANK="BLANK"))(m=h.squash_merge_commit_message||={});let c;(b=>(b.PR_TITLE="PR_TITLE",b.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(c=h.squash_merge_commit_title||={});let d;(p=>(p.PUBLIC="public",p.PRIVATE="private",p.INTERNAL="internal"))(d=h.visibility||={});let v;(b=>(b.OPEN="open",b.CLOSED="closed"))(v=h.state||={})})(Vi||={});var Hi;(h=>{let l;(k=>k.LABELED="labeled")(l=h.action||={});let r;(f=>(f.RESOLVED="resolved",f.OFF_TOPIC="off-topic",f.TOO_HEATED="too heated",f.SPAM="spam"))(r=h.active_lock_reason||={});let e;(f=>(f.BOT="Bot",f.USER="User",f.ORGANIZATION="Organization",f.MANNEQUIN="Mannequin"))(e=h.type||={});let n;(E=>(E.COLLABORATOR="COLLABORATOR",E.CONTRIBUTOR="CONTRIBUTOR",E.FIRST_TIMER="FIRST_TIMER",E.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",E.MANNEQUIN="MANNEQUIN",E.MEMBER="MEMBER",E.NONE="NONE",E.OWNER="OWNER"))(n=h.author_association||={});let s;(p=>(p.MERGE="merge",p.SQUASH="squash",p.REBASE="rebase"))(s=h.merge_method||={});let u;(p=>(p.PR_BODY="PR_BODY",p.PR_TITLE="PR_TITLE",p.BLANK="BLANK"))(u=h.merge_commit_message||={});let _;(b=>(b.PR_TITLE="PR_TITLE",b.MERGE_MESSAGE="MERGE_MESSAGE"))(_=h.merge_commit_title||={});let m;(p=>(p.PR_BODY="PR_BODY",p.COMMIT_MESSAGES="COMMIT_MESSAGES",p.BLANK="BLANK"))(m=h.squash_merge_commit_message||={});let c;(b=>(b.PR_TITLE="PR_TITLE",b.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(c=h.squash_merge_commit_title||={});let d;(p=>(p.PUBLIC="public",p.PRIVATE="private",p.INTERNAL="internal"))(d=h.visibility||={});let v;(b=>(b.OPEN="open",b.CLOSED="closed"))(v=h.state||={})})(Hi||={});var Qi;(h=>{let l;(k=>k.LOCKED="locked")(l=h.action||={});let r;(f=>(f.RESOLVED="resolved",f.OFF_TOPIC="off-topic",f.TOO_HEATED="too heated",f.SPAM="spam"))(r=h.active_lock_reason||={});let e;(p=>(p.BOT="Bot",p.USER="User",p.ORGANIZATION="Organization"))(e=h.type||={});let n;(E=>(E.COLLABORATOR="COLLABORATOR",E.CONTRIBUTOR="CONTRIBUTOR",E.FIRST_TIMER="FIRST_TIMER",E.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",E.MANNEQUIN="MANNEQUIN",E.MEMBER="MEMBER",E.NONE="NONE",E.OWNER="OWNER"))(n=h.author_association||={});let s;(p=>(p.MERGE="merge",p.SQUASH="squash",p.REBASE="rebase"))(s=h.merge_method||={});let u;(p=>(p.PR_BODY="PR_BODY",p.PR_TITLE="PR_TITLE",p.BLANK="BLANK"))(u=h.merge_commit_message||={});let _;(b=>(b.PR_TITLE="PR_TITLE",b.MERGE_MESSAGE="MERGE_MESSAGE"))(_=h.merge_commit_title||={});let m;(p=>(p.PR_BODY="PR_BODY",p.COMMIT_MESSAGES="COMMIT_MESSAGES",p.BLANK="BLANK"))(m=h.squash_merge_commit_message||={});let c;(b=>(b.PR_TITLE="PR_TITLE",b.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(c=h.squash_merge_commit_title||={});let d;(p=>(p.PUBLIC="public",p.PRIVATE="private",p.INTERNAL="internal"))(d=h.visibility||={});let v;(b=>(b.OPEN="open",b.CLOSED="closed"))(v=h.state||={})})(Qi||={});var Ki;(h=>{let l;(k=>k.MILESTONED="milestoned")(l=h.action||={});let r;(f=>(f.RESOLVED="resolved",f.OFF_TOPIC="off-topic",f.TOO_HEATED="too heated",f.SPAM="spam"))(r=h.active_lock_reason||={});let e;(f=>(f.BOT="Bot",f.USER="User",f.ORGANIZATION="Organization",f.MANNEQUIN="Mannequin"))(e=h.type||={});let n;(E=>(E.COLLABORATOR="COLLABORATOR",E.CONTRIBUTOR="CONTRIBUTOR",E.FIRST_TIMER="FIRST_TIMER",E.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",E.MANNEQUIN="MANNEQUIN",E.MEMBER="MEMBER",E.NONE="NONE",E.OWNER="OWNER"))(n=h.author_association||={});let s;(p=>(p.MERGE="merge",p.SQUASH="squash",p.REBASE="rebase"))(s=h.merge_method||={});let u;(p=>(p.PR_BODY="PR_BODY",p.PR_TITLE="PR_TITLE",p.BLANK="BLANK"))(u=h.merge_commit_message||={});let _;(b=>(b.PR_TITLE="PR_TITLE",b.MERGE_MESSAGE="MERGE_MESSAGE"))(_=h.merge_commit_title||={});let m;(p=>(p.PR_BODY="PR_BODY",p.COMMIT_MESSAGES="COMMIT_MESSAGES",p.BLANK="BLANK"))(m=h.squash_merge_commit_message||={});let c;(b=>(b.PR_TITLE="PR_TITLE",b.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(c=h.squash_merge_commit_title||={});let d;(p=>(p.PUBLIC="public",p.PRIVATE="private",p.INTERNAL="internal"))(d=h.visibility||={});let v;(b=>(b.OPEN="open",b.CLOSED="closed"))(v=h.state||={})})(Ki||={});var Yi;(u=>{let l;(m=>m.OPENED="opened")(l=u.action||={});let r;(d=>(d.PR_BODY="PR_BODY",d.PR_TITLE="PR_TITLE",d.BLANK="BLANK"))(r=u.merge_commit_message||={});let e;(c=>(c.PR_TITLE="PR_TITLE",c.MERGE_MESSAGE="MERGE_MESSAGE"))(e=u.merge_commit_title||={});let n;(d=>(d.PR_BODY="PR_BODY",d.COMMIT_MESSAGES="COMMIT_MESSAGES",d.BLANK="BLANK"))(n=u.squash_merge_commit_message||={});let s;(c=>(c.PR_TITLE="PR_TITLE",c.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(s=u.squash_merge_commit_title||={})})(Yi||={});var Zi;(u=>{let l;(m=>m.READY_FOR_REVIEW="ready_for_review")(l=u.action||={});let r;(d=>(d.PR_BODY="PR_BODY",d.PR_TITLE="PR_TITLE",d.BLANK="BLANK"))(r=u.merge_commit_message||={});let e;(c=>(c.PR_TITLE="PR_TITLE",c.MERGE_MESSAGE="MERGE_MESSAGE"))(e=u.merge_commit_title||={});let n;(d=>(d.PR_BODY="PR_BODY",d.COMMIT_MESSAGES="COMMIT_MESSAGES",d.BLANK="BLANK"))(n=u.squash_merge_commit_message||={});let s;(c=>(c.PR_TITLE="PR_TITLE",c.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(s=u.squash_merge_commit_title||={})})(Zi||={});var Xi;(u=>{let l;(m=>m.REOPENED="reopened")(l=u.action||={});let r;(d=>(d.PR_BODY="PR_BODY",d.PR_TITLE="PR_TITLE",d.BLANK="BLANK"))(r=u.merge_commit_message||={});let e;(c=>(c.PR_TITLE="PR_TITLE",c.MERGE_MESSAGE="MERGE_MESSAGE"))(e=u.merge_commit_title||={});let n;(d=>(d.PR_BODY="PR_BODY",d.COMMIT_MESSAGES="COMMIT_MESSAGES",d.BLANK="BLANK"))(n=u.squash_merge_commit_message||={});let s;(c=>(c.PR_TITLE="PR_TITLE",c.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(s=u.squash_merge_commit_title||={})})(Xi||={});var $i;(b=>{let l;(f=>f.CREATED="created")(l=b.action||={});let r;(C=>(C.COLLABORATOR="COLLABORATOR",C.CONTRIBUTOR="CONTRIBUTOR",C.FIRST_TIMER="FIRST_TIMER",C.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",C.MANNEQUIN="MANNEQUIN",C.MEMBER="MEMBER",C.NONE="NONE",C.OWNER="OWNER"))(r=b.author_association||={});let e;(O=>(O.LEFT="LEFT",O.RIGHT="RIGHT"))(e=b.side||={});let n;(O=>(O.LEFT="LEFT",O.RIGHT="RIGHT"))(n=b.start_side||={});let s;(O=>(O.LINE="line",O.FILE="file"))(s=b.subject_type||={});let u;(I=>(I.BOT="Bot",I.USER="User",I.ORGANIZATION="Organization"))(u=b.type||={});let _;(P=>(P.RESOLVED="resolved",P.OFF_TOPIC="off-topic",P.TOO_HEATED="too heated",P.SPAM="spam"))(_=b.active_lock_reason||={});let m;(I=>(I.MERGE="merge",I.SQUASH="squash",I.REBASE="rebase"))(m=b.merge_method||={});let c;(I=>(I.PR_BODY="PR_BODY",I.PR_TITLE="PR_TITLE",I.BLANK="BLANK"))(c=b.merge_commit_message||={});let d;(O=>(O.PR_TITLE="PR_TITLE",O.MERGE_MESSAGE="MERGE_MESSAGE"))(d=b.merge_commit_title||={});let v;(I=>(I.PR_BODY="PR_BODY",I.COMMIT_MESSAGES="COMMIT_MESSAGES",I.BLANK="BLANK"))(v=b.squash_merge_commit_message||={});let h;(O=>(O.PR_TITLE="PR_TITLE",O.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(h=b.squash_merge_commit_title||={});let R;(I=>(I.PUBLIC="public",I.PRIVATE="private",I.INTERNAL="internal"))(R=b.visibility||={});let k;(O=>(O.OPEN="open",O.CLOSED="closed"))(k=b.state||={})})($i||={});var Ji;(b=>{let l;(f=>f.DELETED="deleted")(l=b.action||={});let r;(C=>(C.COLLABORATOR="COLLABORATOR",C.CONTRIBUTOR="CONTRIBUTOR",C.FIRST_TIMER="FIRST_TIMER",C.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",C.MANNEQUIN="MANNEQUIN",C.MEMBER="MEMBER",C.NONE="NONE",C.OWNER="OWNER"))(r=b.author_association||={});let e;(O=>(O.LEFT="LEFT",O.RIGHT="RIGHT"))(e=b.side||={});let n;(O=>(O.LEFT="LEFT",O.RIGHT="RIGHT"))(n=b.start_side||={});let s;(O=>(O.LINE="line",O.FILE="file"))(s=b.subject_type||={});let u;(I=>(I.BOT="Bot",I.USER="User",I.ORGANIZATION="Organization"))(u=b.type||={});let _;(P=>(P.RESOLVED="resolved",P.OFF_TOPIC="off-topic",P.TOO_HEATED="too heated",P.SPAM="spam"))(_=b.active_lock_reason||={});let m;(I=>(I.MERGE="merge",I.SQUASH="squash",I.REBASE="rebase"))(m=b.merge_method||={});let c;(I=>(I.PR_BODY="PR_BODY",I.PR_TITLE="PR_TITLE",I.BLANK="BLANK"))(c=b.merge_commit_message||={});let d;(O=>(O.PR_TITLE="PR_TITLE",O.MERGE_MESSAGE="MERGE_MESSAGE"))(d=b.merge_commit_title||={});let v;(I=>(I.PR_BODY="PR_BODY",I.COMMIT_MESSAGES="COMMIT_MESSAGES",I.BLANK="BLANK"))(v=b.squash_merge_commit_message||={});let h;(O=>(O.PR_TITLE="PR_TITLE",O.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(h=b.squash_merge_commit_title||={});let R;(I=>(I.PUBLIC="public",I.PRIVATE="private",I.INTERNAL="internal"))(R=b.visibility||={});let k;(O=>(O.OPEN="open",O.CLOSED="closed"))(k=b.state||={})})(Ji||={});var ro;(b=>{let l;(f=>f.EDITED="edited")(l=b.action||={});let r;(C=>(C.COLLABORATOR="COLLABORATOR",C.CONTRIBUTOR="CONTRIBUTOR",C.FIRST_TIMER="FIRST_TIMER",C.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",C.MANNEQUIN="MANNEQUIN",C.MEMBER="MEMBER",C.NONE="NONE",C.OWNER="OWNER"))(r=b.author_association||={});let e;(O=>(O.LEFT="LEFT",O.RIGHT="RIGHT"))(e=b.side||={});let n;(O=>(O.LEFT="LEFT",O.RIGHT="RIGHT"))(n=b.start_side||={});let s;(O=>(O.LINE="line",O.FILE="file"))(s=b.subject_type||={});let u;(I=>(I.BOT="Bot",I.USER="User",I.ORGANIZATION="Organization"))(u=b.type||={});let _;(P=>(P.RESOLVED="resolved",P.OFF_TOPIC="off-topic",P.TOO_HEATED="too heated",P.SPAM="spam"))(_=b.active_lock_reason||={});let m;(I=>(I.MERGE="merge",I.SQUASH="squash",I.REBASE="rebase"))(m=b.merge_method||={});let c;(I=>(I.PR_BODY="PR_BODY",I.PR_TITLE="PR_TITLE",I.BLANK="BLANK"))(c=b.merge_commit_message||={});let d;(O=>(O.PR_TITLE="PR_TITLE",O.MERGE_MESSAGE="MERGE_MESSAGE"))(d=b.merge_commit_title||={});let v;(I=>(I.PR_BODY="PR_BODY",I.COMMIT_MESSAGES="COMMIT_MESSAGES",I.BLANK="BLANK"))(v=b.squash_merge_commit_message||={});let h;(O=>(O.PR_TITLE="PR_TITLE",O.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(h=b.squash_merge_commit_title||={});let R;(I=>(I.PUBLIC="public",I.PRIVATE="private",I.INTERNAL="internal"))(R=b.visibility||={});let k;(O=>(O.OPEN="open",O.CLOSED="closed"))(k=b.state||={})})(ro||={});var eo;(h=>{let l;(k=>k.DISMISSED="dismissed")(l=h.action||={});let r;(f=>(f.RESOLVED="resolved",f.OFF_TOPIC="off-topic",f.TOO_HEATED="too heated",f.SPAM="spam"))(r=h.active_lock_reason||={});let e;(f=>(f.BOT="Bot",f.USER="User",f.ORGANIZATION="Organization",f.MANNEQUIN="Mannequin"))(e=h.type||={});let n;(E=>(E.COLLABORATOR="COLLABORATOR",E.CONTRIBUTOR="CONTRIBUTOR",E.FIRST_TIMER="FIRST_TIMER",E.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",E.MANNEQUIN="MANNEQUIN",E.MEMBER="MEMBER",E.NONE="NONE",E.OWNER="OWNER"))(n=h.author_association||={});let s;(p=>(p.MERGE="merge",p.SQUASH="squash",p.REBASE="rebase"))(s=h.merge_method||={});let u;(p=>(p.PR_BODY="PR_BODY",p.PR_TITLE="PR_TITLE",p.BLANK="BLANK"))(u=h.merge_commit_message||={});let _;(b=>(b.PR_TITLE="PR_TITLE",b.MERGE_MESSAGE="MERGE_MESSAGE"))(_=h.merge_commit_title||={});let m;(p=>(p.PR_BODY="PR_BODY",p.COMMIT_MESSAGES="COMMIT_MESSAGES",p.BLANK="BLANK"))(m=h.squash_merge_commit_message||={});let c;(b=>(b.PR_TITLE="PR_TITLE",b.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(c=h.squash_merge_commit_title||={});let d;(p=>(p.PUBLIC="public",p.PRIVATE="private",p.INTERNAL="internal"))(d=h.visibility||={});let v;(b=>(b.OPEN="open",b.CLOSED="closed"))(v=h.state||={})})(eo||={});var to;(m=>{let l;(d=>d.EDITED="edited")(l=m.action||={});let r;(R=>(R.RESOLVED="resolved",R.OFF_TOPIC="off-topic",R.TOO_HEATED="too heated",R.SPAM="spam"))(r=m.active_lock_reason||={});let e;(R=>(R.BOT="Bot",R.USER="User",R.ORGANIZATION="Organization",R.MANNEQUIN="Mannequin"))(e=m.type||={});let n;(f=>(f.COLLABORATOR="COLLABORATOR",f.CONTRIBUTOR="CONTRIBUTOR",f.FIRST_TIMER="FIRST_TIMER",f.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",f.MANNEQUIN="MANNEQUIN",f.MEMBER="MEMBER",f.NONE="NONE",f.OWNER="OWNER"))(n=m.author_association||={});let s;(h=>(h.MERGE="merge",h.SQUASH="squash",h.REBASE="rebase"))(s=m.merge_method||={});let u;(h=>(h.PUBLIC="public",h.PRIVATE="private",h.INTERNAL="internal"))(u=m.visibility||={});let _;(v=>(v.OPEN="open",v.CLOSED="closed"))(_=m.state||={})})(to||={});var no;(R=>{let l;(b=>b.REVIEW_REQUEST_REMOVED="review_request_removed")(l=R.action||={});let r;(O=>(O.RESOLVED="resolved",O.OFF_TOPIC="off-topic",O.TOO_HEATED="too heated",O.SPAM="spam"))(r=R.active_lock_reason||={});let e;(f=>(f.BOT="Bot",f.USER="User",f.ORGANIZATION="Organization"))(e=R.type||={});let n;(D=>(D.COLLABORATOR="COLLABORATOR",D.CONTRIBUTOR="CONTRIBUTOR",D.FIRST_TIMER="FIRST_TIMER",D.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",D.MANNEQUIN="MANNEQUIN",D.MEMBER="MEMBER",D.NONE="NONE",D.OWNER="OWNER"))(n=R.author_association||={});let s;(f=>(f.MERGE="merge",f.SQUASH="squash",f.REBASE="rebase"))(s=R.merge_method||={});let u;(f=>(f.PR_BODY="PR_BODY",f.PR_TITLE="PR_TITLE",f.BLANK="BLANK"))(u=R.merge_commit_message||={});let _;(p=>(p.PR_TITLE="PR_TITLE",p.MERGE_MESSAGE="MERGE_MESSAGE"))(_=R.merge_commit_title||={});let m;(f=>(f.PR_BODY="PR_BODY",f.COMMIT_MESSAGES="COMMIT_MESSAGES",f.BLANK="BLANK"))(m=R.squash_merge_commit_message||={});let c;(p=>(p.PR_TITLE="PR_TITLE",p.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(c=R.squash_merge_commit_title||={});let d;(f=>(f.PUBLIC="public",f.PRIVATE="private",f.INTERNAL="internal"))(d=R.visibility||={});let v;(p=>(p.OPEN="open",p.CLOSED="closed"))(v=R.state||={});let h;(f=>(f.OPEN="open",f.CLOSED="closed",f.SECRET="secret"))(h=R.privacy||={})})(no||={});var so;(R=>{let l;(b=>b.REVIEW_REQUESTED="review_requested")(l=R.action||={});let r;(O=>(O.RESOLVED="resolved",O.OFF_TOPIC="off-topic",O.TOO_HEATED="too heated",O.SPAM="spam"))(r=R.active_lock_reason||={});let e;(O=>(O.BOT="Bot",O.USER="User",O.ORGANIZATION="Organization",O.MANNEQUIN="Mannequin"))(e=R.type||={});let n;(D=>(D.COLLABORATOR="COLLABORATOR",D.CONTRIBUTOR="CONTRIBUTOR",D.FIRST_TIMER="FIRST_TIMER",D.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",D.MANNEQUIN="MANNEQUIN",D.MEMBER="MEMBER",D.NONE="NONE",D.OWNER="OWNER"))(n=R.author_association||={});let s;(f=>(f.MERGE="merge",f.SQUASH="squash",f.REBASE="rebase"))(s=R.merge_method||={});let u;(f=>(f.PR_BODY="PR_BODY",f.PR_TITLE="PR_TITLE",f.BLANK="BLANK"))(u=R.merge_commit_message||={});let _;(p=>(p.PR_TITLE="PR_TITLE",p.MERGE_MESSAGE="MERGE_MESSAGE"))(_=R.merge_commit_title||={});let m;(f=>(f.PR_BODY="PR_BODY",f.COMMIT_MESSAGES="COMMIT_MESSAGES",f.BLANK="BLANK"))(m=R.squash_merge_commit_message||={});let c;(p=>(p.PR_TITLE="PR_TITLE",p.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(c=R.squash_merge_commit_title||={});let d;(f=>(f.PUBLIC="public",f.PRIVATE="private",f.INTERNAL="internal"))(d=R.visibility||={});let v;(p=>(p.OPEN="open",p.CLOSED="closed"))(v=R.state||={});let h;(f=>(f.OPEN="open",f.CLOSED="closed",f.SECRET="secret"))(h=R.privacy||={})})(so||={});var io;(h=>{let l;(k=>k.SUBMITTED="submitted")(l=h.action||={});let r;(f=>(f.RESOLVED="resolved",f.OFF_TOPIC="off-topic",f.TOO_HEATED="too heated",f.SPAM="spam"))(r=h.active_lock_reason||={});let e;(f=>(f.BOT="Bot",f.USER="User",f.ORGANIZATION="Organization",f.MANNEQUIN="Mannequin"))(e=h.type||={});let n;(E=>(E.COLLABORATOR="COLLABORATOR",E.CONTRIBUTOR="CONTRIBUTOR",E.FIRST_TIMER="FIRST_TIMER",E.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",E.MANNEQUIN="MANNEQUIN",E.MEMBER="MEMBER",E.NONE="NONE",E.OWNER="OWNER"))(n=h.author_association||={});let s;(p=>(p.MERGE="merge",p.SQUASH="squash",p.REBASE="rebase"))(s=h.merge_method||={});let u;(p=>(p.PR_BODY="PR_BODY",p.PR_TITLE="PR_TITLE",p.BLANK="BLANK"))(u=h.merge_commit_message||={});let _;(b=>(b.PR_TITLE="PR_TITLE",b.MERGE_MESSAGE="MERGE_MESSAGE"))(_=h.merge_commit_title||={});let m;(p=>(p.PR_BODY="PR_BODY",p.COMMIT_MESSAGES="COMMIT_MESSAGES",p.BLANK="BLANK"))(m=h.squash_merge_commit_message||={});let c;(b=>(b.PR_TITLE="PR_TITLE",b.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(c=h.squash_merge_commit_title||={});let d;(p=>(p.PUBLIC="public",p.PRIVATE="private",p.INTERNAL="internal"))(d=h.visibility||={});let v;(b=>(b.OPEN="open",b.CLOSED="closed"))(v=h.state||={})})(io||={});var oo;(m=>{let l;(d=>d.RESOLVED="resolved")(l=m.action||={});let r;(R=>(R.RESOLVED="resolved",R.OFF_TOPIC="off-topic",R.TOO_HEATED="too heated",R.SPAM="spam"))(r=m.active_lock_reason||={});let e;(h=>(h.BOT="Bot",h.USER="User",h.ORGANIZATION="Organization"))(e=m.type||={});let n;(f=>(f.COLLABORATOR="COLLABORATOR",f.CONTRIBUTOR="CONTRIBUTOR",f.FIRST_TIMER="FIRST_TIMER",f.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",f.MANNEQUIN="MANNEQUIN",f.MEMBER="MEMBER",f.NONE="NONE",f.OWNER="OWNER"))(n=m.author_association||={});let s;(h=>(h.MERGE="merge",h.SQUASH="squash",h.REBASE="rebase"))(s=m.merge_method||={});let u;(h=>(h.PUBLIC="public",h.PRIVATE="private",h.INTERNAL="internal"))(u=m.visibility||={});let _;(v=>(v.OPEN="open",v.CLOSED="closed"))(_=m.state||={})})(oo||={});var lo;(m=>{let l;(d=>d.UNRESOLVED="unresolved")(l=m.action||={});let r;(R=>(R.RESOLVED="resolved",R.OFF_TOPIC="off-topic",R.TOO_HEATED="too heated",R.SPAM="spam"))(r=m.active_lock_reason||={});let e;(h=>(h.BOT="Bot",h.USER="User",h.ORGANIZATION="Organization"))(e=m.type||={});let n;(f=>(f.COLLABORATOR="COLLABORATOR",f.CONTRIBUTOR="CONTRIBUTOR",f.FIRST_TIMER="FIRST_TIMER",f.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",f.MANNEQUIN="MANNEQUIN",f.MEMBER="MEMBER",f.NONE="NONE",f.OWNER="OWNER"))(n=m.author_association||={});let s;(h=>(h.MERGE="merge",h.SQUASH="squash",h.REBASE="rebase"))(s=m.merge_method||={});let u;(h=>(h.PUBLIC="public",h.PRIVATE="private",h.INTERNAL="internal"))(u=m.visibility||={});let _;(v=>(v.OPEN="open",v.CLOSED="closed"))(_=m.state||={})})(lo||={});var ao;(h=>{let l;(k=>k.SYNCHRONIZE="synchronize")(l=h.action||={});let r;(f=>(f.RESOLVED="resolved",f.OFF_TOPIC="off-topic",f.TOO_HEATED="too heated",f.SPAM="spam"))(r=h.active_lock_reason||={});let e;(f=>(f.BOT="Bot",f.USER="User",f.ORGANIZATION="Organization",f.MANNEQUIN="Mannequin"))(e=h.type||={});let n;(E=>(E.COLLABORATOR="COLLABORATOR",E.CONTRIBUTOR="CONTRIBUTOR",E.FIRST_TIMER="FIRST_TIMER",E.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",E.MANNEQUIN="MANNEQUIN",E.MEMBER="MEMBER",E.NONE="NONE",E.OWNER="OWNER"))(n=h.author_association||={});let s;(p=>(p.MERGE="merge",p.SQUASH="squash",p.REBASE="rebase"))(s=h.merge_method||={});let u;(p=>(p.PR_BODY="PR_BODY",p.PR_TITLE="PR_TITLE",p.BLANK="BLANK"))(u=h.merge_commit_message||={});let _;(b=>(b.PR_TITLE="PR_TITLE",b.MERGE_MESSAGE="MERGE_MESSAGE"))(_=h.merge_commit_title||={});let m;(p=>(p.PR_BODY="PR_BODY",p.COMMIT_MESSAGES="COMMIT_MESSAGES",p.BLANK="BLANK"))(m=h.squash_merge_commit_message||={});let c;(b=>(b.PR_TITLE="PR_TITLE",b.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(c=h.squash_merge_commit_title||={});let d;(p=>(p.PUBLIC="public",p.PRIVATE="private",p.INTERNAL="internal"))(d=h.visibility||={});let v;(b=>(b.OPEN="open",b.CLOSED="closed"))(v=h.state||={})})(ao||={});var uo;(h=>{let l;(k=>k.UNASSIGNED="unassigned")(l=h.action||={});let r;(f=>(f.BOT="Bot",f.USER="User",f.ORGANIZATION="Organization",f.MANNEQUIN="Mannequin"))(r=h.type||={});let e;(f=>(f.RESOLVED="resolved",f.OFF_TOPIC="off-topic",f.TOO_HEATED="too heated",f.SPAM="spam"))(e=h.active_lock_reason||={});let n;(E=>(E.COLLABORATOR="COLLABORATOR",E.CONTRIBUTOR="CONTRIBUTOR",E.FIRST_TIMER="FIRST_TIMER",E.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",E.MANNEQUIN="MANNEQUIN",E.MEMBER="MEMBER",E.NONE="NONE",E.OWNER="OWNER"))(n=h.author_association||={});let s;(p=>(p.MERGE="merge",p.SQUASH="squash",p.REBASE="rebase"))(s=h.merge_method||={});let u;(p=>(p.PR_BODY="PR_BODY",p.PR_TITLE="PR_TITLE",p.BLANK="BLANK"))(u=h.merge_commit_message||={});let _;(b=>(b.PR_TITLE="PR_TITLE",b.MERGE_MESSAGE="MERGE_MESSAGE"))(_=h.merge_commit_title||={});let m;(p=>(p.PR_BODY="PR_BODY",p.COMMIT_MESSAGES="COMMIT_MESSAGES",p.BLANK="BLANK"))(m=h.squash_merge_commit_message||={});let c;(b=>(b.PR_TITLE="PR_TITLE",b.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(c=h.squash_merge_commit_title||={});let d;(p=>(p.PUBLIC="public",p.PRIVATE="private",p.INTERNAL="internal"))(d=h.visibility||={});let v;(b=>(b.OPEN="open",b.CLOSED="closed"))(v=h.state||={})})(uo||={});var _o;(h=>{let l;(k=>k.UNLABELED="unlabeled")(l=h.action||={});let r;(f=>(f.RESOLVED="resolved",f.OFF_TOPIC="off-topic",f.TOO_HEATED="too heated",f.SPAM="spam"))(r=h.active_lock_reason||={});let e;(f=>(f.BOT="Bot",f.USER="User",f.ORGANIZATION="Organization",f.MANNEQUIN="Mannequin"))(e=h.type||={});let n;(E=>(E.COLLABORATOR="COLLABORATOR",E.CONTRIBUTOR="CONTRIBUTOR",E.FIRST_TIMER="FIRST_TIMER",E.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",E.MANNEQUIN="MANNEQUIN",E.MEMBER="MEMBER",E.NONE="NONE",E.OWNER="OWNER"))(n=h.author_association||={});let s;(p=>(p.MERGE="merge",p.SQUASH="squash",p.REBASE="rebase"))(s=h.merge_method||={});let u;(p=>(p.PR_BODY="PR_BODY",p.PR_TITLE="PR_TITLE",p.BLANK="BLANK"))(u=h.merge_commit_message||={});let _;(b=>(b.PR_TITLE="PR_TITLE",b.MERGE_MESSAGE="MERGE_MESSAGE"))(_=h.merge_commit_title||={});let m;(p=>(p.PR_BODY="PR_BODY",p.COMMIT_MESSAGES="COMMIT_MESSAGES",p.BLANK="BLANK"))(m=h.squash_merge_commit_message||={});let c;(b=>(b.PR_TITLE="PR_TITLE",b.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(c=h.squash_merge_commit_title||={});let d;(p=>(p.PUBLIC="public",p.PRIVATE="private",p.INTERNAL="internal"))(d=h.visibility||={});let v;(b=>(b.OPEN="open",b.CLOSED="closed"))(v=h.state||={})})(_o||={});var go;(h=>{let l;(k=>k.UNLOCKED="unlocked")(l=h.action||={});let r;(f=>(f.RESOLVED="resolved",f.OFF_TOPIC="off-topic",f.TOO_HEATED="too heated",f.SPAM="spam"))(r=h.active_lock_reason||={});let e;(p=>(p.BOT="Bot",p.USER="User",p.ORGANIZATION="Organization"))(e=h.type||={});let n;(E=>(E.COLLABORATOR="COLLABORATOR",E.CONTRIBUTOR="CONTRIBUTOR",E.FIRST_TIMER="FIRST_TIMER",E.FIRST_TIME_CONTRIBUTOR="FIRST_TIME_CONTRIBUTOR",E.MANNEQUIN="MANNEQUIN",E.MEMBER="MEMBER",E.NONE="NONE",E.OWNER="OWNER"))(n=h.author_association||={});let s;(p=>(p.MERGE="merge",p.SQUASH="squash",p.REBASE="rebase"))(s=h.merge_method||={});let u;(p=>(p.PR_BODY="PR_BODY",p.PR_TITLE="PR_TITLE",p.BLANK="BLANK"))(u=h.merge_commit_message||={});let _;(b=>(b.PR_TITLE="PR_TITLE",b.MERGE_MESSAGE="MERGE_MESSAGE"))(_=h.merge_commit_title||={});let m;(p=>(p.PR_BODY="PR_BODY",p.COMMIT_MESSAGES="COMMIT_MESSAGES",p.BLANK="BLANK"))(m=h.squash_merge_commit_message||={});let c;(b=>(b.PR_TITLE="PR_TITLE",b.COMMIT_OR_PR_TITLE="COMMIT_OR_PR_TITLE"))(c=h.squash_merge_commit_title||={});let d;(p=>(p.PUBLIC="public",p.PRIVATE="private",p.INTERNAL="internal"))(d=h.visibility||={});let v;(b=>(b.OPEN="open",b.CLOSED="closed"))(v=h.state||={})})(go||={});var mo;(e=>{let l;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(l=e.type||={});let r;(_=>(_.PUBLIC="public",_.PRIVATE="private",_.INTERNAL="internal"))(r=e.visibility||={})})(mo||={});var po;(r=>{let l;(n=>n.PUBLISHED="published")(l=r.action||={})})(po||={});var co;(e=>{let l;(s=>s.CREATED="created")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(co||={});var bo;(e=>{let l;(s=>s.DELETED="deleted")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(bo||={});var ho;(e=>{let l;(s=>s.EDITED="edited")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(ho||={});var yo;(e=>{let l;(s=>s.PRERELEASED="prereleased")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(yo||={});var fo;(e=>{let l;(s=>s.PUBLISHED="published")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(fo||={});var wo;(e=>{let l;(s=>s.RELEASED="released")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(wo||={});var Eo;(e=>{let l;(s=>s.UNPUBLISHED="unpublished")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(Eo||={});var vo;(r=>{let l;(n=>n.PUBLISHED="published")(l=r.action||={})})(vo||={});var Ro;(r=>{let l;(n=>n.REPORTED="reported")(l=r.action||={})})(Ro||={});var To;(r=>{let l;(n=>n.ARCHIVED="archived")(l=r.action||={})})(To||={});var Ao;(r=>{let l;(n=>n.CREATED="created")(l=r.action||={})})(Ao||={});var ko;(r=>{let l;(n=>n.DELETED="deleted")(l=r.action||={})})(ko||={});var xo;(r=>{let l;(n=>n.EDITED="edited")(l=r.action||={})})(xo||={});var Io;(r=>{let l;(u=>(u.SUCCESS="success",u.CANCELLED="cancelled",u.FAILURE="failure"))(l=r.status||={})})(Io||={});var Oo;(r=>{let l;(n=>n.PRIVATIZED="privatized")(l=r.action||={})})(Oo||={});var No;(r=>{let l;(n=>n.PUBLICIZED="publicized")(l=r.action||={})})(No||={});var zo;(r=>{let l;(n=>n.RENAMED="renamed")(l=r.action||={})})(zo||={});var Po;(e=>{let l;(s=>s.TRANSFERRED="transferred")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(Po||={});var Co;(r=>{let l;(n=>n.UNARCHIVED="unarchived")(l=r.action||={})})(Co||={});var Do;(n=>{let l;(u=>u.CREATE="create")(l=n.action||={});let r;(m=>(m.BOT="Bot",m.USER="User",m.ORGANIZATION="Organization"))(r=n.type||={});let e;(m=>(m.OPEN="open",m.DISMISSED="dismissed",m.FIXED="fixed"))(e=n.state||={})})(Do||={});var qo;(n=>{let l;(u=>u.DISMISS="dismiss")(l=n.action||={});let r;(m=>(m.BOT="Bot",m.USER="User",m.ORGANIZATION="Organization"))(r=n.type||={});let e;(m=>(m.OPEN="open",m.DISMISSED="dismissed",m.FIXED="fixed"))(e=n.state||={})})(qo||={});var So;(n=>{let l;(u=>u.REOPEN="reopen")(l=n.action||={});let r;(m=>(m.BOT="Bot",m.USER="User",m.ORGANIZATION="Organization"))(r=n.type||={});let e;(m=>(m.OPEN="open",m.DISMISSED="dismissed",m.FIXED="fixed"))(e=n.state||={})})(So||={});var Lo;(n=>{let l;(u=>u.RESOLVE="resolve")(l=n.action||={});let r;(m=>(m.BOT="Bot",m.USER="User",m.ORGANIZATION="Organization"))(r=n.type||={});let e;(m=>(m.OPEN="open",m.DISMISSED="dismissed",m.FIXED="fixed"))(e=n.state||={})})(Lo||={});var Uo;(r=>{let l;(n=>n.CREATED="created")(l=r.action||={})})(Uo||={});var Mo;(r=>{let l;(n=>n.CREATED="created")(l=r.action||={})})(Mo||={});var Go;(r=>{let l;(n=>n.REOPENED="reopened")(l=r.action||={})})(Go||={});var Bo;(r=>{let l;(n=>n.RESOLVED="resolved")(l=r.action||={})})(Bo||={});var Wo;(r=>{let l;(n=>n.REVOKED="revoked")(l=r.action||={})})(Wo||={});var Fo;(r=>{let l;(n=>n.PUBLISHED="published")(l=r.action||={})})(Fo||={});var jo;(r=>{let l;(n=>n.UPDATED="updated")(l=r.action||={})})(jo||={});var Vo;(r=>{let l;(n=>n.WITHDRAWN="withdrawn")(l=r.action||={})})(Vo||={});var Ho;(e=>{let l;(s=>s.CANCELLED="cancelled")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(Ho||={});var Qo;(e=>{let l;(s=>s.CREATED="created")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(Qo||={});var Ko;(e=>{let l;(s=>s.EDITED="edited")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(Ko||={});var Yo;(e=>{let l;(s=>s.PENDING_CANCELLATION="pending_cancellation")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(Yo||={});var Zo;(e=>{let l;(s=>s.PENDING_TIER_CHANGE="pending_tier_change")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(Zo||={});var Xo;(e=>{let l;(s=>s.TIER_CHANGED="tier_changed")(l=e.action||={});let r;(_=>(_.BOT="Bot",_.USER="User",_.ORGANIZATION="Organization"))(r=e.type||={})})(Xo||={});var $o;(r=>{let l;(n=>n.CREATED="created")(l=r.action||={})})($o||={});var Jo;(r=>{let l;(n=>n.DELETED="deleted")(l=r.action||={})})(Jo||={});var rl;(n=>{let l;(m=>(m.BOT="Bot",m.USER="User",m.ORGANIZATION="Organization"))(l=n.type||={});let r;(P=>(P.EXPIRED_KEY="expired_key",P.NOT_SIGNING_KEY="not_signing_key",P.GPGVERIFY_ERROR="gpgverify_error",P.GPGVERIFY_UNAVAILABLE="gpgverify_unavailable",P.UNSIGNED="unsigned",P.UNKNOWN_SIGNATURE_TYPE="unknown_signature_type",P.NO_USER="no_user",P.UNVERIFIED_EMAIL="unverified_email",P.BAD_EMAIL="bad_email",P.UNKNOWN_KEY="unknown_key",P.MALFORMED_SIGNATURE="malformed_signature",P.INVALID="invalid",P.VALID="valid",P.BAD_CERT="bad_cert",P.OCSP_PENDING="ocsp_pending"))(r=n.reason||={});let e;(c=>(c.PENDING="pending",c.SUCCESS="success",c.FAILURE="failure",c.ERROR="error"))(e=n.state||={})})(rl||={});var el;(e=>{let l;(_=>(_.OPEN="open",_.CLOSED="closed",_.SECRET="secret"))(l=e.privacy||={});let r;(u=>(u.NOTIFICATIONS_ENABLED="notifications_enabled",u.NOTIFICATIONS_DISABLED="notifications_disabled"))(r=e.notification_setting||={})})(el||={});var tl;(u=>{let l;(m=>m.ADDED_TO_REPOSITORY="added_to_repository")(l=u.action||={});let r;(d=>(d.BOT="Bot",d.USER="User",d.ORGANIZATION="Organization"))(r=u.type||={});let e;(d=>(d.PUBLIC="public",d.PRIVATE="private",d.INTERNAL="internal"))(e=u.visibility||={});let n;(d=>(d.OPEN="open",d.CLOSED="closed",d.SECRET="secret"))(n=u.privacy||={});let s;(c=>(c.NOTIFICATIONS_ENABLED="notifications_enabled",c.NOTIFICATIONS_DISABLED="notifications_disabled"))(s=u.notification_setting||={})})(tl||={});var nl;(u=>{let l;(m=>m.CREATED="created")(l=u.action||={});let r;(d=>(d.BOT="Bot",d.USER="User",d.ORGANIZATION="Organization"))(r=u.type||={});let e;(d=>(d.PUBLIC="public",d.PRIVATE="private",d.INTERNAL="internal"))(e=u.visibility||={});let n;(d=>(d.OPEN="open",d.CLOSED="closed",d.SECRET="secret"))(n=u.privacy||={});let s;(c=>(c.NOTIFICATIONS_ENABLED="notifications_enabled",c.NOTIFICATIONS_DISABLED="notifications_disabled"))(s=u.notification_setting||={})})(nl||={});var sl;(u=>{let l;(m=>m.DELETED="deleted")(l=u.action||={});let r;(d=>(d.BOT="Bot",d.USER="User",d.ORGANIZATION="Organization"))(r=u.type||={});let e;(d=>(d.PUBLIC="public",d.PRIVATE="private",d.INTERNAL="internal"))(e=u.visibility||={});let n;(d=>(d.OPEN="open",d.CLOSED="closed",d.SECRET="secret"))(n=u.privacy||={});let s;(c=>(c.NOTIFICATIONS_ENABLED="notifications_enabled",c.NOTIFICATIONS_DISABLED="notifications_disabled"))(s=u.notification_setting||={})})(sl||={});var il;(u=>{let l;(m=>m.EDITED="edited")(l=u.action||={});let r;(d=>(d.BOT="Bot",d.USER="User",d.ORGANIZATION="Organization"))(r=u.type||={});let e;(d=>(d.PUBLIC="public",d.PRIVATE="private",d.INTERNAL="internal"))(e=u.visibility||={});let n;(d=>(d.OPEN="open",d.CLOSED="closed",d.SECRET="secret"))(n=u.privacy||={});let s;(c=>(c.NOTIFICATIONS_ENABLED="notifications_enabled",c.NOTIFICATIONS_DISABLED="notifications_disabled"))(s=u.notification_setting||={})})(il||={});var ol;(u=>{let l;(m=>m.REMOVED_FROM_REPOSITORY="removed_from_repository")(l=u.action||={});let r;(d=>(d.BOT="Bot",d.USER="User",d.ORGANIZATION="Organization"))(r=u.type||={});let e;(d=>(d.PUBLIC="public",d.PRIVATE="private",d.INTERNAL="internal"))(e=u.visibility||={});let n;(d=>(d.OPEN="open",d.CLOSED="closed",d.SECRET="secret"))(n=u.privacy||={});let s;(c=>(c.NOTIFICATIONS_ENABLED="notifications_enabled",c.NOTIFICATIONS_DISABLED="notifications_disabled"))(s=u.notification_setting||={})})(ol||={});var ll;(r=>{let l;(n=>n.STARTED="started")(l=r.action||={})})(ll||={});var al;(n=>{let l;(u=>u.COMPLETED="completed")(l=n.action||={});let r;(h=>(h.SUCCESS="success",h.FAILURE="failure",h.SKIPPED="skipped",h.CANCELLED="cancelled",h.ACTION_REQUIRED="action_required",h.NEUTRAL="neutral",h.TIMED_OUT="timed_out"))(r=n.conclusion||={});let e;(c=>(c.QUEUED="queued",c.IN_PROGRESS="in_progress",c.COMPLETED="completed",c.WAITING="waiting"))(e=n.status||={})})(al||={});var ul;(n=>{let l;(u=>u.IN_PROGRESS="in_progress")(l=n.action||={});let r;(c=>(c.SUCCESS="success",c.FAILURE="failure",c.CANCELLED="cancelled",c.NEUTRAL="neutral"))(r=n.conclusion||={});let e;(m=>(m.QUEUED="queued",m.IN_PROGRESS="in_progress",m.COMPLETED="completed"))(e=n.status||={})})(ul||={});var _l;(e=>{let l;(s=>s.QUEUED="queued")(l=e.action||={});let r;(m=>(m.QUEUED="queued",m.IN_PROGRESS="in_progress",m.COMPLETED="completed",m.WAITING="waiting"))(r=e.status||={})})(_l||={});var gl;(e=>{let l;(s=>s.WAITING="waiting")(l=e.action||={});let r;(m=>(m.QUEUED="queued",m.IN_PROGRESS="in_progress",m.COMPLETED="completed",m.WAITING="waiting"))(r=e.status||={})})(gl||={});var ml;(s=>{let l;(_=>_.COMPLETED="completed")(l=s.action||={});let r;(c=>(c.BOT="Bot",c.USER="User",c.ORGANIZATION="Organization"))(r=s.type||={});let e;(k=>(k.SUCCESS="success",k.FAILURE="failure",k.NEUTRAL="neutral",k.CANCELLED="cancelled",k.TIMED_OUT="timed_out",k.ACTION_REQUIRED="action_required",k.STALE="stale",k.SKIPPED="skipped"))(e=s.conclusion||={});let n;(h=>(h.REQUESTED="requested",h.IN_PROGRESS="in_progress",h.COMPLETED="completed",h.QUEUED="queued",h.PENDING="pending",h.WAITING="waiting"))(n=s.status||={})})(ml||={});var pl;(s=>{let l;(_=>_.IN_PROGRESS="in_progress")(l=s.action||={});let r;(c=>(c.BOT="Bot",c.USER="User",c.ORGANIZATION="Organization"))(r=s.type||={});let e;(k=>(k.SUCCESS="success",k.FAILURE="failure",k.NEUTRAL="neutral",k.CANCELLED="cancelled",k.TIMED_OUT="timed_out",k.ACTION_REQUIRED="action_required",k.STALE="stale",k.SKIPPED="skipped"))(e=s.conclusion||={});let n;(v=>(v.REQUESTED="requested",v.IN_PROGRESS="in_progress",v.COMPLETED="completed",v.QUEUED="queued",v.PENDING="pending"))(n=s.status||={})})(pl||={});var dl;(s=>{let l;(_=>_.REQUESTED="requested")(l=s.action||={});let r;(c=>(c.BOT="Bot",c.USER="User",c.ORGANIZATION="Organization"))(r=s.type||={});let e;(b=>(b.SUCCESS="success",b.FAILURE="failure",b.NEUTRAL="neutral",b.CANCELLED="cancelled",b.TIMED_OUT="timed_out",b.ACTION_REQUIRED="action_required",b.STALE="stale",b.SKIPPED="skipped",b.STARTUP_FAILURE="startup_failure"))(e=s.conclusion||={});let n;(h=>(h.REQUESTED="requested",h.IN_PROGRESS="in_progress",h.COMPLETED="completed",h.QUEUED="queued",h.PENDING="pending",h.WAITING="waiting"))(n=s.status||={})})(dl||={});var cl;(r=>{let l;(m=>(m.ACTIVE="active",m.DELETED="deleted",m.DISABLED_FORK="disabled_fork",m.DISABLED_INACTIVITY="disabled_inactivity",m.DISABLED_MANUALLY="disabled_manually"))(l=r.state||={})})(cl||={});var bl=(b=>(b.COMPLETED="completed",b.ACTION_REQUIRED="action_required",b.CANCELLED="cancelled",b.FAILURE="failure",b.NEUTRAL="neutral",b.SKIPPED="skipped",b.STALE="stale",b.SUCCESS="success",b.TIMED_OUT="timed_out",b.IN_PROGRESS="in_progress",b.QUEUED="queued",b.REQUESTED="requested",b.WAITING="waiting",b.PENDING="pending",b))(bl||{});var ir=l=>l!=null,er=l=>typeof l=="string",sr=l=>er(l)&&l!=="",or=l=>typeof l=="object"&&typeof l.type=="string"&&typeof l.stream=="function"&&typeof l.arrayBuffer=="function"&&typeof l.constructor=="function"&&typeof l.constructor.name=="string"&&/^(Blob|File)$/.test(l.constructor.name)&&/^(Blob|File)$/.test(l[Symbol.toStringTag]),hl=l=>l instanceof FormData,yl=l=>{try{return btoa(l)}catch{return Buffer.from(l).toString("base64")}},fl=l=>{let r=[],e=(s,u)=>{r.push(`${encodeURIComponent(s)}=${encodeURIComponent(String(u))}`)},n=(s,u)=>{ir(u)&&(Array.isArray(u)?u.forEach(_=>{n(s,_)}):typeof u=="object"?Object.entries(u).forEach(([_,m])=>{n(`${s}[${_}]`,m)}):e(s,u))};return Object.entries(l).forEach(([s,u])=>{n(s,u)}),r.length>0?`?${r.join("&")}`:""},wl=(l,r)=>{let e=l.ENCODE_PATH||encodeURI,n=r.url.replace("{api-version}",l.VERSION).replace(/{(.*?)}/g,(u,_)=>r.path?.hasOwnProperty(_)?e(String(r.path[_])):u),s=`${l.BASE}${n}`;return r.query?`${s}${fl(r.query)}`:s},El=l=>{if(l.formData){let r=new FormData,e=(n,s)=>{er(s)||or(s)?r.append(n,s):r.append(n,JSON.stringify(s))};return Object.entries(l.formData).filter(([n,s])=>ir(s)).forEach(([n,s])=>{Array.isArray(s)?s.forEach(u=>e(n,u)):e(n,s)}),r}},nr=async(l,r)=>typeof r=="function"?r(l):r,vl=async(l,r)=>{let e=await nr(r,l.TOKEN),n=await nr(r,l.USERNAME),s=await nr(r,l.PASSWORD),u=await nr(r,l.HEADERS),_=Object.entries({Accept:"application/json",...u,...r.headers}).filter(([m,c])=>ir(c)).reduce((m,[c,d])=>({...m,[c]:String(d)}),{});if(sr(e)&&(_.Authorization=`Bearer ${e}`),sr(n)&&sr(s)){let m=yl(`${n}:${s}`);_.Authorization=`Basic ${m}`}return r.body&&(r.mediaType?_["Content-Type"]=r.mediaType:or(r.body)?_["Content-Type"]=r.body.type||"application/octet-stream":er(r.body)?_["Content-Type"]="text/plain":hl(r.body)||(_["Content-Type"]="application/json")),new Headers(_)},Rl=l=>{if(l.body!==void 0)return l.mediaType?.includes("/json")?JSON.stringify(l.body):er(l.body)||or(l.body)||hl(l.body)?l.body:JSON.stringify(l.body)},Tl=async(l,r,e,n,s,u,_)=>{let m=new AbortController,c={headers:u,body:n??s,method:r.method,signal:m.signal};return l.WITH_CREDENTIALS&&(c.credentials=l.CREDENTIALS),_(()=>m.abort()),await fetch(e,c)},Al=(l,r)=>{if(r){let e=l.headers.get(r);if(er(e))return e}},kl=async l=>{if(l.status!==204)try{let r=l.headers.get("Content-Type");if(r)return["application/json","application/problem+json"].some(s=>r.toLowerCase().startsWith(s))?await l.json():await l.text()}catch(r){console.error(r)}},xl=(l,r)=>{let n={400:"Bad Request",401:"Unauthorized",403:"Forbidden",404:"Not Found",500:"Internal Server Error",502:"Bad Gateway",503:"Service Unavailable",...l.errors}[r.status];if(n)throw new J(l,r,n);if(!r.ok){let s=r.status??"unknown",u=r.statusText??"unknown",_=(()=>{try{return JSON.stringify(r.body,null,2)}catch{return}})();throw new J(l,r,`Generic Error: status: ${s}; status text: ${u}; body: ${_}`)}},o=(l,r)=>new rr(async(e,n,s)=>{try{let u=wl(l,r),_=El(r),m=Rl(r),c=await vl(l,r);if(!s.isCancelled){let d=await Tl(l,r,u,m,_,c,s),v=await kl(d),h=Al(d,r.responseHeader),R={url:u,ok:d.ok,status:d.status,statusText:d.statusText,body:h??v};xl(r,R),e(R.body)}}catch(u){n(u)}});var lr=class{static actionsGetActionsCacheUsageForOrg(r){return o(i,{method:"GET",url:"/orgs/{org}/actions/cache/usage",path:{org:r}})}static actionsGetActionsCacheUsageByRepoForOrg(r,e=30,n=1){return o(i,{method:"GET",url:"/orgs/{org}/actions/cache/usage-by-repository",path:{org:r},query:{per_page:e,page:n}})}static actionsGetGithubActionsPermissionsOrganization(r){return o(i,{method:"GET",url:"/orgs/{org}/actions/permissions",path:{org:r}})}static actionsSetGithubActionsPermissionsOrganization(r,e){return o(i,{method:"PUT",url:"/orgs/{org}/actions/permissions",path:{org:r},body:e,mediaType:"application/json"})}static actionsListSelectedRepositoriesEnabledGithubActionsOrganization(r,e=30,n=1){return o(i,{method:"GET",url:"/orgs/{org}/actions/permissions/repositories",path:{org:r},query:{per_page:e,page:n}})}static actionsSetSelectedRepositoriesEnabledGithubActionsOrganization(r,e){return o(i,{method:"PUT",url:"/orgs/{org}/actions/permissions/repositories",path:{org:r},body:e,mediaType:"application/json"})}static actionsEnableSelectedRepositoryGithubActionsOrganization(r,e){return o(i,{method:"PUT",url:"/orgs/{org}/actions/permissions/repositories/{repository_id}",path:{org:r,repository_id:e}})}static actionsDisableSelectedRepositoryGithubActionsOrganization(r,e){return o(i,{method:"DELETE",url:"/orgs/{org}/actions/permissions/repositories/{repository_id}",path:{org:r,repository_id:e}})}static actionsGetAllowedActionsOrganization(r){return o(i,{method:"GET",url:"/orgs/{org}/actions/permissions/selected-actions",path:{org:r}})}static actionsSetAllowedActionsOrganization(r,e){return o(i,{method:"PUT",url:"/orgs/{org}/actions/permissions/selected-actions",path:{org:r},body:e,mediaType:"application/json"})}static actionsGetGithubActionsDefaultWorkflowPermissionsOrganization(r){return o(i,{method:"GET",url:"/orgs/{org}/actions/permissions/workflow",path:{org:r}})}static actionsSetGithubActionsDefaultWorkflowPermissionsOrganization(r,e){return o(i,{method:"PUT",url:"/orgs/{org}/actions/permissions/workflow",path:{org:r},body:e,mediaType:"application/json"})}static actionsListSelfHostedRunnersForOrg(r,e=30,n=1){return o(i,{method:"GET",url:"/orgs/{org}/actions/runners",path:{org:r},query:{per_page:e,page:n}})}static actionsListRunnerApplicationsForOrg(r){return o(i,{method:"GET",url:"/orgs/{org}/actions/runners/downloads",path:{org:r}})}static actionsGenerateRunnerJitconfigForOrg(r,e){return o(i,{method:"POST",url:"/orgs/{org}/actions/runners/generate-jitconfig",path:{org:r},body:e,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static actionsCreateRegistrationTokenForOrg(r){return o(i,{method:"POST",url:"/orgs/{org}/actions/runners/registration-token",path:{org:r}})}static actionsCreateRemoveTokenForOrg(r){return o(i,{method:"POST",url:"/orgs/{org}/actions/runners/remove-token",path:{org:r}})}static actionsGetSelfHostedRunnerForOrg(r,e){return o(i,{method:"GET",url:"/orgs/{org}/actions/runners/{runner_id}",path:{org:r,runner_id:e}})}static actionsDeleteSelfHostedRunnerFromOrg(r,e){return o(i,{method:"DELETE",url:"/orgs/{org}/actions/runners/{runner_id}",path:{org:r,runner_id:e}})}static actionsListLabelsForSelfHostedRunnerForOrg(r,e){return o(i,{method:"GET",url:"/orgs/{org}/actions/runners/{runner_id}/labels",path:{org:r,runner_id:e},errors:{404:"Resource not found"}})}static actionsAddCustomLabelsToSelfHostedRunnerForOrg(r,e,n){return o(i,{method:"POST",url:"/orgs/{org}/actions/runners/{runner_id}/labels",path:{org:r,runner_id:e},body:n,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static actionsSetCustomLabelsForSelfHostedRunnerForOrg(r,e,n){return o(i,{method:"PUT",url:"/orgs/{org}/actions/runners/{runner_id}/labels",path:{org:r,runner_id:e},body:n,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static actionsRemoveAllCustomLabelsFromSelfHostedRunnerForOrg(r,e){return o(i,{method:"DELETE",url:"/orgs/{org}/actions/runners/{runner_id}/labels",path:{org:r,runner_id:e},errors:{404:"Resource not found"}})}static actionsRemoveCustomLabelFromSelfHostedRunnerForOrg(r,e,n){return o(i,{method:"DELETE",url:"/orgs/{org}/actions/runners/{runner_id}/labels/{name}",path:{org:r,runner_id:e,name:n},errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static actionsListOrgSecrets(r,e=30,n=1){return o(i,{method:"GET",url:"/orgs/{org}/actions/secrets",path:{org:r},query:{per_page:e,page:n}})}static actionsGetOrgPublicKey(r){return o(i,{method:"GET",url:"/orgs/{org}/actions/secrets/public-key",path:{org:r}})}static actionsGetOrgSecret(r,e){return o(i,{method:"GET",url:"/orgs/{org}/actions/secrets/{secret_name}",path:{org:r,secret_name:e}})}static actionsCreateOrUpdateOrgSecret(r,e,n){return o(i,{method:"PUT",url:"/orgs/{org}/actions/secrets/{secret_name}",path:{org:r,secret_name:e},body:n,mediaType:"application/json"})}static actionsDeleteOrgSecret(r,e){return o(i,{method:"DELETE",url:"/orgs/{org}/actions/secrets/{secret_name}",path:{org:r,secret_name:e}})}static actionsListSelectedReposForOrgSecret(r,e,n=1,s=30){return o(i,{method:"GET",url:"/orgs/{org}/actions/secrets/{secret_name}/repositories",path:{org:r,secret_name:e},query:{page:n,per_page:s}})}static actionsSetSelectedReposForOrgSecret(r,e,n){return o(i,{method:"PUT",url:"/orgs/{org}/actions/secrets/{secret_name}/repositories",path:{org:r,secret_name:e},body:n,mediaType:"application/json"})}static actionsAddSelectedRepoToOrgSecret(r,e,n){return o(i,{method:"PUT",url:"/orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}",path:{org:r,secret_name:e,repository_id:n},errors:{409:"Conflict when visibility type is not set to selected"}})}static actionsRemoveSelectedRepoFromOrgSecret(r,e,n){return o(i,{method:"DELETE",url:"/orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}",path:{org:r,secret_name:e,repository_id:n},errors:{409:"Conflict when visibility type not set to selected"}})}static actionsListOrgVariables(r,e=10,n=1){return o(i,{method:"GET",url:"/orgs/{org}/actions/variables",path:{org:r},query:{per_page:e,page:n}})}static actionsCreateOrgVariable(r,e){return o(i,{method:"POST",url:"/orgs/{org}/actions/variables",path:{org:r},body:e,mediaType:"application/json"})}static actionsGetOrgVariable(r,e){return o(i,{method:"GET",url:"/orgs/{org}/actions/variables/{name}",path:{org:r,name:e}})}static actionsUpdateOrgVariable(r,e,n){return o(i,{method:"PATCH",url:"/orgs/{org}/actions/variables/{name}",path:{org:r,name:e},body:n,mediaType:"application/json"})}static actionsDeleteOrgVariable(r,e){return o(i,{method:"DELETE",url:"/orgs/{org}/actions/variables/{name}",path:{org:r,name:e}})}static actionsListSelectedReposForOrgVariable(r,e,n=1,s=30){return o(i,{method:"GET",url:"/orgs/{org}/actions/variables/{name}/repositories",path:{org:r,name:e},query:{page:n,per_page:s},errors:{409:"Response when the visibility of the variable is not set to `selected`"}})}static actionsSetSelectedReposForOrgVariable(r,e,n){return o(i,{method:"PUT",url:"/orgs/{org}/actions/variables/{name}/repositories",path:{org:r,name:e},body:n,mediaType:"application/json",errors:{409:"Response when the visibility of the variable is not set to `selected`"}})}static actionsAddSelectedRepoToOrgVariable(r,e,n){return o(i,{method:"PUT",url:"/orgs/{org}/actions/variables/{name}/repositories/{repository_id}",path:{org:r,name:e,repository_id:n},errors:{409:"Response when the visibility of the variable is not set to `selected`"}})}static actionsRemoveSelectedRepoFromOrgVariable(r,e,n){return o(i,{method:"DELETE",url:"/orgs/{org}/actions/variables/{name}/repositories/{repository_id}",path:{org:r,name:e,repository_id:n},errors:{409:"Response when the visibility of the variable is not set to `selected`"}})}static actionsListArtifactsForRepo(r,e,n=30,s=1,u){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/artifacts",path:{owner:r,repo:e},query:{per_page:n,page:s,name:u}})}static actionsGetArtifact(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/artifacts/{artifact_id}",path:{owner:r,repo:e,artifact_id:n}})}static actionsDeleteArtifact(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/actions/artifacts/{artifact_id}",path:{owner:r,repo:e,artifact_id:n}})}static actionsDownloadArtifact(r,e,n,s){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}",path:{owner:r,repo:e,artifact_id:n,archive_format:s},errors:{302:"Response",410:"Gone"}})}static actionsGetActionsCacheUsage(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/cache/usage",path:{owner:r,repo:e}})}static actionsGetActionsCacheList(r,e,n=30,s=1,u,_,m="last_accessed_at",c="desc"){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/caches",path:{owner:r,repo:e},query:{per_page:n,page:s,ref:u,key:_,sort:m,direction:c}})}static actionsDeleteActionsCacheByKey(r,e,n,s){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/actions/caches",path:{owner:r,repo:e},query:{key:n,ref:s}})}static actionsDeleteActionsCacheById(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/actions/caches/{cache_id}",path:{owner:r,repo:e,cache_id:n}})}static actionsGetJobForWorkflowRun(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/jobs/{job_id}",path:{owner:r,repo:e,job_id:n}})}static actionsDownloadJobLogsForWorkflowRun(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/jobs/{job_id}/logs",path:{owner:r,repo:e,job_id:n},errors:{302:"Response"}})}static actionsReRunJobForWorkflowRun(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/actions/jobs/{job_id}/rerun",path:{owner:r,repo:e,job_id:n},body:s,mediaType:"application/json",errors:{403:"Forbidden"}})}static actionsGetCustomOidcSubClaimForRepo(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/oidc/customization/sub",path:{owner:r,repo:e},errors:{400:"Bad Request",404:"Resource not found"}})}static actionsSetCustomOidcSubClaimForRepo(r,e,n){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/actions/oidc/customization/sub",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{400:"Bad Request",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static actionsListRepoOrganizationSecrets(r,e,n=30,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/organization-secrets",path:{owner:r,repo:e},query:{per_page:n,page:s}})}static actionsListRepoOrganizationVariables(r,e,n=10,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/organization-variables",path:{owner:r,repo:e},query:{per_page:n,page:s}})}static actionsGetGithubActionsPermissionsRepository(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/permissions",path:{owner:r,repo:e}})}static actionsSetGithubActionsPermissionsRepository(r,e,n){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/actions/permissions",path:{owner:r,repo:e},body:n,mediaType:"application/json"})}static actionsGetWorkflowAccessToRepository(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/permissions/access",path:{owner:r,repo:e}})}static actionsSetWorkflowAccessToRepository(r,e,n){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/actions/permissions/access",path:{owner:r,repo:e},body:n,mediaType:"application/json"})}static actionsGetAllowedActionsRepository(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/permissions/selected-actions",path:{owner:r,repo:e}})}static actionsSetAllowedActionsRepository(r,e,n){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/actions/permissions/selected-actions",path:{owner:r,repo:e},body:n,mediaType:"application/json"})}static actionsGetGithubActionsDefaultWorkflowPermissionsRepository(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/permissions/workflow",path:{owner:r,repo:e}})}static actionsSetGithubActionsDefaultWorkflowPermissionsRepository(r,e,n){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/actions/permissions/workflow",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{409:"Conflict response when changing a setting is prevented by the owning organization"}})}static actionsListSelfHostedRunnersForRepo(r,e,n=30,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/runners",path:{owner:r,repo:e},query:{per_page:n,page:s}})}static actionsListRunnerApplicationsForRepo(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/runners/downloads",path:{owner:r,repo:e}})}static actionsGenerateRunnerJitconfigForRepo(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/actions/runners/generate-jitconfig",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static actionsCreateRegistrationTokenForRepo(r,e){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/actions/runners/registration-token",path:{owner:r,repo:e}})}static actionsCreateRemoveTokenForRepo(r,e){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/actions/runners/remove-token",path:{owner:r,repo:e}})}static actionsGetSelfHostedRunnerForRepo(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/runners/{runner_id}",path:{owner:r,repo:e,runner_id:n}})}static actionsDeleteSelfHostedRunnerFromRepo(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/actions/runners/{runner_id}",path:{owner:r,repo:e,runner_id:n}})}static actionsListLabelsForSelfHostedRunnerForRepo(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/runners/{runner_id}/labels",path:{owner:r,repo:e,runner_id:n},errors:{404:"Resource not found"}})}static actionsAddCustomLabelsToSelfHostedRunnerForRepo(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/actions/runners/{runner_id}/labels",path:{owner:r,repo:e,runner_id:n},body:s,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static actionsSetCustomLabelsForSelfHostedRunnerForRepo(r,e,n,s){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/actions/runners/{runner_id}/labels",path:{owner:r,repo:e,runner_id:n},body:s,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static actionsRemoveAllCustomLabelsFromSelfHostedRunnerForRepo(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/actions/runners/{runner_id}/labels",path:{owner:r,repo:e,runner_id:n},errors:{404:"Resource not found"}})}static actionsRemoveCustomLabelFromSelfHostedRunnerForRepo(r,e,n,s){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/actions/runners/{runner_id}/labels/{name}",path:{owner:r,repo:e,runner_id:n,name:s},errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static actionsListWorkflowRunsForRepo(r,e,n,s,u,_,m=30,c=1,d,v=!1,h,R){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/runs",path:{owner:r,repo:e},query:{actor:n,branch:s,event:u,status:_,per_page:m,page:c,created:d,exclude_pull_requests:v,check_suite_id:h,head_sha:R}})}static actionsGetWorkflowRun(r,e,n,s=!1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/runs/{run_id}",path:{owner:r,repo:e,run_id:n},query:{exclude_pull_requests:s}})}static actionsDeleteWorkflowRun(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/actions/runs/{run_id}",path:{owner:r,repo:e,run_id:n}})}static actionsGetReviewsForRun(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/runs/{run_id}/approvals",path:{owner:r,repo:e,run_id:n}})}static actionsApproveWorkflowRun(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/actions/runs/{run_id}/approve",path:{owner:r,repo:e,run_id:n},errors:{403:"Forbidden",404:"Resource not found"}})}static actionsListWorkflowRunArtifacts(r,e,n,s=30,u=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/runs/{run_id}/artifacts",path:{owner:r,repo:e,run_id:n},query:{per_page:s,page:u}})}static actionsGetWorkflowRunAttempt(r,e,n,s,u=!1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}",path:{owner:r,repo:e,run_id:n,attempt_number:s},query:{exclude_pull_requests:u}})}static actionsListJobsForWorkflowRunAttempt(r,e,n,s,u=30,_=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs",path:{owner:r,repo:e,run_id:n,attempt_number:s},query:{per_page:u,page:_},errors:{404:"Resource not found"}})}static actionsDownloadWorkflowRunAttemptLogs(r,e,n,s){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/logs",path:{owner:r,repo:e,run_id:n,attempt_number:s},errors:{302:"Response"}})}static actionsCancelWorkflowRun(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/actions/runs/{run_id}/cancel",path:{owner:r,repo:e,run_id:n},errors:{409:"Conflict"}})}static actionsReviewCustomGatesForRun(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/actions/runs/{run_id}/deployment_protection_rule",path:{owner:r,repo:e,run_id:n},body:s,mediaType:"application/json"})}static actionsListJobsForWorkflowRun(r,e,n,s="latest",u=30,_=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/runs/{run_id}/jobs",path:{owner:r,repo:e,run_id:n},query:{filter:s,per_page:u,page:_}})}static actionsDownloadWorkflowRunLogs(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/runs/{run_id}/logs",path:{owner:r,repo:e,run_id:n},errors:{302:"Response"}})}static actionsDeleteWorkflowRunLogs(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/actions/runs/{run_id}/logs",path:{owner:r,repo:e,run_id:n},errors:{403:"Forbidden",500:"Internal Error"}})}static actionsGetPendingDeploymentsForRun(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/runs/{run_id}/pending_deployments",path:{owner:r,repo:e,run_id:n}})}static actionsReviewPendingDeploymentsForRun(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/actions/runs/{run_id}/pending_deployments",path:{owner:r,repo:e,run_id:n},body:s,mediaType:"application/json"})}static actionsReRunWorkflow(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/actions/runs/{run_id}/rerun",path:{owner:r,repo:e,run_id:n},body:s,mediaType:"application/json"})}static actionsReRunWorkflowFailedJobs(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs",path:{owner:r,repo:e,run_id:n},body:s,mediaType:"application/json"})}static actionsGetWorkflowRunUsage(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/runs/{run_id}/timing",path:{owner:r,repo:e,run_id:n}})}static actionsListRepoSecrets(r,e,n=30,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/secrets",path:{owner:r,repo:e},query:{per_page:n,page:s}})}static actionsGetRepoPublicKey(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/secrets/public-key",path:{owner:r,repo:e}})}static actionsGetRepoSecret(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/secrets/{secret_name}",path:{owner:r,repo:e,secret_name:n}})}static actionsCreateOrUpdateRepoSecret(r,e,n,s){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/actions/secrets/{secret_name}",path:{owner:r,repo:e,secret_name:n},body:s,mediaType:"application/json"})}static actionsDeleteRepoSecret(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/actions/secrets/{secret_name}",path:{owner:r,repo:e,secret_name:n}})}static actionsListRepoVariables(r,e,n=10,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/variables",path:{owner:r,repo:e},query:{per_page:n,page:s}})}static actionsCreateRepoVariable(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/actions/variables",path:{owner:r,repo:e},body:n,mediaType:"application/json"})}static actionsGetRepoVariable(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/variables/{name}",path:{owner:r,repo:e,name:n}})}static actionsUpdateRepoVariable(r,e,n,s){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/actions/variables/{name}",path:{owner:r,repo:e,name:n},body:s,mediaType:"application/json"})}static actionsDeleteRepoVariable(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/actions/variables/{name}",path:{owner:r,repo:e,name:n}})}static actionsListRepoWorkflows(r,e,n=30,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/workflows",path:{owner:r,repo:e},query:{per_page:n,page:s}})}static actionsGetWorkflow(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/workflows/{workflow_id}",path:{owner:r,repo:e,workflow_id:n}})}static actionsDisableWorkflow(r,e,n){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/actions/workflows/{workflow_id}/disable",path:{owner:r,repo:e,workflow_id:n}})}static actionsCreateWorkflowDispatch(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",path:{owner:r,repo:e,workflow_id:n},body:s,mediaType:"application/json"})}static actionsEnableWorkflow(r,e,n){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/actions/workflows/{workflow_id}/enable",path:{owner:r,repo:e,workflow_id:n}})}static actionsListWorkflowRuns(r,e,n,s,u,_,m,c=30,d=1,v,h=!1,R,k){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs",path:{owner:r,repo:e,workflow_id:n},query:{actor:s,branch:u,event:_,status:m,per_page:c,page:d,created:v,exclude_pull_requests:h,check_suite_id:R,head_sha:k}})}static actionsGetWorkflowUsage(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/actions/workflows/{workflow_id}/timing",path:{owner:r,repo:e,workflow_id:n}})}static actionsListEnvironmentSecrets(r,e,n=30,s=1){return o(i,{method:"GET",url:"/repositories/{repository_id}/environments/{environment_name}/secrets",path:{repository_id:r,environment_name:e},query:{per_page:n,page:s}})}static actionsGetEnvironmentPublicKey(r,e){return o(i,{method:"GET",url:"/repositories/{repository_id}/environments/{environment_name}/secrets/public-key",path:{repository_id:r,environment_name:e}})}static actionsGetEnvironmentSecret(r,e,n){return o(i,{method:"GET",url:"/repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}",path:{repository_id:r,environment_name:e,secret_name:n}})}static actionsCreateOrUpdateEnvironmentSecret(r,e,n,s){return o(i,{method:"PUT",url:"/repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}",path:{repository_id:r,environment_name:e,secret_name:n},body:s,mediaType:"application/json"})}static actionsDeleteEnvironmentSecret(r,e,n){return o(i,{method:"DELETE",url:"/repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}",path:{repository_id:r,environment_name:e,secret_name:n}})}static actionsListEnvironmentVariables(r,e,n=10,s=1){return o(i,{method:"GET",url:"/repositories/{repository_id}/environments/{environment_name}/variables",path:{repository_id:r,environment_name:e},query:{per_page:n,page:s}})}static actionsCreateEnvironmentVariable(r,e,n){return o(i,{method:"POST",url:"/repositories/{repository_id}/environments/{environment_name}/variables",path:{repository_id:r,environment_name:e},body:n,mediaType:"application/json"})}static actionsGetEnvironmentVariable(r,e,n){return o(i,{method:"GET",url:"/repositories/{repository_id}/environments/{environment_name}/variables/{name}",path:{repository_id:r,environment_name:e,name:n}})}static actionsUpdateEnvironmentVariable(r,e,n,s){return o(i,{method:"PATCH",url:"/repositories/{repository_id}/environments/{environment_name}/variables/{name}",path:{repository_id:r,name:e,environment_name:n},body:s,mediaType:"application/json"})}static actionsDeleteEnvironmentVariable(r,e,n){return o(i,{method:"DELETE",url:"/repositories/{repository_id}/environments/{environment_name}/variables/{name}",path:{repository_id:r,name:e,environment_name:n}})}};var ar=class{static activityListPublicEvents(r=30,e=1){return o(i,{method:"GET",url:"/events",query:{per_page:r,page:e},errors:{304:"Not modified",403:"Forbidden",503:"Service unavailable"}})}static activityGetFeeds(){return o(i,{method:"GET",url:"/feeds"})}static activityListPublicEventsForRepoNetwork(r,e,n=30,s=1){return o(i,{method:"GET",url:"/networks/{owner}/{repo}/events",path:{owner:r,repo:e},query:{per_page:n,page:s},errors:{301:"Moved permanently",304:"Not modified",403:"Forbidden",404:"Resource not found"}})}static activityListNotificationsForAuthenticatedUser(r=!1,e=!1,n,s,u=1,_=50){return o(i,{method:"GET",url:"/notifications",query:{all:r,participating:e,since:n,before:s,page:u,per_page:_},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",422:"Validation failed, or the endpoint has been spammed."}})}static activityMarkNotificationsAsRead(r){return o(i,{method:"PUT",url:"/notifications",body:r,mediaType:"application/json",errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden"}})}static activityGetThread(r){return o(i,{method:"GET",url:"/notifications/threads/{thread_id}",path:{thread_id:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden"}})}static activityMarkThreadAsRead(r){return o(i,{method:"PATCH",url:"/notifications/threads/{thread_id}",path:{thread_id:r},errors:{304:"Not modified",403:"Forbidden"}})}static activityGetThreadSubscriptionForAuthenticatedUser(r){return o(i,{method:"GET",url:"/notifications/threads/{thread_id}/subscription",path:{thread_id:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden"}})}static activitySetThreadSubscription(r,e){return o(i,{method:"PUT",url:"/notifications/threads/{thread_id}/subscription",path:{thread_id:r},body:e,mediaType:"application/json",errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden"}})}static activityDeleteThreadSubscription(r){return o(i,{method:"DELETE",url:"/notifications/threads/{thread_id}/subscription",path:{thread_id:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden"}})}static activityListPublicOrgEvents(r,e=30,n=1){return o(i,{method:"GET",url:"/orgs/{org}/events",path:{org:r},query:{per_page:e,page:n}})}static activityListRepoEvents(r,e,n=30,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/events",path:{owner:r,repo:e},query:{per_page:n,page:s}})}static activityListRepoNotificationsForAuthenticatedUser(r,e,n=!1,s=!1,u,_,m=30,c=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/notifications",path:{owner:r,repo:e},query:{all:n,participating:s,since:u,before:_,per_page:m,page:c}})}static activityMarkRepoNotificationsAsRead(r,e,n){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/notifications",path:{owner:r,repo:e},body:n,mediaType:"application/json"})}static activityListStargazersForRepo(r,e,n=30,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/stargazers",path:{owner:r,repo:e},query:{per_page:n,page:s},errors:{422:"Validation failed, or the endpoint has been spammed."}})}static activityListWatchersForRepo(r,e,n=30,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/subscribers",path:{owner:r,repo:e},query:{per_page:n,page:s}})}static activityGetRepoSubscription(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/subscription",path:{owner:r,repo:e},errors:{403:"Forbidden",404:"Not Found if you don't subscribe to the repository"}})}static activitySetRepoSubscription(r,e,n){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/subscription",path:{owner:r,repo:e},body:n,mediaType:"application/json"})}static activityDeleteRepoSubscription(r,e){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/subscription",path:{owner:r,repo:e}})}static activityListReposStarredByAuthenticatedUser(r="created",e="desc",n=30,s=1){return o(i,{method:"GET",url:"/user/starred",query:{sort:r,direction:e,per_page:n,page:s},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden"}})}static activityCheckRepoIsStarredByAuthenticatedUser(r,e){return o(i,{method:"GET",url:"/user/starred/{owner}/{repo}",path:{owner:r,repo:e},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Not Found if this repository is not starred by you"}})}static activityStarRepoForAuthenticatedUser(r,e){return o(i,{method:"PUT",url:"/user/starred/{owner}/{repo}",path:{owner:r,repo:e},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static activityUnstarRepoForAuthenticatedUser(r,e){return o(i,{method:"DELETE",url:"/user/starred/{owner}/{repo}",path:{owner:r,repo:e},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static activityListWatchedReposForAuthenticatedUser(r=30,e=1){return o(i,{method:"GET",url:"/user/subscriptions",query:{per_page:r,page:e},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden"}})}static activityListEventsForAuthenticatedUser(r,e=30,n=1){return o(i,{method:"GET",url:"/users/{username}/events",path:{username:r},query:{per_page:e,page:n}})}static activityListOrgEventsForAuthenticatedUser(r,e,n=30,s=1){return o(i,{method:"GET",url:"/users/{username}/events/orgs/{org}",path:{username:r,org:e},query:{per_page:n,page:s}})}static activityListPublicEventsForUser(r,e=30,n=1){return o(i,{method:"GET",url:"/users/{username}/events/public",path:{username:r},query:{per_page:e,page:n}})}static activityListReceivedEventsForUser(r,e=30,n=1){return o(i,{method:"GET",url:"/users/{username}/received_events",path:{username:r},query:{per_page:e,page:n}})}static activityListReceivedPublicEventsForUser(r,e=30,n=1){return o(i,{method:"GET",url:"/users/{username}/received_events/public",path:{username:r},query:{per_page:e,page:n}})}static activityListReposStarredByUser(r,e="created",n="desc",s=30,u=1){return o(i,{method:"GET",url:"/users/{username}/starred",path:{username:r},query:{sort:e,direction:n,per_page:s,page:u}})}static activityListReposWatchedByUser(r,e=30,n=1){return o(i,{method:"GET",url:"/users/{username}/subscriptions",path:{username:r},query:{per_page:e,page:n}})}};var ur=class{static appsGetAuthenticated(){return o(i,{method:"GET",url:"/app"})}static appsCreateFromManifest(r){return o(i,{method:"POST",url:"/app-manifests/{code}/conversions",path:{code:r},errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static appsGetWebhookConfigForApp(){return o(i,{method:"GET",url:"/app/hook/config"})}static appsUpdateWebhookConfigForApp(r){return o(i,{method:"PATCH",url:"/app/hook/config",body:r,mediaType:"application/json"})}static appsListWebhookDeliveries(r=30,e,n){return o(i,{method:"GET",url:"/app/hook/deliveries",query:{per_page:r,cursor:e,redelivery:n},errors:{400:"Bad Request",422:"Validation failed, or the endpoint has been spammed."}})}static appsGetWebhookDelivery(r){return o(i,{method:"GET",url:"/app/hook/deliveries/{delivery_id}",path:{delivery_id:r},errors:{400:"Bad Request",422:"Validation failed, or the endpoint has been spammed."}})}static appsRedeliverWebhookDelivery(r){return o(i,{method:"POST",url:"/app/hook/deliveries/{delivery_id}/attempts",path:{delivery_id:r},errors:{400:"Bad Request",422:"Validation failed, or the endpoint has been spammed."}})}static appsListInstallationRequestsForAuthenticatedApp(r=30,e=1){return o(i,{method:"GET",url:"/app/installation-requests",query:{per_page:r,page:e},errors:{304:"Not modified",401:"Requires authentication"}})}static appsListInstallations(r=30,e=1,n,s){return o(i,{method:"GET",url:"/app/installations",query:{per_page:r,page:e,since:n,outdated:s}})}static appsGetInstallation(r){return o(i,{method:"GET",url:"/app/installations/{installation_id}",path:{installation_id:r},errors:{404:"Resource not found"}})}static appsDeleteInstallation(r){return o(i,{method:"DELETE",url:"/app/installations/{installation_id}",path:{installation_id:r},errors:{404:"Resource not found"}})}static appsCreateInstallationAccessToken(r,e){return o(i,{method:"POST",url:"/app/installations/{installation_id}/access_tokens",path:{installation_id:r},body:e,mediaType:"application/json",errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static appsSuspendInstallation(r){return o(i,{method:"PUT",url:"/app/installations/{installation_id}/suspended",path:{installation_id:r},errors:{404:"Resource not found"}})}static appsUnsuspendInstallation(r){return o(i,{method:"DELETE",url:"/app/installations/{installation_id}/suspended",path:{installation_id:r},errors:{404:"Resource not found"}})}static appsDeleteAuthorization(r,e){return o(i,{method:"DELETE",url:"/applications/{client_id}/grant",path:{client_id:r},body:e,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static appsCheckToken(r,e){return o(i,{method:"POST",url:"/applications/{client_id}/token",path:{client_id:r},body:e,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static appsResetToken(r,e){return o(i,{method:"PATCH",url:"/applications/{client_id}/token",path:{client_id:r},body:e,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static appsDeleteToken(r,e){return o(i,{method:"DELETE",url:"/applications/{client_id}/token",path:{client_id:r},body:e,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static appsScopeToken(r,e){return o(i,{method:"POST",url:"/applications/{client_id}/token/scoped",path:{client_id:r},body:e,mediaType:"application/json",errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static appsGetBySlug(r){return o(i,{method:"GET",url:"/apps/{app_slug}",path:{app_slug:r},errors:{403:"Forbidden",404:"Resource not found"}})}static appsListReposAccessibleToInstallation(r=30,e=1){return o(i,{method:"GET",url:"/installation/repositories",query:{per_page:r,page:e},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden"}})}static appsRevokeInstallationAccessToken(){return o(i,{method:"DELETE",url:"/installation/token"})}static appsGetSubscriptionPlanForAccount(r){return o(i,{method:"GET",url:"/marketplace_listing/accounts/{account_id}",path:{account_id:r},errors:{401:"Requires authentication",404:"Not Found when the account has not purchased the listing"}})}static appsListPlans(r=30,e=1){return o(i,{method:"GET",url:"/marketplace_listing/plans",query:{per_page:r,page:e},errors:{401:"Requires authentication",404:"Resource not found"}})}static appsListAccountsForPlan(r,e="created",n,s=30,u=1){return o(i,{method:"GET",url:"/marketplace_listing/plans/{plan_id}/accounts",path:{plan_id:r},query:{sort:e,direction:n,per_page:s,page:u},errors:{401:"Requires authentication",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static appsGetSubscriptionPlanForAccountStubbed(r){return o(i,{method:"GET",url:"/marketplace_listing/stubbed/accounts/{account_id}",path:{account_id:r},errors:{401:"Requires authentication",404:"Not Found when the account has not purchased the listing"}})}static appsListPlansStubbed(r=30,e=1){return o(i,{method:"GET",url:"/marketplace_listing/stubbed/plans",query:{per_page:r,page:e},errors:{401:"Requires authentication"}})}static appsListAccountsForPlanStubbed(r,e="created",n,s=30,u=1){return o(i,{method:"GET",url:"/marketplace_listing/stubbed/plans/{plan_id}/accounts",path:{plan_id:r},query:{sort:e,direction:n,per_page:s,page:u},errors:{401:"Requires authentication"}})}static appsGetOrgInstallation(r){return o(i,{method:"GET",url:"/orgs/{org}/installation",path:{org:r}})}static appsGetRepoInstallation(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/installation",path:{owner:r,repo:e},errors:{301:"Moved permanently",404:"Resource not found"}})}static appsListInstallationsForAuthenticatedUser(r=30,e=1){return o(i,{method:"GET",url:"/user/installations",query:{per_page:r,page:e},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden"}})}static appsListInstallationReposForAuthenticatedUser(r,e=30,n=1){return o(i,{method:"GET",url:"/user/installations/{installation_id}/repositories",path:{installation_id:r},query:{per_page:e,page:n},errors:{304:"Not modified",403:"Forbidden",404:"Resource not found"}})}static appsAddRepoToInstallationForAuthenticatedUser(r,e){return o(i,{method:"PUT",url:"/user/installations/{installation_id}/repositories/{repository_id}",path:{installation_id:r,repository_id:e},errors:{304:"Not modified",403:"Forbidden",404:"Resource not found"}})}static appsRemoveRepoFromInstallationForAuthenticatedUser(r,e){return o(i,{method:"DELETE",url:"/user/installations/{installation_id}/repositories/{repository_id}",path:{installation_id:r,repository_id:e},errors:{304:"Not modified",403:"Forbidden",404:"Resource not found",422:"Returned when the application is installed on `all` repositories in the organization, or if this request would remove the last repository that the application has access to in the organization."}})}static appsListSubscriptionsForAuthenticatedUser(r=30,e=1){return o(i,{method:"GET",url:"/user/marketplace_purchases",query:{per_page:r,page:e},errors:{304:"Not modified",401:"Requires authentication",404:"Resource not found"}})}static appsListSubscriptionsForAuthenticatedUserStubbed(r=30,e=1){return o(i,{method:"GET",url:"/user/marketplace_purchases/stubbed",query:{per_page:r,page:e},errors:{304:"Not modified",401:"Requires authentication"}})}static appsGetUserInstallation(r){return o(i,{method:"GET",url:"/users/{username}/installation",path:{username:r}})}};var _r=class{static billingGetGithubActionsBillingOrg(r){return o(i,{method:"GET",url:"/orgs/{org}/settings/billing/actions",path:{org:r}})}static billingGetGithubPackagesBillingOrg(r){return o(i,{method:"GET",url:"/orgs/{org}/settings/billing/packages",path:{org:r}})}static billingGetSharedStorageBillingOrg(r){return o(i,{method:"GET",url:"/orgs/{org}/settings/billing/shared-storage",path:{org:r}})}static billingGetGithubActionsBillingUser(r){return o(i,{method:"GET",url:"/users/{username}/settings/billing/actions",path:{username:r}})}static billingGetGithubPackagesBillingUser(r){return o(i,{method:"GET",url:"/users/{username}/settings/billing/packages",path:{username:r}})}static billingGetSharedStorageBillingUser(r){return o(i,{method:"GET",url:"/users/{username}/settings/billing/shared-storage",path:{username:r}})}};var gr=class{static checksCreate(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/check-runs",path:{owner:r,repo:e},body:n,mediaType:"application/json"})}static checksGet(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/check-runs/{check_run_id}",path:{owner:r,repo:e,check_run_id:n}})}static checksUpdate(r,e,n,s){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/check-runs/{check_run_id}",path:{owner:r,repo:e,check_run_id:n},body:s,mediaType:"application/json"})}static checksListAnnotations(r,e,n,s=30,u=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/check-runs/{check_run_id}/annotations",path:{owner:r,repo:e,check_run_id:n},query:{per_page:s,page:u}})}static checksRerequestRun(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/check-runs/{check_run_id}/rerequest",path:{owner:r,repo:e,check_run_id:n},errors:{403:"Forbidden if the check run is not rerequestable or doesn't belong to the authenticated GitHub App",404:"Resource not found",422:"Validation error if the check run is not rerequestable"}})}static checksCreateSuite(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/check-suites",path:{owner:r,repo:e},body:n,mediaType:"application/json"})}static checksSetSuitesPreferences(r,e,n){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/check-suites/preferences",path:{owner:r,repo:e},body:n,mediaType:"application/json"})}static checksGetSuite(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/check-suites/{check_suite_id}",path:{owner:r,repo:e,check_suite_id:n}})}static checksListForSuite(r,e,n,s,u,_="latest",m=30,c=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs",path:{owner:r,repo:e,check_suite_id:n},query:{check_name:s,status:u,filter:_,per_page:m,page:c}})}static checksRerequestSuite(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/check-suites/{check_suite_id}/rerequest",path:{owner:r,repo:e,check_suite_id:n}})}static checksListForRef(r,e,n,s,u,_="latest",m=30,c=1,d){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/commits/{ref}/check-runs",path:{owner:r,repo:e,ref:n},query:{check_name:s,status:u,filter:_,per_page:m,page:c,app_id:d}})}static checksListSuitesForRef(r,e,n,s,u,_=30,m=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/commits/{ref}/check-suites",path:{owner:r,repo:e,ref:n},query:{app_id:s,check_name:u,per_page:_,page:m}})}};var mr=class{static codeScanningListAlertsForOrg(r,e,n,s,u,_=1,m=30,c="desc",d,v="created",h){return o(i,{method:"GET",url:"/orgs/{org}/code-scanning/alerts",path:{org:r},query:{tool_name:e,tool_guid:n,before:s,after:u,page:_,per_page:m,direction:c,state:d,sort:v,severity:h},errors:{404:"Resource not found",503:"Service unavailable"}})}static codeScanningListAlertsForRepo(r,e,n,s,u=1,_=30,m,c="desc",d="created",v,h){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/code-scanning/alerts",path:{owner:r,repo:e},query:{tool_name:n,tool_guid:s,page:u,per_page:_,ref:m,direction:c,sort:d,state:v,severity:h},errors:{304:"Not modified",403:"Response if GitHub Advanced Security is not enabled for this repository",404:"Resource not found",503:"Service unavailable"}})}static codeScanningGetAlert(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/code-scanning/alerts/{alert_number}",path:{owner:r,repo:e,alert_number:n},errors:{304:"Not modified",403:"Response if GitHub Advanced Security is not enabled for this repository",404:"Resource not found",503:"Service unavailable"}})}static codeScanningUpdateAlert(r,e,n,s){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/code-scanning/alerts/{alert_number}",path:{owner:r,repo:e,alert_number:n},body:s,mediaType:"application/json",errors:{403:"Response if the repository is archived or if GitHub Advanced Security is not enabled for this repository",404:"Resource not found",503:"Service unavailable"}})}static codeScanningListAlertInstances(r,e,n,s=1,u=30,_){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/code-scanning/alerts/{alert_number}/instances",path:{owner:r,repo:e,alert_number:n},query:{page:s,per_page:u,ref:_},errors:{403:"Response if GitHub Advanced Security is not enabled for this repository",404:"Resource not found",503:"Service unavailable"}})}static codeScanningListRecentAnalyses(r,e,n,s,u=1,_=30,m,c,d="desc",v="created"){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/code-scanning/analyses",path:{owner:r,repo:e},query:{tool_name:n,tool_guid:s,page:u,per_page:_,ref:m,sarif_id:c,direction:d,sort:v},errors:{403:"Response if GitHub Advanced Security is not enabled for this repository",404:"Resource not found",503:"Service unavailable"}})}static codeScanningGetAnalysis(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/code-scanning/analyses/{analysis_id}",path:{owner:r,repo:e,analysis_id:n},errors:{403:"Response if GitHub Advanced Security is not enabled for this repository",404:"Resource not found",503:"Service unavailable"}})}static codeScanningDeleteAnalysis(r,e,n,s){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/code-scanning/analyses/{analysis_id}",path:{owner:r,repo:e,analysis_id:n},query:{confirm_delete:s},errors:{400:"Bad Request",403:"Response if the repository is archived or if GitHub Advanced Security is not enabled for this repository",404:"Resource not found",503:"Service unavailable"}})}static codeScanningListCodeqlDatabases(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/code-scanning/codeql/databases",path:{owner:r,repo:e},errors:{403:"Response if GitHub Advanced Security is not enabled for this repository",404:"Resource not found",503:"Service unavailable"}})}static codeScanningGetCodeqlDatabase(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/code-scanning/codeql/databases/{language}",path:{owner:r,repo:e,language:n},errors:{302:"Found",403:"Response if GitHub Advanced Security is not enabled for this repository",404:"Resource not found",503:"Service unavailable"}})}static codeScanningGetDefaultSetup(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/code-scanning/default-setup",path:{owner:r,repo:e},errors:{403:"Response if GitHub Advanced Security is not enabled for this repository",404:"Resource not found",503:"Service unavailable"}})}static codeScanningUpdateDefaultSetup(r,e,n){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/code-scanning/default-setup",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{403:"Response if GitHub Advanced Security is not enabled for this repository",404:"Resource not found",409:"Response if there is already a validation run in progress with a different default setup configuration",503:"Service unavailable"}})}static codeScanningUploadSarif(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/code-scanning/sarifs",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{400:"Bad Request if the sarif field is invalid",403:"Response if the repository is archived or if GitHub Advanced Security is not enabled for this repository",404:"Resource not found",413:"Payload Too Large if the sarif field is too large",503:"Service unavailable"}})}static codeScanningGetSarif(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/code-scanning/sarifs/{sarif_id}",path:{owner:r,repo:e,sarif_id:n},errors:{403:"Response if GitHub Advanced Security is not enabled for this repository",404:"Not Found if the sarif id does not match any upload",503:"Service unavailable"}})}};var pr=class{static codesOfConductGetAllCodesOfConduct(){return o(i,{method:"GET",url:"/codes_of_conduct",errors:{304:"Not modified"}})}static codesOfConductGetConductCode(r){return o(i,{method:"GET",url:"/codes_of_conduct/{key}",path:{key:r},errors:{304:"Not modified",404:"Resource not found"}})}};var dr=class{static codespacesListInOrganization(r,e=30,n=1){return o(i,{method:"GET",url:"/orgs/{org}/codespaces",path:{org:r},query:{per_page:e,page:n},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",500:"Internal Error"}})}static codespacesSetCodespacesAccess(r,e){return o(i,{method:"PUT",url:"/orgs/{org}/codespaces/access",path:{org:r},body:e,mediaType:"application/json",errors:{304:"Not modified",400:"Users are neither members nor collaborators of this organization.",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed.",500:"Internal Error"}})}static codespacesSetCodespacesAccessUsers(r,e){return o(i,{method:"POST",url:"/orgs/{org}/codespaces/access/selected_users",path:{org:r},body:e,mediaType:"application/json",errors:{304:"Not modified",400:"Users are neither members nor collaborators of this organization.",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed.",500:"Internal Error"}})}static codespacesDeleteCodespacesAccessUsers(r,e){return o(i,{method:"DELETE",url:"/orgs/{org}/codespaces/access/selected_users",path:{org:r},body:e,mediaType:"application/json",errors:{304:"Not modified",400:"Users are neither members nor collaborators of this organization.",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed.",500:"Internal Error"}})}static codespacesListOrgSecrets(r,e=30,n=1){return o(i,{method:"GET",url:"/orgs/{org}/codespaces/secrets",path:{org:r},query:{per_page:e,page:n}})}static codespacesGetOrgPublicKey(r){return o(i,{method:"GET",url:"/orgs/{org}/codespaces/secrets/public-key",path:{org:r}})}static codespacesGetOrgSecret(r,e){return o(i,{method:"GET",url:"/orgs/{org}/codespaces/secrets/{secret_name}",path:{org:r,secret_name:e}})}static codespacesCreateOrUpdateOrgSecret(r,e,n){return o(i,{method:"PUT",url:"/orgs/{org}/codespaces/secrets/{secret_name}",path:{org:r,secret_name:e},body:n,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static codespacesDeleteOrgSecret(r,e){return o(i,{method:"DELETE",url:"/orgs/{org}/codespaces/secrets/{secret_name}",path:{org:r,secret_name:e},errors:{404:"Resource not found"}})}static codespacesListSelectedReposForOrgSecret(r,e,n=1,s=30){return o(i,{method:"GET",url:"/orgs/{org}/codespaces/secrets/{secret_name}/repositories",path:{org:r,secret_name:e},query:{page:n,per_page:s},errors:{404:"Resource not found"}})}static codespacesSetSelectedReposForOrgSecret(r,e,n){return o(i,{method:"PUT",url:"/orgs/{org}/codespaces/secrets/{secret_name}/repositories",path:{org:r,secret_name:e},body:n,mediaType:"application/json",errors:{404:"Resource not found",409:"Conflict when visibility type not set to selected"}})}static codespacesAddSelectedRepoToOrgSecret(r,e,n){return o(i,{method:"PUT",url:"/orgs/{org}/codespaces/secrets/{secret_name}/repositories/{repository_id}",path:{org:r,secret_name:e,repository_id:n},errors:{404:"Resource not found",409:"Conflict when visibility type is not set to selected",422:"Validation failed, or the endpoint has been spammed."}})}static codespacesRemoveSelectedRepoFromOrgSecret(r,e,n){return o(i,{method:"DELETE",url:"/orgs/{org}/codespaces/secrets/{secret_name}/repositories/{repository_id}",path:{org:r,secret_name:e,repository_id:n},errors:{404:"Resource not found",409:"Conflict when visibility type not set to selected",422:"Validation failed, or the endpoint has been spammed."}})}static codespacesGetCodespacesForUserInOrg(r,e,n=30,s=1){return o(i,{method:"GET",url:"/orgs/{org}/members/{username}/codespaces",path:{org:r,username:e},query:{per_page:n,page:s},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",500:"Internal Error"}})}static codespacesDeleteFromOrganization(r,e,n){return o(i,{method:"DELETE",url:"/orgs/{org}/members/{username}/codespaces/{codespace_name}",path:{org:r,username:e,codespace_name:n},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",500:"Internal Error"}})}static codespacesStopInOrganization(r,e,n){return o(i,{method:"POST",url:"/orgs/{org}/members/{username}/codespaces/{codespace_name}/stop",path:{org:r,username:e,codespace_name:n},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",500:"Internal Error"}})}static codespacesListInRepositoryForAuthenticatedUser(r,e,n=30,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/codespaces",path:{owner:r,repo:e},query:{per_page:n,page:s},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found",500:"Internal Error"}})}static codespacesCreateWithRepoForAuthenticatedUser(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/codespaces",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{400:"Bad Request",401:"Requires authentication",403:"Forbidden",404:"Resource not found",503:"Service unavailable"}})}static codespacesListDevcontainersInRepositoryForAuthenticatedUser(r,e,n=30,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/codespaces/devcontainers",path:{owner:r,repo:e},query:{per_page:n,page:s},errors:{400:"Bad Request",401:"Requires authentication",403:"Forbidden",404:"Resource not found",500:"Internal Error"}})}static codespacesRepoMachinesForAuthenticatedUser(r,e,n,s){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/codespaces/machines",path:{owner:r,repo:e},query:{location:n,client_ip:s},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",500:"Internal Error"}})}static codespacesPreFlightWithRepoForAuthenticatedUser(r,e,n,s){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/codespaces/new",path:{owner:r,repo:e},query:{ref:n,client_ip:s},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static codespacesListRepoSecrets(r,e,n=30,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/codespaces/secrets",path:{owner:r,repo:e},query:{per_page:n,page:s}})}static codespacesGetRepoPublicKey(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/codespaces/secrets/public-key",path:{owner:r,repo:e}})}static codespacesGetRepoSecret(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/codespaces/secrets/{secret_name}",path:{owner:r,repo:e,secret_name:n}})}static codespacesCreateOrUpdateRepoSecret(r,e,n,s){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/codespaces/secrets/{secret_name}",path:{owner:r,repo:e,secret_name:n},body:s,mediaType:"application/json"})}static codespacesDeleteRepoSecret(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/codespaces/secrets/{secret_name}",path:{owner:r,repo:e,secret_name:n}})}static codespacesCreateWithPrForAuthenticatedUser(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/pulls/{pull_number}/codespaces",path:{owner:r,repo:e,pull_number:n},body:s,mediaType:"application/json",errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found",503:"Service unavailable"}})}static codespacesListForAuthenticatedUser(r=30,e=1,n){return o(i,{method:"GET",url:"/user/codespaces",query:{per_page:r,page:e,repository_id:n},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",500:"Internal Error"}})}static codespacesCreateForAuthenticatedUser(r){return o(i,{method:"POST",url:"/user/codespaces",body:r,mediaType:"application/json",errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found",503:"Service unavailable"}})}static codespacesListSecretsForAuthenticatedUser(r=30,e=1){return o(i,{method:"GET",url:"/user/codespaces/secrets",query:{per_page:r,page:e}})}static codespacesGetPublicKeyForAuthenticatedUser(){return o(i,{method:"GET",url:"/user/codespaces/secrets/public-key"})}static codespacesGetSecretForAuthenticatedUser(r){return o(i,{method:"GET",url:"/user/codespaces/secrets/{secret_name}",path:{secret_name:r}})}static codespacesCreateOrUpdateSecretForAuthenticatedUser(r,e){return o(i,{method:"PUT",url:"/user/codespaces/secrets/{secret_name}",path:{secret_name:r},body:e,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static codespacesDeleteSecretForAuthenticatedUser(r){return o(i,{method:"DELETE",url:"/user/codespaces/secrets/{secret_name}",path:{secret_name:r}})}static codespacesListRepositoriesForSecretForAuthenticatedUser(r){return o(i,{method:"GET",url:"/user/codespaces/secrets/{secret_name}/repositories",path:{secret_name:r},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found",500:"Internal Error"}})}static codespacesSetRepositoriesForSecretForAuthenticatedUser(r,e){return o(i,{method:"PUT",url:"/user/codespaces/secrets/{secret_name}/repositories",path:{secret_name:r},body:e,mediaType:"application/json",errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found",500:"Internal Error"}})}static codespacesAddRepositoryForSecretForAuthenticatedUser(r,e){return o(i,{method:"PUT",url:"/user/codespaces/secrets/{secret_name}/repositories/{repository_id}",path:{secret_name:r,repository_id:e},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found",500:"Internal Error"}})}static codespacesRemoveRepositoryForSecretForAuthenticatedUser(r,e){return o(i,{method:"DELETE",url:"/user/codespaces/secrets/{secret_name}/repositories/{repository_id}",path:{secret_name:r,repository_id:e},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found",500:"Internal Error"}})}static codespacesGetForAuthenticatedUser(r){return o(i,{method:"GET",url:"/user/codespaces/{codespace_name}",path:{codespace_name:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",500:"Internal Error"}})}static codespacesUpdateForAuthenticatedUser(r,e){return o(i,{method:"PATCH",url:"/user/codespaces/{codespace_name}",path:{codespace_name:r},body:e,mediaType:"application/json",errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static codespacesDeleteForAuthenticatedUser(r){return o(i,{method:"DELETE",url:"/user/codespaces/{codespace_name}",path:{codespace_name:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",500:"Internal Error"}})}static codespacesExportForAuthenticatedUser(r){return o(i,{method:"POST",url:"/user/codespaces/{codespace_name}/exports",path:{codespace_name:r},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed.",500:"Internal Error"}})}static codespacesGetExportDetailsForAuthenticatedUser(r,e){return o(i,{method:"GET",url:"/user/codespaces/{codespace_name}/exports/{export_id}",path:{codespace_name:r,export_id:e},errors:{404:"Resource not found"}})}static codespacesCodespaceMachinesForAuthenticatedUser(r){return o(i,{method:"GET",url:"/user/codespaces/{codespace_name}/machines",path:{codespace_name:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",500:"Internal Error"}})}static codespacesPublishForAuthenticatedUser(r,e){return o(i,{method:"POST",url:"/user/codespaces/{codespace_name}/publish",path:{codespace_name:r},body:e,mediaType:"application/json",errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static codespacesStartForAuthenticatedUser(r){return o(i,{method:"POST",url:"/user/codespaces/{codespace_name}/start",path:{codespace_name:r},errors:{304:"Not modified",400:"Bad Request",401:"Requires authentication",402:"Payment required",403:"Forbidden",404:"Resource not found",409:"Conflict",500:"Internal Error"}})}static codespacesStopForAuthenticatedUser(r){return o(i,{method:"POST",url:"/user/codespaces/{codespace_name}/stop",path:{codespace_name:r},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found",500:"Internal Error"}})}};var cr=class{static copilotGetCopilotOrganizationDetails(r){return o(i,{method:"GET",url:"/orgs/{org}/copilot/billing",path:{org:r},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found",500:"Internal Error"}})}static copilotListCopilotSeats(r,e=1,n=50){return o(i,{method:"GET",url:"/orgs/{org}/copilot/billing/seats",path:{org:r},query:{page:e,per_page:n},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found",500:"Internal Error"}})}static copilotAddCopilotForBusinessSeatsForTeams(r,e){return o(i,{method:"POST",url:"/orgs/{org}/copilot/billing/selected_teams",path:{org:r},body:e,mediaType:"application/json",errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Copilot for Business is not enabled for this organization, billing has not been set up for this organization, a public code suggestions policy has not been set for this organization, or the organization's Copilot access setting is set to enable Copilot for all users or is unconfigured.",500:"Internal Error"}})}static copilotCancelCopilotSeatAssignmentForTeams(r,e){return o(i,{method:"DELETE",url:"/orgs/{org}/copilot/billing/selected_teams",path:{org:r},body:e,mediaType:"application/json",errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Copilot for Business is not enabled for this organization, billing has not been set up for this organization, a public code suggestions policy has not been set for this organization, or the organization's Copilot access setting is set to enable Copilot for all users or is unconfigured.",500:"Internal Error"}})}static copilotAddCopilotForBusinessSeatsForUsers(r,e){return o(i,{method:"POST",url:"/orgs/{org}/copilot/billing/selected_users",path:{org:r},body:e,mediaType:"application/json",errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Copilot for Business is not enabled for this organization, billing has not been set up for this organization, a public code suggestions policy has not been set for this organization, or the organization's Copilot access setting is set to enable Copilot for all users or is unconfigured.",500:"Internal Error"}})}static copilotCancelCopilotSeatAssignmentForUsers(r,e){return o(i,{method:"DELETE",url:"/orgs/{org}/copilot/billing/selected_users",path:{org:r},body:e,mediaType:"application/json",errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Copilot for Business is not enabled for this organization, billing has not been set up for this organization, a public code suggestions policy has not been set for this organization, the seat management setting is set to enable Copilot for all users or is unconfigured, or a user's seat cannot be cancelled because it was assigned to them via a team.",500:"Internal Error"}})}static copilotGetCopilotSeatAssignmentDetailsForUser(r,e){return o(i,{method:"GET",url:"/orgs/{org}/members/{username}/copilot",path:{org:r,username:e},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Copilot for Business is not enabled for this organization or the user has a pending organization invitation.",500:"Internal Error"}})}};var br=class{static dependabotListAlertsForEnterprise(r,e,n,s,u,_,m="created",c="desc",d,v,h=30,R,k=30){return o(i,{method:"GET",url:"/enterprises/{enterprise}/dependabot/alerts",path:{enterprise:r},query:{state:e,severity:n,ecosystem:s,package:u,scope:_,sort:m,direction:c,before:d,after:v,first:h,last:R,per_page:k},errors:{304:"Not modified",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static dependabotListAlertsForOrg(r,e,n,s,u,_,m="created",c="desc",d,v,h=30,R,k=30){return o(i,{method:"GET",url:"/orgs/{org}/dependabot/alerts",path:{org:r},query:{state:e,severity:n,ecosystem:s,package:u,scope:_,sort:m,direction:c,before:d,after:v,first:h,last:R,per_page:k},errors:{304:"Not modified",400:"Bad Request",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static dependabotListOrgSecrets(r,e=30,n=1){return o(i,{method:"GET",url:"/orgs/{org}/dependabot/secrets",path:{org:r},query:{per_page:e,page:n}})}static dependabotGetOrgPublicKey(r){return o(i,{method:"GET",url:"/orgs/{org}/dependabot/secrets/public-key",path:{org:r}})}static dependabotGetOrgSecret(r,e){return o(i,{method:"GET",url:"/orgs/{org}/dependabot/secrets/{secret_name}",path:{org:r,secret_name:e}})}static dependabotCreateOrUpdateOrgSecret(r,e,n){return o(i,{method:"PUT",url:"/orgs/{org}/dependabot/secrets/{secret_name}",path:{org:r,secret_name:e},body:n,mediaType:"application/json"})}static dependabotDeleteOrgSecret(r,e){return o(i,{method:"DELETE",url:"/orgs/{org}/dependabot/secrets/{secret_name}",path:{org:r,secret_name:e}})}static dependabotListSelectedReposForOrgSecret(r,e,n=1,s=30){return o(i,{method:"GET",url:"/orgs/{org}/dependabot/secrets/{secret_name}/repositories",path:{org:r,secret_name:e},query:{page:n,per_page:s}})}static dependabotSetSelectedReposForOrgSecret(r,e,n){return o(i,{method:"PUT",url:"/orgs/{org}/dependabot/secrets/{secret_name}/repositories",path:{org:r,secret_name:e},body:n,mediaType:"application/json"})}static dependabotAddSelectedRepoToOrgSecret(r,e,n){return o(i,{method:"PUT",url:"/orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id}",path:{org:r,secret_name:e,repository_id:n},errors:{409:"Conflict when visibility type is not set to selected"}})}static dependabotRemoveSelectedRepoFromOrgSecret(r,e,n){return o(i,{method:"DELETE",url:"/orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id}",path:{org:r,secret_name:e,repository_id:n},errors:{409:"Conflict when visibility type not set to selected"}})}static dependabotListAlertsForRepo(r,e,n,s,u,_,m,c,d="created",v="desc",h=1,R=30,k,b,p=30,f){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/dependabot/alerts",path:{owner:r,repo:e},query:{state:n,severity:s,ecosystem:u,package:_,manifest:m,scope:c,sort:d,direction:v,page:h,per_page:R,before:k,after:b,first:p,last:f},errors:{304:"Not modified",400:"Bad Request",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static dependabotGetAlert(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/dependabot/alerts/{alert_number}",path:{owner:r,repo:e,alert_number:n},errors:{304:"Not modified",403:"Forbidden",404:"Resource not found"}})}static dependabotUpdateAlert(r,e,n,s){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/dependabot/alerts/{alert_number}",path:{owner:r,repo:e,alert_number:n},body:s,mediaType:"application/json",errors:{400:"Bad Request",403:"Forbidden",404:"Resource not found",409:"Conflict",422:"Validation failed, or the endpoint has been spammed."}})}static dependabotListRepoSecrets(r,e,n=30,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/dependabot/secrets",path:{owner:r,repo:e},query:{per_page:n,page:s}})}static dependabotGetRepoPublicKey(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/dependabot/secrets/public-key",path:{owner:r,repo:e}})}static dependabotGetRepoSecret(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/dependabot/secrets/{secret_name}",path:{owner:r,repo:e,secret_name:n}})}static dependabotCreateOrUpdateRepoSecret(r,e,n,s){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/dependabot/secrets/{secret_name}",path:{owner:r,repo:e,secret_name:n},body:s,mediaType:"application/json"})}static dependabotDeleteRepoSecret(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/dependabot/secrets/{secret_name}",path:{owner:r,repo:e,secret_name:n}})}};var hr=class{static dependencyGraphDiffRange(r,e,n,s){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/dependency-graph/compare/{basehead}",path:{owner:r,repo:e,basehead:n},query:{name:s},errors:{403:"Response if GitHub Advanced Security is not enabled for this repository",404:"Resource not found"}})}static dependencyGraphExportSbom(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/dependency-graph/sbom",path:{owner:r,repo:e},errors:{403:"Forbidden",404:"Resource not found"}})}static dependencyGraphCreateRepositorySnapshot(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/dependency-graph/snapshots",path:{owner:r,repo:e},body:n,mediaType:"application/json"})}};var yr=class{static emojisGet(){return o(i,{method:"GET",url:"/emojis",errors:{304:"Not modified"}})}};var fr=class{static gistsList(r,e=30,n=1){return o(i,{method:"GET",url:"/gists",query:{since:r,per_page:e,page:n},errors:{304:"Not modified",403:"Forbidden"}})}static gistsCreate(r){return o(i,{method:"POST",url:"/gists",body:r,mediaType:"application/json",errors:{304:"Not modified",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static gistsListPublic(r,e=30,n=1){return o(i,{method:"GET",url:"/gists/public",query:{since:r,per_page:e,page:n},errors:{304:"Not modified",403:"Forbidden",422:"Validation failed, or the endpoint has been spammed."}})}static gistsListStarred(r,e=30,n=1){return o(i,{method:"GET",url:"/gists/starred",query:{since:r,per_page:e,page:n},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden"}})}static gistsGet(r){return o(i,{method:"GET",url:"/gists/{gist_id}",path:{gist_id:r},errors:{304:"Not modified",403:"Forbidden Gist",404:"Resource not found"}})}static gistsUpdate(r,e){return o(i,{method:"PATCH",url:"/gists/{gist_id}",path:{gist_id:r},body:e,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static gistsDelete(r){return o(i,{method:"DELETE",url:"/gists/{gist_id}",path:{gist_id:r},errors:{304:"Not modified",403:"Forbidden",404:"Resource not found"}})}static gistsListComments(r,e=30,n=1){return o(i,{method:"GET",url:"/gists/{gist_id}/comments",path:{gist_id:r},query:{per_page:e,page:n},errors:{304:"Not modified",403:"Forbidden",404:"Resource not found"}})}static gistsCreateComment(r,e){return o(i,{method:"POST",url:"/gists/{gist_id}/comments",path:{gist_id:r},body:e,mediaType:"application/json",errors:{304:"Not modified",403:"Forbidden",404:"Resource not found"}})}static gistsGetComment(r,e){return o(i,{method:"GET",url:"/gists/{gist_id}/comments/{comment_id}",path:{gist_id:r,comment_id:e},errors:{304:"Not modified",403:"Forbidden Gist",404:"Resource not found"}})}static gistsUpdateComment(r,e,n){return o(i,{method:"PATCH",url:"/gists/{gist_id}/comments/{comment_id}",path:{gist_id:r,comment_id:e},body:n,mediaType:"application/json",errors:{404:"Resource not found"}})}static gistsDeleteComment(r,e){return o(i,{method:"DELETE",url:"/gists/{gist_id}/comments/{comment_id}",path:{gist_id:r,comment_id:e},errors:{304:"Not modified",403:"Forbidden",404:"Resource not found"}})}static gistsListCommits(r,e=30,n=1){return o(i,{method:"GET",url:"/gists/{gist_id}/commits",path:{gist_id:r},query:{per_page:e,page:n},errors:{304:"Not modified",403:"Forbidden",404:"Resource not found"}})}static gistsListForks(r,e=30,n=1){return o(i,{method:"GET",url:"/gists/{gist_id}/forks",path:{gist_id:r},query:{per_page:e,page:n},errors:{304:"Not modified",403:"Forbidden",404:"Resource not found"}})}static gistsFork(r){return o(i,{method:"POST",url:"/gists/{gist_id}/forks",path:{gist_id:r},errors:{304:"Not modified",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static gistsCheckIsStarred(r){return o(i,{method:"GET",url:"/gists/{gist_id}/star",path:{gist_id:r},errors:{304:"Not modified",403:"Forbidden",404:"Not Found if gist is not starred"}})}static gistsStar(r){return o(i,{method:"PUT",url:"/gists/{gist_id}/star",path:{gist_id:r},errors:{304:"Not modified",403:"Forbidden",404:"Resource not found"}})}static gistsUnstar(r){return o(i,{method:"DELETE",url:"/gists/{gist_id}/star",path:{gist_id:r},errors:{304:"Not modified",403:"Forbidden",404:"Resource not found"}})}static gistsGetRevision(r,e){return o(i,{method:"GET",url:"/gists/{gist_id}/{sha}",path:{gist_id:r,sha:e},errors:{403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static gistsListForUser(r,e,n=30,s=1){return o(i,{method:"GET",url:"/users/{username}/gists",path:{username:r},query:{since:e,per_page:n,page:s},errors:{422:"Validation failed, or the endpoint has been spammed."}})}};var wr=class{static gitCreateBlob(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/git/blobs",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{403:"Forbidden",404:"Resource not found",409:"Conflict",422:"Validation failed, or the endpoint has been spammed."}})}static gitGetBlob(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/git/blobs/{file_sha}",path:{owner:r,repo:e,file_sha:n},errors:{403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static gitCreateCommit(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/git/commits",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static gitGetCommit(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/git/commits/{commit_sha}",path:{owner:r,repo:e,commit_sha:n},errors:{404:"Resource not found"}})}static gitListMatchingRefs(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/git/matching-refs/{ref}",path:{owner:r,repo:e,ref:n}})}static gitGetRef(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/git/ref/{ref}",path:{owner:r,repo:e,ref:n},errors:{404:"Resource not found"}})}static gitCreateRef(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/git/refs",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static gitUpdateRef(r,e,n,s){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/git/refs/{ref}",path:{owner:r,repo:e,ref:n},body:s,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static gitDeleteRef(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/git/refs/{ref}",path:{owner:r,repo:e,ref:n},errors:{422:"Validation failed, or the endpoint has been spammed."}})}static gitCreateTag(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/git/tags",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static gitGetTag(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/git/tags/{tag_sha}",path:{owner:r,repo:e,tag_sha:n},errors:{404:"Resource not found"}})}static gitCreateTree(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/git/trees",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static gitGetTree(r,e,n,s){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/git/trees/{tree_sha}",path:{owner:r,repo:e,tree_sha:n},query:{recursive:s},errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}};var Er=class{static gitignoreGetAllTemplates(){return o(i,{method:"GET",url:"/gitignore/templates",errors:{304:"Not modified"}})}static gitignoreGetTemplate(r){return o(i,{method:"GET",url:"/gitignore/templates/{name}",path:{name:r},errors:{304:"Not modified"}})}};var vr=class{static interactionsGetRestrictionsForOrg(r){return o(i,{method:"GET",url:"/orgs/{org}/interaction-limits",path:{org:r}})}static interactionsSetRestrictionsForOrg(r,e){return o(i,{method:"PUT",url:"/orgs/{org}/interaction-limits",path:{org:r},body:e,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static interactionsRemoveRestrictionsForOrg(r){return o(i,{method:"DELETE",url:"/orgs/{org}/interaction-limits",path:{org:r}})}static interactionsGetRestrictionsForRepo(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/interaction-limits",path:{owner:r,repo:e}})}static interactionsSetRestrictionsForRepo(r,e,n){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/interaction-limits",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{409:"Response"}})}static interactionsRemoveRestrictionsForRepo(r,e){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/interaction-limits",path:{owner:r,repo:e},errors:{409:"Response"}})}static interactionsGetRestrictionsForAuthenticatedUser(){return o(i,{method:"GET",url:"/user/interaction-limits"})}static interactionsSetRestrictionsForAuthenticatedUser(r){return o(i,{method:"PUT",url:"/user/interaction-limits",body:r,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static interactionsRemoveRestrictionsForAuthenticatedUser(){return o(i,{method:"DELETE",url:"/user/interaction-limits"})}};var Rr=class{static issuesList(r="assigned",e="open",n,s="created",u="desc",_,m,c,d,v,h=30,R=1){return o(i,{method:"GET",url:"/issues",query:{filter:r,state:e,labels:n,sort:s,direction:u,since:_,collab:m,orgs:c,owned:d,pulls:v,per_page:h,page:R},errors:{304:"Not modified",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static issuesListForOrg(r,e="assigned",n="open",s,u="created",_="desc",m,c=30,d=1){return o(i,{method:"GET",url:"/orgs/{org}/issues",path:{org:r},query:{filter:e,state:n,labels:s,sort:u,direction:_,since:m,per_page:c,page:d},errors:{404:"Resource not found"}})}static issuesListAssignees(r,e,n=30,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/assignees",path:{owner:r,repo:e},query:{per_page:n,page:s},errors:{404:"Resource not found"}})}static issuesCheckUserCanBeAssigned(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/assignees/{assignee}",path:{owner:r,repo:e,assignee:n},errors:{404:"Otherwise a `404` status code is returned."}})}static issuesListForRepo(r,e,n,s="open",u,_,m,c,d="created",v="desc",h,R=30,k=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/issues",path:{owner:r,repo:e},query:{milestone:n,state:s,assignee:u,creator:_,mentioned:m,labels:c,sort:d,direction:v,since:h,per_page:R,page:k},errors:{301:"Moved permanently",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static issuesCreate(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/issues",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{400:"Bad Request",403:"Forbidden",404:"Resource not found",410:"Gone",422:"Validation failed, or the endpoint has been spammed.",503:"Service unavailable"}})}static issuesListCommentsForRepo(r,e,n="created",s,u,_=30,m=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/issues/comments",path:{owner:r,repo:e},query:{sort:n,direction:s,since:u,per_page:_,page:m},errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static issuesGetComment(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/issues/comments/{comment_id}",path:{owner:r,repo:e,comment_id:n},errors:{404:"Resource not found"}})}static issuesUpdateComment(r,e,n,s){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/issues/comments/{comment_id}",path:{owner:r,repo:e,comment_id:n},body:s,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static issuesDeleteComment(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/issues/comments/{comment_id}",path:{owner:r,repo:e,comment_id:n}})}static issuesListEventsForRepo(r,e,n=30,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/issues/events",path:{owner:r,repo:e},query:{per_page:n,page:s},errors:{422:"Validation failed, or the endpoint has been spammed."}})}static issuesGetEvent(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/issues/events/{event_id}",path:{owner:r,repo:e,event_id:n},errors:{403:"Forbidden",404:"Resource not found",410:"Gone"}})}static issuesGet(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/issues/{issue_number}",path:{owner:r,repo:e,issue_number:n},errors:{301:"Moved permanently",304:"Not modified",404:"Resource not found",410:"Gone"}})}static issuesUpdate(r,e,n,s){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/issues/{issue_number}",path:{owner:r,repo:e,issue_number:n},body:s,mediaType:"application/json",errors:{301:"Moved permanently",403:"Forbidden",404:"Resource not found",410:"Gone",422:"Validation failed, or the endpoint has been spammed.",503:"Service unavailable"}})}static issuesAddAssignees(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/issues/{issue_number}/assignees",path:{owner:r,repo:e,issue_number:n},body:s,mediaType:"application/json"})}static issuesRemoveAssignees(r,e,n,s){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/issues/{issue_number}/assignees",path:{owner:r,repo:e,issue_number:n},body:s,mediaType:"application/json"})}static issuesCheckUserCanBeAssignedToIssue(r,e,n,s){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/issues/{issue_number}/assignees/{assignee}",path:{owner:r,repo:e,issue_number:n,assignee:s},errors:{404:"Response if `assignee` can not be assigned to `issue_number`"}})}static issuesListComments(r,e,n,s,u=30,_=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/issues/{issue_number}/comments",path:{owner:r,repo:e,issue_number:n},query:{since:s,per_page:u,page:_},errors:{404:"Resource not found",410:"Gone"}})}static issuesCreateComment(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/issues/{issue_number}/comments",path:{owner:r,repo:e,issue_number:n},body:s,mediaType:"application/json",errors:{403:"Forbidden",404:"Resource not found",410:"Gone",422:"Validation failed, or the endpoint has been spammed."}})}static issuesListEvents(r,e,n,s=30,u=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/issues/{issue_number}/events",path:{owner:r,repo:e,issue_number:n},query:{per_page:s,page:u},errors:{410:"Gone"}})}static issuesListLabelsOnIssue(r,e,n,s=30,u=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/issues/{issue_number}/labels",path:{owner:r,repo:e,issue_number:n},query:{per_page:s,page:u},errors:{301:"Moved permanently",404:"Resource not found",410:"Gone"}})}static issuesAddLabels(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/issues/{issue_number}/labels",path:{owner:r,repo:e,issue_number:n},body:s,mediaType:"application/json",errors:{301:"Moved permanently",404:"Resource not found",410:"Gone",422:"Validation failed, or the endpoint has been spammed."}})}static issuesSetLabels(r,e,n,s){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/issues/{issue_number}/labels",path:{owner:r,repo:e,issue_number:n},body:s,mediaType:"application/json",errors:{301:"Moved permanently",404:"Resource not found",410:"Gone",422:"Validation failed, or the endpoint has been spammed."}})}static issuesRemoveAllLabels(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/issues/{issue_number}/labels",path:{owner:r,repo:e,issue_number:n},errors:{301:"Moved permanently",404:"Resource not found",410:"Gone"}})}static issuesRemoveLabel(r,e,n,s){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/issues/{issue_number}/labels/{name}",path:{owner:r,repo:e,issue_number:n,name:s},errors:{301:"Moved permanently",404:"Resource not found",410:"Gone"}})}static issuesLock(r,e,n,s){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/issues/{issue_number}/lock",path:{owner:r,repo:e,issue_number:n},body:s,mediaType:"application/json",errors:{403:"Forbidden",404:"Resource not found",410:"Gone",422:"Validation failed, or the endpoint has been spammed."}})}static issuesUnlock(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/issues/{issue_number}/lock",path:{owner:r,repo:e,issue_number:n},errors:{403:"Forbidden",404:"Resource not found"}})}static issuesListEventsForTimeline(r,e,n,s=30,u=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/issues/{issue_number}/timeline",path:{owner:r,repo:e,issue_number:n},query:{per_page:s,page:u},errors:{404:"Resource not found",410:"Gone"}})}static issuesListLabelsForRepo(r,e,n=30,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/labels",path:{owner:r,repo:e},query:{per_page:n,page:s},errors:{404:"Resource not found"}})}static issuesCreateLabel(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/labels",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static issuesGetLabel(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/labels/{name}",path:{owner:r,repo:e,name:n},errors:{404:"Resource not found"}})}static issuesUpdateLabel(r,e,n,s){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/labels/{name}",path:{owner:r,repo:e,name:n},body:s,mediaType:"application/json"})}static issuesDeleteLabel(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/labels/{name}",path:{owner:r,repo:e,name:n}})}static issuesListMilestones(r,e,n="open",s="due_on",u="asc",_=30,m=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/milestones",path:{owner:r,repo:e},query:{state:n,sort:s,direction:u,per_page:_,page:m},errors:{404:"Resource not found"}})}static issuesCreateMilestone(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/milestones",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static issuesGetMilestone(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/milestones/{milestone_number}",path:{owner:r,repo:e,milestone_number:n},errors:{404:"Resource not found"}})}static issuesUpdateMilestone(r,e,n,s){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/milestones/{milestone_number}",path:{owner:r,repo:e,milestone_number:n},body:s,mediaType:"application/json"})}static issuesDeleteMilestone(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/milestones/{milestone_number}",path:{owner:r,repo:e,milestone_number:n},errors:{404:"Resource not found"}})}static issuesListLabelsForMilestone(r,e,n,s=30,u=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/milestones/{milestone_number}/labels",path:{owner:r,repo:e,milestone_number:n},query:{per_page:s,page:u}})}static issuesListForAuthenticatedUser(r="assigned",e="open",n,s="created",u="desc",_,m=30,c=1){return o(i,{method:"GET",url:"/user/issues",query:{filter:r,state:e,labels:n,sort:s,direction:u,since:_,per_page:m,page:c},errors:{304:"Not modified",404:"Resource not found"}})}};var Tr=class{static licensesGetAllCommonlyUsed(r,e=30,n=1){return o(i,{method:"GET",url:"/licenses",query:{featured:r,per_page:e,page:n},errors:{304:"Not modified"}})}static licensesGet(r){return o(i,{method:"GET",url:"/licenses/{license}",path:{license:r},errors:{304:"Not modified",403:"Forbidden",404:"Resource not found"}})}static licensesGetForRepo(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/license",path:{owner:r,repo:e}})}};var Ar=class{static markdownRender(r){return o(i,{method:"POST",url:"/markdown",body:r,mediaType:"application/json",errors:{304:"Not modified"}})}static markdownRenderRaw(r){return o(i,{method:"POST",url:"/markdown/raw",body:r,mediaType:"text/plain",errors:{304:"Not modified"}})}};var kr=class{static metaRoot(){return o(i,{method:"GET",url:"/"})}static metaGet(){return o(i,{method:"GET",url:"/meta",errors:{304:"Not modified"}})}static metaGetOctocat(r){return o(i,{method:"GET",url:"/octocat",query:{s:r}})}static metaGetAllVersions(){return o(i,{method:"GET",url:"/versions",errors:{404:"Resource not found"}})}static metaGetZen(){return o(i,{method:"GET",url:"/zen"})}};var xr=class{static migrationsListForOrg(r,e=30,n=1,s){return o(i,{method:"GET",url:"/orgs/{org}/migrations",path:{org:r},query:{per_page:e,page:n,exclude:s}})}static migrationsStartForOrg(r,e){return o(i,{method:"POST",url:"/orgs/{org}/migrations",path:{org:r},body:e,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static migrationsGetStatusForOrg(r,e,n){return o(i,{method:"GET",url:"/orgs/{org}/migrations/{migration_id}",path:{org:r,migration_id:e},query:{exclude:n},errors:{404:"Resource not found"}})}static migrationsDownloadArchiveForOrg(r,e){return o(i,{method:"GET",url:"/orgs/{org}/migrations/{migration_id}/archive",path:{org:r,migration_id:e},errors:{302:"Response",404:"Resource not found"}})}static migrationsDeleteArchiveForOrg(r,e){return o(i,{method:"DELETE",url:"/orgs/{org}/migrations/{migration_id}/archive",path:{org:r,migration_id:e},errors:{404:"Resource not found"}})}static migrationsUnlockRepoForOrg(r,e,n){return o(i,{method:"DELETE",url:"/orgs/{org}/migrations/{migration_id}/repos/{repo_name}/lock",path:{org:r,migration_id:e,repo_name:n},errors:{404:"Resource not found"}})}static migrationsListReposForOrg(r,e,n=30,s=1){return o(i,{method:"GET",url:"/orgs/{org}/migrations/{migration_id}/repositories",path:{org:r,migration_id:e},query:{per_page:n,page:s},errors:{404:"Resource not found"}})}static migrationsGetImportStatus(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/import",path:{owner:r,repo:e},errors:{404:"Resource not found",503:"Unavailable due to service under maintenance."}})}static migrationsStartImport(r,e,n){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/import",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed.",503:"Unavailable due to service under maintenance."}})}static migrationsUpdateImport(r,e,n){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/import",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{503:"Unavailable due to service under maintenance."}})}static migrationsCancelImport(r,e){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/import",path:{owner:r,repo:e},errors:{503:"Unavailable due to service under maintenance."}})}static migrationsGetCommitAuthors(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/import/authors",path:{owner:r,repo:e},query:{since:n},errors:{404:"Resource not found",503:"Unavailable due to service under maintenance."}})}static migrationsMapCommitAuthor(r,e,n,s){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/import/authors/{author_id}",path:{owner:r,repo:e,author_id:n},body:s,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed.",503:"Unavailable due to service under maintenance."}})}static migrationsGetLargeFiles(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/import/large_files",path:{owner:r,repo:e},errors:{503:"Unavailable due to service under maintenance."}})}static migrationsSetLfsPreference(r,e,n){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/import/lfs",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed.",503:"Unavailable due to service under maintenance."}})}static migrationsListForAuthenticatedUser(r=30,e=1){return o(i,{method:"GET",url:"/user/migrations",query:{per_page:r,page:e},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden"}})}static migrationsStartForAuthenticatedUser(r){return o(i,{method:"POST",url:"/user/migrations",body:r,mediaType:"application/json",errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",422:"Validation failed, or the endpoint has been spammed."}})}static migrationsGetStatusForAuthenticatedUser(r,e){return o(i,{method:"GET",url:"/user/migrations/{migration_id}",path:{migration_id:r},query:{exclude:e},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static migrationsGetArchiveForAuthenticatedUser(r){return o(i,{method:"GET",url:"/user/migrations/{migration_id}/archive",path:{migration_id:r},errors:{302:"Response",304:"Not modified",401:"Requires authentication",403:"Forbidden"}})}static migrationsDeleteArchiveForAuthenticatedUser(r){return o(i,{method:"DELETE",url:"/user/migrations/{migration_id}/archive",path:{migration_id:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static migrationsUnlockRepoForAuthenticatedUser(r,e){return o(i,{method:"DELETE",url:"/user/migrations/{migration_id}/repos/{repo_name}/lock",path:{migration_id:r,repo_name:e},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static migrationsListReposForAuthenticatedUser(r,e=30,n=1){return o(i,{method:"GET",url:"/user/migrations/{migration_id}/repositories",path:{migration_id:r},query:{per_page:e,page:n},errors:{404:"Resource not found"}})}};var Ir=class{static oidcGetOidcCustomSubTemplateForOrg(r){return o(i,{method:"GET",url:"/orgs/{org}/actions/oidc/customization/sub",path:{org:r}})}static oidcUpdateOidcCustomSubTemplateForOrg(r,e){return o(i,{method:"PUT",url:"/orgs/{org}/actions/oidc/customization/sub",path:{org:r},body:e,mediaType:"application/json",errors:{403:"Forbidden",404:"Resource not found"}})}};var Or=class{static orgsList(r,e=30){return o(i,{method:"GET",url:"/organizations",query:{since:r,per_page:e},errors:{304:"Not modified"}})}static orgsGet(r){return o(i,{method:"GET",url:"/orgs/{org}",path:{org:r},errors:{404:"Resource not found"}})}static orgsUpdate(r,e){return o(i,{method:"PATCH",url:"/orgs/{org}",path:{org:r},body:e,mediaType:"application/json",errors:{409:"Conflict",422:"Validation failed"}})}static orgsDelete(r){return o(i,{method:"DELETE",url:"/orgs/{org}",path:{org:r},errors:{403:"Forbidden",404:"Resource not found"}})}static orgsListBlockedUsers(r,e=30,n=1){return o(i,{method:"GET",url:"/orgs/{org}/blocks",path:{org:r},query:{per_page:e,page:n}})}static orgsCheckBlockedUser(r,e){return o(i,{method:"GET",url:"/orgs/{org}/blocks/{username}",path:{org:r,username:e},errors:{404:"If the user is not blocked"}})}static orgsBlockUser(r,e){return o(i,{method:"PUT",url:"/orgs/{org}/blocks/{username}",path:{org:r,username:e},errors:{422:"Validation failed, or the endpoint has been spammed."}})}static orgsUnblockUser(r,e){return o(i,{method:"DELETE",url:"/orgs/{org}/blocks/{username}",path:{org:r,username:e}})}static orgsListFailedInvitations(r,e=30,n=1){return o(i,{method:"GET",url:"/orgs/{org}/failed_invitations",path:{org:r},query:{per_page:e,page:n},errors:{404:"Resource not found"}})}static orgsListWebhooks(r,e=30,n=1){return o(i,{method:"GET",url:"/orgs/{org}/hooks",path:{org:r},query:{per_page:e,page:n},errors:{404:"Resource not found"}})}static orgsCreateWebhook(r,e){return o(i,{method:"POST",url:"/orgs/{org}/hooks",path:{org:r},body:e,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static orgsGetWebhook(r,e){return o(i,{method:"GET",url:"/orgs/{org}/hooks/{hook_id}",path:{org:r,hook_id:e},errors:{404:"Resource not found"}})}static orgsUpdateWebhook(r,e,n){return o(i,{method:"PATCH",url:"/orgs/{org}/hooks/{hook_id}",path:{org:r,hook_id:e},body:n,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static orgsDeleteWebhook(r,e){return o(i,{method:"DELETE",url:"/orgs/{org}/hooks/{hook_id}",path:{org:r,hook_id:e},errors:{404:"Resource not found"}})}static orgsGetWebhookConfigForOrg(r,e){return o(i,{method:"GET",url:"/orgs/{org}/hooks/{hook_id}/config",path:{org:r,hook_id:e}})}static orgsUpdateWebhookConfigForOrg(r,e,n){return o(i,{method:"PATCH",url:"/orgs/{org}/hooks/{hook_id}/config",path:{org:r,hook_id:e},body:n,mediaType:"application/json"})}static orgsListWebhookDeliveries(r,e,n=30,s,u){return o(i,{method:"GET",url:"/orgs/{org}/hooks/{hook_id}/deliveries",path:{org:r,hook_id:e},query:{per_page:n,cursor:s,redelivery:u},errors:{400:"Bad Request",422:"Validation failed, or the endpoint has been spammed."}})}static orgsGetWebhookDelivery(r,e,n){return o(i,{method:"GET",url:"/orgs/{org}/hooks/{hook_id}/deliveries/{delivery_id}",path:{org:r,hook_id:e,delivery_id:n},errors:{400:"Bad Request",422:"Validation failed, or the endpoint has been spammed."}})}static orgsRedeliverWebhookDelivery(r,e,n){return o(i,{method:"POST",url:"/orgs/{org}/hooks/{hook_id}/deliveries/{delivery_id}/attempts",path:{org:r,hook_id:e,delivery_id:n},errors:{400:"Bad Request",422:"Validation failed, or the endpoint has been spammed."}})}static orgsPingWebhook(r,e){return o(i,{method:"POST",url:"/orgs/{org}/hooks/{hook_id}/pings",path:{org:r,hook_id:e},errors:{404:"Resource not found"}})}static orgsListAppInstallations(r,e=30,n=1){return o(i,{method:"GET",url:"/orgs/{org}/installations",path:{org:r},query:{per_page:e,page:n}})}static orgsListPendingInvitations(r,e=30,n=1,s="all",u="all"){return o(i,{method:"GET",url:"/orgs/{org}/invitations",path:{org:r},query:{per_page:e,page:n,role:s,invitation_source:u},errors:{404:"Resource not found"}})}static orgsCreateInvitation(r,e){return o(i,{method:"POST",url:"/orgs/{org}/invitations",path:{org:r},body:e,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static orgsCancelInvitation(r,e){return o(i,{method:"DELETE",url:"/orgs/{org}/invitations/{invitation_id}",path:{org:r,invitation_id:e},errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static orgsListInvitationTeams(r,e,n=30,s=1){return o(i,{method:"GET",url:"/orgs/{org}/invitations/{invitation_id}/teams",path:{org:r,invitation_id:e},query:{per_page:n,page:s},errors:{404:"Resource not found"}})}static orgsListMembers(r,e="all",n="all",s=30,u=1){return o(i,{method:"GET",url:"/orgs/{org}/members",path:{org:r},query:{filter:e,role:n,per_page:s,page:u},errors:{422:"Validation failed, or the endpoint has been spammed."}})}static orgsCheckMembershipForUser(r,e){return o(i,{method:"GET",url:"/orgs/{org}/members/{username}",path:{org:r,username:e},errors:{302:"Response if requester is not an organization member",404:"Not Found if requester is an organization member and user is not a member"}})}static orgsRemoveMember(r,e){return o(i,{method:"DELETE",url:"/orgs/{org}/members/{username}",path:{org:r,username:e},errors:{403:"Forbidden"}})}static orgsGetMembershipForUser(r,e){return o(i,{method:"GET",url:"/orgs/{org}/memberships/{username}",path:{org:r,username:e},errors:{403:"Forbidden",404:"Resource not found"}})}static orgsSetMembershipForUser(r,e,n){return o(i,{method:"PUT",url:"/orgs/{org}/memberships/{username}",path:{org:r,username:e},body:n,mediaType:"application/json",errors:{403:"Forbidden",422:"Validation failed, or the endpoint has been spammed."}})}static orgsRemoveMembershipForUser(r,e){return o(i,{method:"DELETE",url:"/orgs/{org}/memberships/{username}",path:{org:r,username:e},errors:{403:"Forbidden",404:"Resource not found"}})}static orgsListOutsideCollaborators(r,e="all",n=30,s=1){return o(i,{method:"GET",url:"/orgs/{org}/outside_collaborators",path:{org:r},query:{filter:e,per_page:n,page:s}})}static orgsConvertMemberToOutsideCollaborator(r,e,n){return o(i,{method:"PUT",url:"/orgs/{org}/outside_collaborators/{username}",path:{org:r,username:e},body:n,mediaType:"application/json",errors:{403:'Forbidden if user is the last owner of the organization, not a member of the organization, or if the enterprise enforces a policy for inviting outside collaborators. For more information, see "[Enforcing repository management policies in your enterprise](https://docs.github.com/admin/policies/enforcing-policies-for-your-enterprise/enforcing-repository-management-policies-in-your-enterprise#enforcing-a-policy-for-inviting-outside-collaborators-to-repositories)."',404:"Resource not found"}})}static orgsRemoveOutsideCollaborator(r,e){return o(i,{method:"DELETE",url:"/orgs/{org}/outside_collaborators/{username}",path:{org:r,username:e},errors:{422:"Unprocessable Entity if user is a member of the organization"}})}static orgsListPatGrantRequests(r,e=30,n=1,s="created_at",u="desc",_,m,c,d,v){return o(i,{method:"GET",url:"/orgs/{org}/personal-access-token-requests",path:{org:r},query:{per_page:e,page:n,sort:s,direction:u,owner:_,repository:m,permission:c,last_used_before:d,last_used_after:v},errors:{403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed.",500:"Internal Error"}})}static orgsReviewPatGrantRequestsInBulk(r,e){return o(i,{method:"POST",url:"/orgs/{org}/personal-access-token-requests",path:{org:r},body:e,mediaType:"application/json",errors:{403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed.",500:"Internal Error"}})}static orgsReviewPatGrantRequest(r,e,n){return o(i,{method:"POST",url:"/orgs/{org}/personal-access-token-requests/{pat_request_id}",path:{org:r,pat_request_id:e},body:n,mediaType:"application/json",errors:{403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed.",500:"Internal Error"}})}static orgsListPatGrantRequestRepositories(r,e,n=30,s=1){return o(i,{method:"GET",url:"/orgs/{org}/personal-access-token-requests/{pat_request_id}/repositories",path:{org:r,pat_request_id:e},query:{per_page:n,page:s},errors:{403:"Forbidden",404:"Resource not found",500:"Internal Error"}})}static orgsListPatGrants(r,e=30,n=1,s="created_at",u="desc",_,m,c,d,v){return o(i,{method:"GET",url:"/orgs/{org}/personal-access-tokens",path:{org:r},query:{per_page:e,page:n,sort:s,direction:u,owner:_,repository:m,permission:c,last_used_before:d,last_used_after:v},errors:{403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed.",500:"Internal Error"}})}static orgsUpdatePatAccesses(r,e){return o(i,{method:"POST",url:"/orgs/{org}/personal-access-tokens",path:{org:r},body:e,mediaType:"application/json",errors:{403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed.",500:"Internal Error"}})}static orgsUpdatePatAccess(r,e,n){return o(i,{method:"POST",url:"/orgs/{org}/personal-access-tokens/{pat_id}",path:{org:r,pat_id:e},body:n,mediaType:"application/json",errors:{403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed.",500:"Internal Error"}})}static orgsListPatGrantRepositories(r,e,n=30,s=1){return o(i,{method:"GET",url:"/orgs/{org}/personal-access-tokens/{pat_id}/repositories",path:{org:r,pat_id:e},query:{per_page:n,page:s},errors:{403:"Forbidden",404:"Resource not found",500:"Internal Error"}})}static orgsListPublicMembers(r,e=30,n=1){return o(i,{method:"GET",url:"/orgs/{org}/public_members",path:{org:r},query:{per_page:e,page:n}})}static orgsCheckPublicMembershipForUser(r,e){return o(i,{method:"GET",url:"/orgs/{org}/public_members/{username}",path:{org:r,username:e},errors:{404:"Not Found if user is not a public member"}})}static orgsSetPublicMembershipForAuthenticatedUser(r,e){return o(i,{method:"PUT",url:"/orgs/{org}/public_members/{username}",path:{org:r,username:e},errors:{403:"Forbidden"}})}static orgsRemovePublicMembershipForAuthenticatedUser(r,e){return o(i,{method:"DELETE",url:"/orgs/{org}/public_members/{username}",path:{org:r,username:e}})}static orgsListSecurityManagerTeams(r){return o(i,{method:"GET",url:"/orgs/{org}/security-managers",path:{org:r}})}static orgsAddSecurityManagerTeam(r,e){return o(i,{method:"PUT",url:"/orgs/{org}/security-managers/teams/{team_slug}",path:{org:r,team_slug:e},errors:{409:"The organization has reached the maximum number of security manager teams."}})}static orgsRemoveSecurityManagerTeam(r,e){return o(i,{method:"DELETE",url:"/orgs/{org}/security-managers/teams/{team_slug}",path:{org:r,team_slug:e}})}static orgsEnableOrDisableSecurityProductOnAllOrgRepos(r,e,n,s){return o(i,{method:"POST",url:"/orgs/{org}/{security_product}/{enablement}",path:{org:r,security_product:e,enablement:n},body:s,mediaType:"application/json",errors:{422:"The action could not be taken due to an in progress enablement, or a policy is preventing enablement"}})}static orgsListMembershipsForAuthenticatedUser(r,e=30,n=1){return o(i,{method:"GET",url:"/user/memberships/orgs",query:{state:r,per_page:e,page:n},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",422:"Validation failed, or the endpoint has been spammed."}})}static orgsGetMembershipForAuthenticatedUser(r){return o(i,{method:"GET",url:"/user/memberships/orgs/{org}",path:{org:r},errors:{403:"Forbidden",404:"Resource not found"}})}static orgsUpdateMembershipForAuthenticatedUser(r,e){return o(i,{method:"PATCH",url:"/user/memberships/orgs/{org}",path:{org:r},body:e,mediaType:"application/json",errors:{403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static orgsListForAuthenticatedUser(r=30,e=1){return o(i,{method:"GET",url:"/user/orgs",query:{per_page:r,page:e},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden"}})}static orgsListForUser(r,e=30,n=1){return o(i,{method:"GET",url:"/users/{username}/orgs",path:{username:r},query:{per_page:e,page:n}})}};var Nr=class{static packagesListDockerMigrationConflictingPackagesForOrganization(r){return o(i,{method:"GET",url:"/orgs/{org}/docker/conflicts",path:{org:r},errors:{401:"Requires authentication",403:"Forbidden"}})}static packagesListPackagesForOrganization(r,e,n,s=1,u=30){return o(i,{method:"GET",url:"/orgs/{org}/packages",path:{org:e},query:{package_type:r,visibility:n,page:s,per_page:u},errors:{400:"The value of `per_page` multiplied by `page` cannot be greater than 10000.",401:"Requires authentication",403:"Forbidden"}})}static packagesGetPackageForOrganization(r,e,n){return o(i,{method:"GET",url:"/orgs/{org}/packages/{package_type}/{package_name}",path:{package_type:r,package_name:e,org:n}})}static packagesDeletePackageForOrg(r,e,n){return o(i,{method:"DELETE",url:"/orgs/{org}/packages/{package_type}/{package_name}",path:{package_type:r,package_name:e,org:n},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static packagesRestorePackageForOrg(r,e,n,s){return o(i,{method:"POST",url:"/orgs/{org}/packages/{package_type}/{package_name}/restore",path:{package_type:r,package_name:e,org:n},query:{token:s},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static packagesGetAllPackageVersionsForPackageOwnedByOrg(r,e,n,s=1,u=30,_="active"){return o(i,{method:"GET",url:"/orgs/{org}/packages/{package_type}/{package_name}/versions",path:{package_type:r,package_name:e,org:n},query:{page:s,per_page:u,state:_},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static packagesGetPackageVersionForOrganization(r,e,n,s){return o(i,{method:"GET",url:"/orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}",path:{package_type:r,package_name:e,org:n,package_version_id:s}})}static packagesDeletePackageVersionForOrg(r,e,n,s){return o(i,{method:"DELETE",url:"/orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}",path:{package_type:r,package_name:e,org:n,package_version_id:s},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static packagesRestorePackageVersionForOrg(r,e,n,s){return o(i,{method:"POST",url:"/orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}/restore",path:{package_type:r,package_name:e,org:n,package_version_id:s},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static packagesListDockerMigrationConflictingPackagesForAuthenticatedUser(){return o(i,{method:"GET",url:"/user/docker/conflicts"})}static packagesListPackagesForAuthenticatedUser(r,e,n=1,s=30){return o(i,{method:"GET",url:"/user/packages",query:{package_type:r,visibility:e,page:n,per_page:s},errors:{400:"The value of `per_page` multiplied by `page` cannot be greater than 10000."}})}static packagesGetPackageForAuthenticatedUser(r,e){return o(i,{method:"GET",url:"/user/packages/{package_type}/{package_name}",path:{package_type:r,package_name:e}})}static packagesDeletePackageForAuthenticatedUser(r,e){return o(i,{method:"DELETE",url:"/user/packages/{package_type}/{package_name}",path:{package_type:r,package_name:e},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static packagesRestorePackageForAuthenticatedUser(r,e,n){return o(i,{method:"POST",url:"/user/packages/{package_type}/{package_name}/restore",path:{package_type:r,package_name:e},query:{token:n},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static packagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUser(r,e,n=1,s=30,u="active"){return o(i,{method:"GET",url:"/user/packages/{package_type}/{package_name}/versions",path:{package_type:r,package_name:e},query:{page:n,per_page:s,state:u},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static packagesGetPackageVersionForAuthenticatedUser(r,e,n){return o(i,{method:"GET",url:"/user/packages/{package_type}/{package_name}/versions/{package_version_id}",path:{package_type:r,package_name:e,package_version_id:n}})}static packagesDeletePackageVersionForAuthenticatedUser(r,e,n){return o(i,{method:"DELETE",url:"/user/packages/{package_type}/{package_name}/versions/{package_version_id}",path:{package_type:r,package_name:e,package_version_id:n},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static packagesRestorePackageVersionForAuthenticatedUser(r,e,n){return o(i,{method:"POST",url:"/user/packages/{package_type}/{package_name}/versions/{package_version_id}/restore",path:{package_type:r,package_name:e,package_version_id:n},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static packagesListDockerMigrationConflictingPackagesForUser(r){return o(i,{method:"GET",url:"/users/{username}/docker/conflicts",path:{username:r},errors:{401:"Requires authentication",403:"Forbidden"}})}static packagesListPackagesForUser(r,e,n,s=1,u=30){return o(i,{method:"GET",url:"/users/{username}/packages",path:{username:e},query:{package_type:r,visibility:n,page:s,per_page:u},errors:{400:"The value of `per_page` multiplied by `page` cannot be greater than 10000.",401:"Requires authentication",403:"Forbidden"}})}static packagesGetPackageForUser(r,e,n){return o(i,{method:"GET",url:"/users/{username}/packages/{package_type}/{package_name}",path:{package_type:r,package_name:e,username:n}})}static packagesDeletePackageForUser(r,e,n){return o(i,{method:"DELETE",url:"/users/{username}/packages/{package_type}/{package_name}",path:{package_type:r,package_name:e,username:n},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static packagesRestorePackageForUser(r,e,n,s){return o(i,{method:"POST",url:"/users/{username}/packages/{package_type}/{package_name}/restore",path:{package_type:r,package_name:e,username:n},query:{token:s},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static packagesGetAllPackageVersionsForPackageOwnedByUser(r,e,n){return o(i,{method:"GET",url:"/users/{username}/packages/{package_type}/{package_name}/versions",path:{package_type:r,package_name:e,username:n},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static packagesGetPackageVersionForUser(r,e,n,s){return o(i,{method:"GET",url:"/users/{username}/packages/{package_type}/{package_name}/versions/{package_version_id}",path:{package_type:r,package_name:e,package_version_id:n,username:s}})}static packagesDeletePackageVersionForUser(r,e,n,s){return o(i,{method:"DELETE",url:"/users/{username}/packages/{package_type}/{package_name}/versions/{package_version_id}",path:{package_type:r,package_name:e,username:n,package_version_id:s},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static packagesRestorePackageVersionForUser(r,e,n,s){return o(i,{method:"POST",url:"/users/{username}/packages/{package_type}/{package_name}/versions/{package_version_id}/restore",path:{package_type:r,package_name:e,username:n,package_version_id:s},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}};var zr=class{static projectsListForOrg(r,e="open",n=30,s=1){return o(i,{method:"GET",url:"/orgs/{org}/projects",path:{org:r},query:{state:e,per_page:n,page:s},errors:{422:"Validation failed, or the endpoint has been spammed."}})}static projectsCreateForOrg(r,e){return o(i,{method:"POST",url:"/orgs/{org}/projects",path:{org:r},body:e,mediaType:"application/json",errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found",410:"Gone",422:"Validation failed, or the endpoint has been spammed."}})}static projectsGetCard(r){return o(i,{method:"GET",url:"/projects/columns/cards/{card_id}",path:{card_id:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static projectsUpdateCard(r,e){return o(i,{method:"PATCH",url:"/projects/columns/cards/{card_id}",path:{card_id:r},body:e,mediaType:"application/json",errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static projectsDeleteCard(r){return o(i,{method:"DELETE",url:"/projects/columns/cards/{card_id}",path:{card_id:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static projectsMoveCard(r,e){return o(i,{method:"POST",url:"/projects/columns/cards/{card_id}/moves",path:{card_id:r},body:e,mediaType:"application/json",errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",422:"Validation failed, or the endpoint has been spammed.",503:"Response"}})}static projectsGetColumn(r){return o(i,{method:"GET",url:"/projects/columns/{column_id}",path:{column_id:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static projectsUpdateColumn(r,e){return o(i,{method:"PATCH",url:"/projects/columns/{column_id}",path:{column_id:r},body:e,mediaType:"application/json",errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden"}})}static projectsDeleteColumn(r){return o(i,{method:"DELETE",url:"/projects/columns/{column_id}",path:{column_id:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden"}})}static projectsListCards(r,e="not_archived",n=30,s=1){return o(i,{method:"GET",url:"/projects/columns/{column_id}/cards",path:{column_id:r},query:{archived_state:e,per_page:n,page:s},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden"}})}static projectsCreateCard(r,e){return o(i,{method:"POST",url:"/projects/columns/{column_id}/cards",path:{column_id:r},body:e,mediaType:"application/json",errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",422:"Validation failed",503:"Response"}})}static projectsMoveColumn(r,e){return o(i,{method:"POST",url:"/projects/columns/{column_id}/moves",path:{column_id:r},body:e,mediaType:"application/json",errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",422:"Validation failed, or the endpoint has been spammed."}})}static projectsGet(r){return o(i,{method:"GET",url:"/projects/{project_id}",path:{project_id:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden"}})}static projectsUpdate(r,e){return o(i,{method:"PATCH",url:"/projects/{project_id}",path:{project_id:r},body:e,mediaType:"application/json",errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Not Found if the authenticated user does not have access to the project",410:"Gone",422:"Validation failed, or the endpoint has been spammed."}})}static projectsDelete(r){return o(i,{method:"DELETE",url:"/projects/{project_id}",path:{project_id:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",410:"Gone"}})}static projectsListCollaborators(r,e="all",n=30,s=1){return o(i,{method:"GET",url:"/projects/{project_id}/collaborators",path:{project_id:r},query:{affiliation:e,per_page:n,page:s},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static projectsAddCollaborator(r,e,n){return o(i,{method:"PUT",url:"/projects/{project_id}/collaborators/{username}",path:{project_id:r,username:e},body:n,mediaType:"application/json",errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static projectsRemoveCollaborator(r,e){return o(i,{method:"DELETE",url:"/projects/{project_id}/collaborators/{username}",path:{project_id:r,username:e},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static projectsGetPermissionForUser(r,e){return o(i,{method:"GET",url:"/projects/{project_id}/collaborators/{username}/permission",path:{project_id:r,username:e},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static projectsListColumns(r,e=30,n=1){return o(i,{method:"GET",url:"/projects/{project_id}/columns",path:{project_id:r},query:{per_page:e,page:n},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden"}})}static projectsCreateColumn(r,e){return o(i,{method:"POST",url:"/projects/{project_id}/columns",path:{project_id:r},body:e,mediaType:"application/json",errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",422:"Validation failed, or the endpoint has been spammed."}})}static projectsListForRepo(r,e,n="open",s=30,u=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/projects",path:{owner:r,repo:e},query:{state:n,per_page:s,page:u},errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found",410:"Gone",422:"Validation failed, or the endpoint has been spammed."}})}static projectsCreateForRepo(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/projects",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{401:"Requires authentication",403:"Forbidden",404:"Resource not found",410:"Gone",422:"Validation failed, or the endpoint has been spammed."}})}static projectsCreateForAuthenticatedUser(r){return o(i,{method:"POST",url:"/user/projects",body:r,mediaType:"application/json",errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",422:"Validation failed, or the endpoint has been spammed."}})}static projectsListForUser(r,e="open",n=30,s=1){return o(i,{method:"GET",url:"/users/{username}/projects",path:{username:r},query:{state:e,per_page:n,page:s},errors:{422:"Validation failed, or the endpoint has been spammed."}})}};var Pr=class{static pullsList(r,e,n="open",s,u,_="created",m,c=30,d=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/pulls",path:{owner:r,repo:e},query:{state:n,head:s,base:u,sort:_,direction:m,per_page:c,page:d},errors:{304:"Not modified",422:"Validation failed, or the endpoint has been spammed."}})}static pullsCreate(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/pulls",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{403:"Forbidden",422:"Validation failed, or the endpoint has been spammed."}})}static pullsListReviewCommentsForRepo(r,e,n,s,u,_=30,m=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/pulls/comments",path:{owner:r,repo:e},query:{sort:n,direction:s,since:u,per_page:_,page:m}})}static pullsGetReviewComment(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/pulls/comments/{comment_id}",path:{owner:r,repo:e,comment_id:n},errors:{404:"Resource not found"}})}static pullsUpdateReviewComment(r,e,n,s){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/pulls/comments/{comment_id}",path:{owner:r,repo:e,comment_id:n},body:s,mediaType:"application/json"})}static pullsDeleteReviewComment(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/pulls/comments/{comment_id}",path:{owner:r,repo:e,comment_id:n},errors:{404:"Resource not found"}})}static pullsGet(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/pulls/{pull_number}",path:{owner:r,repo:e,pull_number:n},errors:{304:"Not modified",404:"Resource not found",500:"Internal Error",503:"Service unavailable"}})}static pullsUpdate(r,e,n,s){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/pulls/{pull_number}",path:{owner:r,repo:e,pull_number:n},body:s,mediaType:"application/json",errors:{403:"Forbidden",422:"Validation failed, or the endpoint has been spammed."}})}static pullsListReviewComments(r,e,n,s="created",u,_,m=30,c=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/pulls/{pull_number}/comments",path:{owner:r,repo:e,pull_number:n},query:{sort:s,direction:u,since:_,per_page:m,page:c}})}static pullsCreateReviewComment(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/pulls/{pull_number}/comments",path:{owner:r,repo:e,pull_number:n},body:s,mediaType:"application/json",errors:{403:"Forbidden",422:"Validation failed, or the endpoint has been spammed."}})}static pullsCreateReplyForReviewComment(r,e,n,s,u){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies",path:{owner:r,repo:e,pull_number:n,comment_id:s},body:u,mediaType:"application/json",errors:{404:"Resource not found"}})}static pullsListCommits(r,e,n,s=30,u=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/pulls/{pull_number}/commits",path:{owner:r,repo:e,pull_number:n},query:{per_page:s,page:u}})}static pullsListFiles(r,e,n,s=30,u=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/pulls/{pull_number}/files",path:{owner:r,repo:e,pull_number:n},query:{per_page:s,page:u},errors:{422:"Validation failed, or the endpoint has been spammed.",500:"Internal Error",503:"Service unavailable"}})}static pullsCheckIfMerged(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/pulls/{pull_number}/merge",path:{owner:r,repo:e,pull_number:n},errors:{404:"Not Found if pull request has not been merged"}})}static pullsMerge(r,e,n,s){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/pulls/{pull_number}/merge",path:{owner:r,repo:e,pull_number:n},body:s,mediaType:"application/json",errors:{403:"Forbidden",404:"Resource not found",405:"Method Not Allowed if merge cannot be performed",409:"Conflict if sha was provided and pull request head did not match",422:"Validation failed, or the endpoint has been spammed."}})}static pullsListRequestedReviewers(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers",path:{owner:r,repo:e,pull_number:n}})}static pullsRequestReviewers(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers",path:{owner:r,repo:e,pull_number:n},body:s,mediaType:"application/json",errors:{403:"Forbidden",422:"Unprocessable Entity if user is not a collaborator"}})}static pullsRemoveRequestedReviewers(r,e,n,s){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers",path:{owner:r,repo:e,pull_number:n},body:s,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static pullsListReviews(r,e,n,s=30,u=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/pulls/{pull_number}/reviews",path:{owner:r,repo:e,pull_number:n},query:{per_page:s,page:u}})}static pullsCreateReview(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/pulls/{pull_number}/reviews",path:{owner:r,repo:e,pull_number:n},body:s,mediaType:"application/json",errors:{403:"Forbidden",422:"Validation failed, or the endpoint has been spammed."}})}static pullsGetReview(r,e,n,s){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}",path:{owner:r,repo:e,pull_number:n,review_id:s},errors:{404:"Resource not found"}})}static pullsUpdateReview(r,e,n,s,u){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}",path:{owner:r,repo:e,pull_number:n,review_id:s},body:u,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static pullsDeletePendingReview(r,e,n,s){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}",path:{owner:r,repo:e,pull_number:n,review_id:s},errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static pullsListCommentsForReview(r,e,n,s,u=30,_=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments",path:{owner:r,repo:e,pull_number:n,review_id:s},query:{per_page:u,page:_},errors:{404:"Resource not found"}})}static pullsDismissReview(r,e,n,s,u){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals",path:{owner:r,repo:e,pull_number:n,review_id:s},body:u,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static pullsSubmitReview(r,e,n,s,u){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events",path:{owner:r,repo:e,pull_number:n,review_id:s},body:u,mediaType:"application/json",errors:{403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static pullsUpdateBranch(r,e,n,s){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/pulls/{pull_number}/update-branch",path:{owner:r,repo:e,pull_number:n},body:s,mediaType:"application/json",errors:{403:"Forbidden",422:"Validation failed, or the endpoint has been spammed."}})}};var Cr=class{static rateLimitGet(){return o(i,{method:"GET",url:"/rate_limit",errors:{304:"Not modified",404:"Resource not found"}})}};var Dr=class{static reactionsListForTeamDiscussionCommentInOrg(r,e,n,s,u,_=30,m=1){return o(i,{method:"GET",url:"/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions",path:{org:r,team_slug:e,discussion_number:n,comment_number:s},query:{content:u,per_page:_,page:m}})}static reactionsCreateForTeamDiscussionCommentInOrg(r,e,n,s,u){return o(i,{method:"POST",url:"/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions",path:{org:r,team_slug:e,discussion_number:n,comment_number:s},body:u,mediaType:"application/json"})}static reactionsDeleteForTeamDiscussionComment(r,e,n,s,u){return o(i,{method:"DELETE",url:"/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions/{reaction_id}",path:{org:r,team_slug:e,discussion_number:n,comment_number:s,reaction_id:u}})}static reactionsListForTeamDiscussionInOrg(r,e,n,s,u=30,_=1){return o(i,{method:"GET",url:"/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions",path:{org:r,team_slug:e,discussion_number:n},query:{content:s,per_page:u,page:_}})}static reactionsCreateForTeamDiscussionInOrg(r,e,n,s){return o(i,{method:"POST",url:"/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions",path:{org:r,team_slug:e,discussion_number:n},body:s,mediaType:"application/json"})}static reactionsDeleteForTeamDiscussion(r,e,n,s){return o(i,{method:"DELETE",url:"/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions/{reaction_id}",path:{org:r,team_slug:e,discussion_number:n,reaction_id:s}})}static reactionsListForCommitComment(r,e,n,s,u=30,_=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/comments/{comment_id}/reactions",path:{owner:r,repo:e,comment_id:n},query:{content:s,per_page:u,page:_},errors:{404:"Resource not found"}})}static reactionsCreateForCommitComment(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/comments/{comment_id}/reactions",path:{owner:r,repo:e,comment_id:n},body:s,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static reactionsDeleteForCommitComment(r,e,n,s){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}",path:{owner:r,repo:e,comment_id:n,reaction_id:s}})}static reactionsListForIssueComment(r,e,n,s,u=30,_=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/issues/comments/{comment_id}/reactions",path:{owner:r,repo:e,comment_id:n},query:{content:s,per_page:u,page:_},errors:{404:"Resource not found"}})}static reactionsCreateForIssueComment(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/issues/comments/{comment_id}/reactions",path:{owner:r,repo:e,comment_id:n},body:s,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static reactionsDeleteForIssueComment(r,e,n,s){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}",path:{owner:r,repo:e,comment_id:n,reaction_id:s}})}static reactionsListForIssue(r,e,n,s,u=30,_=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/issues/{issue_number}/reactions",path:{owner:r,repo:e,issue_number:n},query:{content:s,per_page:u,page:_},errors:{404:"Resource not found",410:"Gone"}})}static reactionsCreateForIssue(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/issues/{issue_number}/reactions",path:{owner:r,repo:e,issue_number:n},body:s,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static reactionsDeleteForIssue(r,e,n,s){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}",path:{owner:r,repo:e,issue_number:n,reaction_id:s}})}static reactionsListForPullRequestReviewComment(r,e,n,s,u=30,_=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",path:{owner:r,repo:e,comment_id:n},query:{content:s,per_page:u,page:_},errors:{404:"Resource not found"}})}static reactionsCreateForPullRequestReviewComment(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",path:{owner:r,repo:e,comment_id:n},body:s,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static reactionsDeleteForPullRequestComment(r,e,n,s){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}",path:{owner:r,repo:e,comment_id:n,reaction_id:s}})}static reactionsListForRelease(r,e,n,s,u=30,_=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/releases/{release_id}/reactions",path:{owner:r,repo:e,release_id:n},query:{content:s,per_page:u,page:_},errors:{404:"Resource not found"}})}static reactionsCreateForRelease(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/releases/{release_id}/reactions",path:{owner:r,repo:e,release_id:n},body:s,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static reactionsDeleteForRelease(r,e,n,s){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/releases/{release_id}/reactions/{reaction_id}",path:{owner:r,repo:e,release_id:n,reaction_id:s}})}static reactionsListForTeamDiscussionCommentLegacy(r,e,n,s,u=30,_=1){return o(i,{method:"GET",url:"/teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}/reactions",path:{team_id:r,discussion_number:e,comment_number:n},query:{content:s,per_page:u,page:_}})}static reactionsCreateForTeamDiscussionCommentLegacy(r,e,n,s){return o(i,{method:"POST",url:"/teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}/reactions",path:{team_id:r,discussion_number:e,comment_number:n},body:s,mediaType:"application/json"})}static reactionsListForTeamDiscussionLegacy(r,e,n,s=30,u=1){return o(i,{method:"GET",url:"/teams/{team_id}/discussions/{discussion_number}/reactions",path:{team_id:r,discussion_number:e},query:{content:n,per_page:s,page:u}})}static reactionsCreateForTeamDiscussionLegacy(r,e,n){return o(i,{method:"POST",url:"/teams/{team_id}/discussions/{discussion_number}/reactions",path:{team_id:r,discussion_number:e},body:n,mediaType:"application/json"})}};var qr=class{static reposListForOrg(r,e="all",n="created",s,u=30,_=1){return o(i,{method:"GET",url:"/orgs/{org}/repos",path:{org:r},query:{type:e,sort:n,direction:s,per_page:u,page:_}})}static reposCreateInOrg(r,e){return o(i,{method:"POST",url:"/orgs/{org}/repos",path:{org:r},body:e,mediaType:"application/json",errors:{403:"Forbidden",422:"Validation failed, or the endpoint has been spammed."}})}static reposGetOrgRulesets(r,e=30,n=1){return o(i,{method:"GET",url:"/orgs/{org}/rulesets",path:{org:r},query:{per_page:e,page:n},errors:{404:"Resource not found",500:"Internal Error"}})}static reposCreateOrgRuleset(r,e){return o(i,{method:"POST",url:"/orgs/{org}/rulesets",path:{org:r},body:e,mediaType:"application/json",errors:{404:"Resource not found",500:"Internal Error"}})}static reposGetOrgRuleset(r,e){return o(i,{method:"GET",url:"/orgs/{org}/rulesets/{ruleset_id}",path:{org:r,ruleset_id:e},errors:{404:"Resource not found",500:"Internal Error"}})}static reposUpdateOrgRuleset(r,e,n){return o(i,{method:"PUT",url:"/orgs/{org}/rulesets/{ruleset_id}",path:{org:r,ruleset_id:e},body:n,mediaType:"application/json",errors:{404:"Resource not found",500:"Internal Error"}})}static reposDeleteOrgRuleset(r,e){return o(i,{method:"DELETE",url:"/orgs/{org}/rulesets/{ruleset_id}",path:{org:r,ruleset_id:e},errors:{404:"Resource not found",500:"Internal Error"}})}static reposGet(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}",path:{owner:r,repo:e},errors:{301:"Moved permanently",403:"Forbidden",404:"Resource not found"}})}static reposUpdate(r,e,n){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{307:"Temporary Redirect",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static reposDelete(r,e){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}",path:{owner:r,repo:e},errors:{307:"Temporary Redirect",403:"If an organization owner has configured the organization to prevent members from deleting organization-owned repositories, a member will get this response:",404:"Resource not found"}})}static reposListActivities(r,e,n="desc",s=30,u,_,m,c,d,v){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/activity",path:{owner:r,repo:e},query:{direction:n,per_page:s,before:u,after:_,ref:m,actor:c,time_period:d,activity_type:v},errors:{422:"Validation failed, or the endpoint has been spammed."}})}static reposListAutolinks(r,e,n=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/autolinks",path:{owner:r,repo:e},query:{page:n}})}static reposCreateAutolink(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/autolinks",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static reposGetAutolink(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/autolinks/{autolink_id}",path:{owner:r,repo:e,autolink_id:n},errors:{404:"Resource not found"}})}static reposDeleteAutolink(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/autolinks/{autolink_id}",path:{owner:r,repo:e,autolink_id:n},errors:{404:"Resource not found"}})}static reposCheckAutomatedSecurityFixes(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/automated-security-fixes",path:{owner:r,repo:e},errors:{404:"Not Found if dependabot is not enabled for the repository"}})}static reposEnableAutomatedSecurityFixes(r,e){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/automated-security-fixes",path:{owner:r,repo:e}})}static reposDisableAutomatedSecurityFixes(r,e){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/automated-security-fixes",path:{owner:r,repo:e}})}static reposListBranches(r,e,n,s=30,u=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/branches",path:{owner:r,repo:e},query:{protected:n,per_page:s,page:u},errors:{404:"Resource not found"}})}static reposGetBranch(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/branches/{branch}",path:{owner:r,repo:e,branch:n},errors:{301:"Moved permanently",404:"Resource not found"}})}static reposGetBranchProtection(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/branches/{branch}/protection",path:{owner:r,repo:e,branch:n},errors:{404:"Resource not found"}})}static reposUpdateBranchProtection(r,e,n,s){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/branches/{branch}/protection",path:{owner:r,repo:e,branch:n},body:s,mediaType:"application/json",errors:{403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static reposDeleteBranchProtection(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/branches/{branch}/protection",path:{owner:r,repo:e,branch:n},errors:{403:"Forbidden"}})}static reposGetAdminBranchProtection(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins",path:{owner:r,repo:e,branch:n}})}static reposSetAdminBranchProtection(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins",path:{owner:r,repo:e,branch:n}})}static reposDeleteAdminBranchProtection(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins",path:{owner:r,repo:e,branch:n},errors:{404:"Resource not found"}})}static reposGetPullRequestReviewProtection(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews",path:{owner:r,repo:e,branch:n}})}static reposUpdatePullRequestReviewProtection(r,e,n,s){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews",path:{owner:r,repo:e,branch:n},body:s,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static reposDeletePullRequestReviewProtection(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews",path:{owner:r,repo:e,branch:n},errors:{404:"Resource not found"}})}static reposGetCommitSignatureProtection(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/branches/{branch}/protection/required_signatures",path:{owner:r,repo:e,branch:n},errors:{404:"Resource not found"}})}static reposCreateCommitSignatureProtection(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/branches/{branch}/protection/required_signatures",path:{owner:r,repo:e,branch:n},errors:{404:"Resource not found"}})}static reposDeleteCommitSignatureProtection(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/branches/{branch}/protection/required_signatures",path:{owner:r,repo:e,branch:n},errors:{404:"Resource not found"}})}static reposGetStatusChecksProtection(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks",path:{owner:r,repo:e,branch:n},errors:{404:"Resource not found"}})}static reposUpdateStatusCheckProtection(r,e,n,s){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks",path:{owner:r,repo:e,branch:n},body:s,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static reposRemoveStatusCheckProtection(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks",path:{owner:r,repo:e,branch:n}})}static reposGetAllStatusCheckContexts(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts",path:{owner:r,repo:e,branch:n},errors:{404:"Resource not found"}})}static reposAddStatusCheckContexts(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts",path:{owner:r,repo:e,branch:n},body:s,mediaType:"application/json",errors:{403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static reposSetStatusCheckContexts(r,e,n,s){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts",path:{owner:r,repo:e,branch:n},body:s,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static reposRemoveStatusCheckContexts(r,e,n,s){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts",path:{owner:r,repo:e,branch:n},body:s,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static reposGetAccessRestrictions(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/branches/{branch}/protection/restrictions",path:{owner:r,repo:e,branch:n},errors:{404:"Resource not found"}})}static reposDeleteAccessRestrictions(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/branches/{branch}/protection/restrictions",path:{owner:r,repo:e,branch:n}})}static reposGetAppsWithAccessToProtectedBranch(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps",path:{owner:r,repo:e,branch:n},errors:{404:"Resource not found"}})}static reposAddAppAccessRestrictions(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps",path:{owner:r,repo:e,branch:n},body:s,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static reposSetAppAccessRestrictions(r,e,n,s){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps",path:{owner:r,repo:e,branch:n},body:s,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static reposRemoveAppAccessRestrictions(r,e,n,s){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps",path:{owner:r,repo:e,branch:n},body:s,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static reposGetTeamsWithAccessToProtectedBranch(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams",path:{owner:r,repo:e,branch:n},errors:{404:"Resource not found"}})}static reposAddTeamAccessRestrictions(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams",path:{owner:r,repo:e,branch:n},body:s,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static reposSetTeamAccessRestrictions(r,e,n,s){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams",path:{owner:r,repo:e,branch:n},body:s,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static reposRemoveTeamAccessRestrictions(r,e,n,s){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams",path:{owner:r,repo:e,branch:n},body:s,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static reposGetUsersWithAccessToProtectedBranch(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users",path:{owner:r,repo:e,branch:n},errors:{404:"Resource not found"}})}static reposAddUserAccessRestrictions(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users",path:{owner:r,repo:e,branch:n},body:s,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static reposSetUserAccessRestrictions(r,e,n,s){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users",path:{owner:r,repo:e,branch:n},body:s,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static reposRemoveUserAccessRestrictions(r,e,n,s){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users",path:{owner:r,repo:e,branch:n},body:s,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static reposRenameBranch(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/branches/{branch}/rename",path:{owner:r,repo:e,branch:n},body:s,mediaType:"application/json",errors:{403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static reposCodeownersErrors(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/codeowners/errors",path:{owner:r,repo:e},query:{ref:n},errors:{404:"Resource not found"}})}static reposListCollaborators(r,e,n="all",s,u=30,_=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/collaborators",path:{owner:r,repo:e},query:{affiliation:n,permission:s,per_page:u,page:_},errors:{404:"Resource not found"}})}static reposCheckCollaborator(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/collaborators/{username}",path:{owner:r,repo:e,username:n},errors:{404:"Not Found if user is not a collaborator"}})}static reposAddCollaborator(r,e,n,s){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/collaborators/{username}",path:{owner:r,repo:e,username:n},body:s,mediaType:"application/json",errors:{403:"Forbidden",422:"Validation failed, or the endpoint has been spammed."}})}static reposRemoveCollaborator(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/collaborators/{username}",path:{owner:r,repo:e,username:n},errors:{403:"Forbidden",422:"Validation failed, or the endpoint has been spammed."}})}static reposGetCollaboratorPermissionLevel(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/collaborators/{username}/permission",path:{owner:r,repo:e,username:n},errors:{404:"Resource not found"}})}static reposListCommitCommentsForRepo(r,e,n=30,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/comments",path:{owner:r,repo:e},query:{per_page:n,page:s}})}static reposGetCommitComment(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/comments/{comment_id}",path:{owner:r,repo:e,comment_id:n},errors:{404:"Resource not found"}})}static reposUpdateCommitComment(r,e,n,s){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/comments/{comment_id}",path:{owner:r,repo:e,comment_id:n},body:s,mediaType:"application/json",errors:{404:"Resource not found"}})}static reposDeleteCommitComment(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/comments/{comment_id}",path:{owner:r,repo:e,comment_id:n},errors:{404:"Resource not found"}})}static reposListCommits(r,e,n,s,u,_,m,c,d=30,v=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/commits",path:{owner:r,repo:e},query:{sha:n,path:s,author:u,committer:_,since:m,until:c,per_page:d,page:v},errors:{400:"Bad Request",404:"Resource not found",409:"Conflict",500:"Internal Error"}})}static reposListBranchesForHeadCommit(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head",path:{owner:r,repo:e,commit_sha:n},errors:{422:"Validation failed, or the endpoint has been spammed."}})}static reposListCommentsForCommit(r,e,n,s=30,u=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/commits/{commit_sha}/comments",path:{owner:r,repo:e,commit_sha:n},query:{per_page:s,page:u}})}static reposCreateCommitComment(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/commits/{commit_sha}/comments",path:{owner:r,repo:e,commit_sha:n},body:s,mediaType:"application/json",errors:{403:"Forbidden",422:"Validation failed, or the endpoint has been spammed."}})}static reposListPullRequestsAssociatedWithCommit(r,e,n,s=30,u=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/commits/{commit_sha}/pulls",path:{owner:r,repo:e,commit_sha:n},query:{per_page:s,page:u}})}static reposGetCommit(r,e,n,s=1,u=30){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/commits/{ref}",path:{owner:r,repo:e,ref:n},query:{page:s,per_page:u},errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed.",500:"Internal Error",503:"Service unavailable"}})}static reposGetCombinedStatusForRef(r,e,n,s=30,u=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/commits/{ref}/status",path:{owner:r,repo:e,ref:n},query:{per_page:s,page:u},errors:{404:"Resource not found"}})}static reposListCommitStatusesForRef(r,e,n,s=30,u=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/commits/{ref}/statuses",path:{owner:r,repo:e,ref:n},query:{per_page:s,page:u},errors:{301:"Moved permanently"}})}static reposGetCommunityProfileMetrics(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/community/profile",path:{owner:r,repo:e}})}static reposCompareCommits(r,e,n,s=1,u=30){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/compare/{basehead}",path:{owner:r,repo:e,basehead:n},query:{page:s,per_page:u},errors:{404:"Resource not found",500:"Internal Error",503:"Service unavailable"}})}static reposGetContent(r,e,n,s){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/contents/{path}",path:{owner:r,repo:e,path:n},query:{ref:s},errors:{302:"Found",403:"Forbidden",404:"Resource not found"}})}static reposCreateOrUpdateFileContents(r,e,n,s){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/contents/{path}",path:{owner:r,repo:e,path:n},body:s,mediaType:"application/json",errors:{404:"Resource not found",409:"Conflict",422:"Validation failed, or the endpoint has been spammed."}})}static reposDeleteFile(r,e,n,s){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/contents/{path}",path:{owner:r,repo:e,path:n},body:s,mediaType:"application/json",errors:{404:"Resource not found",409:"Conflict",422:"Validation failed, or the endpoint has been spammed.",503:"Service unavailable"}})}static reposListContributors(r,e,n,s=30,u=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/contributors",path:{owner:r,repo:e},query:{anon:n,per_page:s,page:u},errors:{403:"Forbidden",404:"Resource not found"}})}static reposListDeployments(r,e,n="none",s="none",u="none",_="none",m=30,c=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/deployments",path:{owner:r,repo:e},query:{sha:n,ref:s,task:u,environment:_,per_page:m,page:c}})}static reposCreateDeployment(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/deployments",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{409:"Conflict when there is a merge conflict or the commit's status checks failed",422:"Validation failed, or the endpoint has been spammed."}})}static reposGetDeployment(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/deployments/{deployment_id}",path:{owner:r,repo:e,deployment_id:n},errors:{404:"Resource not found"}})}static reposDeleteDeployment(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/deployments/{deployment_id}",path:{owner:r,repo:e,deployment_id:n},errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static reposListDeploymentStatuses(r,e,n,s=30,u=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/deployments/{deployment_id}/statuses",path:{owner:r,repo:e,deployment_id:n},query:{per_page:s,page:u},errors:{404:"Resource not found"}})}static reposCreateDeploymentStatus(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/deployments/{deployment_id}/statuses",path:{owner:r,repo:e,deployment_id:n},body:s,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static reposGetDeploymentStatus(r,e,n,s){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/deployments/{deployment_id}/statuses/{status_id}",path:{owner:r,repo:e,deployment_id:n,status_id:s},errors:{404:"Resource not found"}})}static reposCreateDispatchEvent(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/dispatches",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static reposGetAllEnvironments(r,e,n=30,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/environments",path:{owner:r,repo:e},query:{per_page:n,page:s}})}static reposGetEnvironment(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/environments/{environment_name}",path:{owner:r,repo:e,environment_name:n}})}static reposCreateOrUpdateEnvironment(r,e,n,s){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/environments/{environment_name}",path:{owner:r,repo:e,environment_name:n},body:s,mediaType:"application/json",errors:{422:"Validation error when the environment name is invalid or when `protected_branches` and `custom_branch_policies` in `deployment_branch_policy` are set to the same value"}})}static reposDeleteAnEnvironment(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/environments/{environment_name}",path:{owner:r,repo:e,environment_name:n}})}static reposListDeploymentBranchPolicies(r,e,n,s=30,u=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/environments/{environment_name}/deployment-branch-policies",path:{owner:r,repo:e,environment_name:n},query:{per_page:s,page:u}})}static reposCreateDeploymentBranchPolicy(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/environments/{environment_name}/deployment-branch-policies",path:{owner:r,repo:e,environment_name:n},body:s,mediaType:"application/json",errors:{303:"Response if the same branch name pattern already exists",404:"Not Found or `deployment_branch_policy.custom_branch_policies` property for the environment is set to false"}})}static reposGetDeploymentBranchPolicy(r,e,n,s){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/environments/{environment_name}/deployment-branch-policies/{branch_policy_id}",path:{owner:r,repo:e,environment_name:n,branch_policy_id:s}})}static reposUpdateDeploymentBranchPolicy(r,e,n,s,u){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/environments/{environment_name}/deployment-branch-policies/{branch_policy_id}",path:{owner:r,repo:e,environment_name:n,branch_policy_id:s},body:u,mediaType:"application/json"})}static reposDeleteDeploymentBranchPolicy(r,e,n,s){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/environments/{environment_name}/deployment-branch-policies/{branch_policy_id}",path:{owner:r,repo:e,environment_name:n,branch_policy_id:s}})}static reposGetAllDeploymentProtectionRules(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/environments/{environment_name}/deployment_protection_rules",path:{environment_name:r,repo:e,owner:n}})}static reposCreateDeploymentProtectionRule(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/environments/{environment_name}/deployment_protection_rules",path:{environment_name:r,repo:e,owner:n},body:s,mediaType:"application/json"})}static reposListCustomDeploymentRuleIntegrations(r,e,n,s=1,u=30){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/environments/{environment_name}/deployment_protection_rules/apps",path:{environment_name:r,repo:e,owner:n},query:{page:s,per_page:u}})}static reposGetCustomDeploymentProtectionRule(r,e,n,s){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/environments/{environment_name}/deployment_protection_rules/{protection_rule_id}",path:{owner:r,repo:e,environment_name:n,protection_rule_id:s}})}static reposDisableDeploymentProtectionRule(r,e,n,s){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/environments/{environment_name}/deployment_protection_rules/{protection_rule_id}",path:{environment_name:r,repo:e,owner:n,protection_rule_id:s}})}static reposListForks(r,e,n="newest",s=30,u=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/forks",path:{owner:r,repo:e},query:{sort:n,per_page:s,page:u},errors:{400:"Bad Request"}})}static reposCreateFork(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/forks",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{400:"Bad Request",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static reposListWebhooks(r,e,n=30,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/hooks",path:{owner:r,repo:e},query:{per_page:n,page:s},errors:{404:"Resource not found"}})}static reposCreateWebhook(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/hooks",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static reposGetWebhook(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/hooks/{hook_id}",path:{owner:r,repo:e,hook_id:n},errors:{404:"Resource not found"}})}static reposUpdateWebhook(r,e,n,s){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/hooks/{hook_id}",path:{owner:r,repo:e,hook_id:n},body:s,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static reposDeleteWebhook(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/hooks/{hook_id}",path:{owner:r,repo:e,hook_id:n},errors:{404:"Resource not found"}})}static reposGetWebhookConfigForRepo(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/hooks/{hook_id}/config",path:{owner:r,repo:e,hook_id:n}})}static reposUpdateWebhookConfigForRepo(r,e,n,s){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/hooks/{hook_id}/config",path:{owner:r,repo:e,hook_id:n},body:s,mediaType:"application/json"})}static reposListWebhookDeliveries(r,e,n,s=30,u,_){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/hooks/{hook_id}/deliveries",path:{owner:r,repo:e,hook_id:n},query:{per_page:s,cursor:u,redelivery:_},errors:{400:"Bad Request",422:"Validation failed, or the endpoint has been spammed."}})}static reposGetWebhookDelivery(r,e,n,s){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/hooks/{hook_id}/deliveries/{delivery_id}",path:{owner:r,repo:e,hook_id:n,delivery_id:s},errors:{400:"Bad Request",422:"Validation failed, or the endpoint has been spammed."}})}static reposRedeliverWebhookDelivery(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/hooks/{hook_id}/deliveries/{delivery_id}/attempts",path:{owner:r,repo:e,hook_id:n,delivery_id:s},errors:{400:"Bad Request",422:"Validation failed, or the endpoint has been spammed."}})}static reposPingWebhook(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/hooks/{hook_id}/pings",path:{owner:r,repo:e,hook_id:n},errors:{404:"Resource not found"}})}static reposTestPushWebhook(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/hooks/{hook_id}/tests",path:{owner:r,repo:e,hook_id:n},errors:{404:"Resource not found"}})}static reposListInvitations(r,e,n=30,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/invitations",path:{owner:r,repo:e},query:{per_page:n,page:s}})}static reposUpdateInvitation(r,e,n,s){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/invitations/{invitation_id}",path:{owner:r,repo:e,invitation_id:n},body:s,mediaType:"application/json"})}static reposDeleteInvitation(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/invitations/{invitation_id}",path:{owner:r,repo:e,invitation_id:n}})}static reposListDeployKeys(r,e,n=30,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/keys",path:{owner:r,repo:e},query:{per_page:n,page:s}})}static reposCreateDeployKey(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/keys",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{422:"Validation failed, or the endpoint has been spammed."}})}static reposGetDeployKey(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/keys/{key_id}",path:{owner:r,repo:e,key_id:n},errors:{404:"Resource not found"}})}static reposDeleteDeployKey(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/keys/{key_id}",path:{owner:r,repo:e,key_id:n}})}static reposListLanguages(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/languages",path:{owner:r,repo:e}})}static reposEnableLfsForRepo(r,e){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/lfs",path:{owner:r,repo:e},errors:{403:`We will return a 403 with one of the following messages:
+var J = class extends Error {
+  url;
+  status;
+  statusText;
+  body;
+  request;
+  constructor(r, e, n) {
+    super(n),
+      (this.name = "ApiError"),
+      (this.url = e.url),
+      (this.status = e.status),
+      (this.statusText = e.statusText),
+      (this.body = e.body),
+      (this.request = r);
+  }
+};
+var tr = class extends Error {
+    constructor(r) {
+      super(r), (this.name = "CancelError");
+    }
+    get isCancelled() {
+      return !0;
+    }
+  },
+  rr = class {
+    #e;
+    #t;
+    #r;
+    #n;
+    #s;
+    #o;
+    #i;
+    constructor(r) {
+      (this.#e = !1),
+        (this.#t = !1),
+        (this.#r = !1),
+        (this.#n = []),
+        (this.#s = new Promise((e, n) => {
+          (this.#o = e), (this.#i = n);
+          let s = (m) => {
+              this.#e || this.#t || this.#r || ((this.#e = !0), this.#o?.(m));
+            },
+            u = (m) => {
+              this.#e || this.#t || this.#r || ((this.#t = !0), this.#i?.(m));
+            },
+            _ = (m) => {
+              this.#e || this.#t || this.#r || this.#n.push(m);
+            };
+          return (
+            Object.defineProperty(_, "isResolved", { get: () => this.#e }),
+            Object.defineProperty(_, "isRejected", { get: () => this.#t }),
+            Object.defineProperty(_, "isCancelled", { get: () => this.#r }),
+            r(s, u, _)
+          );
+        }));
+    }
+    get [Symbol.toStringTag]() {
+      return "Cancellable Promise";
+    }
+    then(r, e) {
+      return this.#s.then(r, e);
+    }
+    catch(r) {
+      return this.#s.catch(r);
+    }
+    finally(r) {
+      return this.#s.finally(r);
+    }
+    cancel() {
+      if (!(this.#e || this.#t || this.#r)) {
+        if (((this.#r = !0), this.#n.length))
+          try {
+            for (let r of this.#n) r();
+          } catch (r) {
+            console.warn("Cancellation threw an error", r);
+            return;
+          }
+        (this.#n.length = 0), this.#i?.(new tr("Request aborted"));
+      }
+    }
+    get isCancelled() {
+      return this.#r;
+    }
+  };
+var i = {
+  BASE: "https://api.github.com",
+  VERSION: "1.1.4",
+  WITH_CREDENTIALS: !1,
+  CREDENTIALS: "include",
+  TOKEN: void 0,
+  USERNAME: void 0,
+  PASSWORD: void 0,
+  HEADERS: void 0,
+  ENCODE_PATH: void 0,
+};
+var Br;
+((r) => {
+  let l;
+  ((I) => (
+    (I.AUTH = "auth"),
+    (I.ERROR = "error"),
+    (I.NONE = "none"),
+    (I.DETECTING = "detecting"),
+    (I.CHOOSE = "choose"),
+    (I.AUTH_FAILED = "auth_failed"),
+    (I.IMPORTING = "importing"),
+    (I.MAPPING = "mapping"),
+    (I.WAITING_TO_PUSH = "waiting_to_push"),
+    (I.PUSHING = "pushing"),
+    (I.COMPLETE = "complete"),
+    (I.SETUP = "setup"),
+    (I.UNKNOWN = "unknown"),
+    (I.DETECTION_FOUND_MULTIPLE = "detection_found_multiple"),
+    (I.DETECTION_FOUND_NOTHING = "detection_found_nothing"),
+    (I.DETECTION_NEEDS_AUTH = "detection_needs_auth")
+  ))((l = r.status ||= {}));
+})((Br ||= {}));
+var Wr;
+((e) => {
+  let l;
+  ((d) => (
+    (d.NPM = "npm"),
+    (d.MAVEN = "maven"),
+    (d.RUBYGEMS = "rubygems"),
+    (d.DOCKER = "docker"),
+    (d.NUGET = "nuget"),
+    (d.CONTAINER = "container")
+  ))((l = e.package_type ||= {}));
+  let r;
+  ((u) => ((u.PRIVATE = "private"), (u.PUBLIC = "public")))((r = e.visibility ||= {}));
+})((Wr ||= {}));
+var Fr = ((n) => (
+  (n.CREATED_AT = "created_at"), (n.LAST_ACCESSED_AT = "last_accessed_at"), (n.SIZE_IN_BYTES = "size_in_bytes"), n
+))(Fr || {});
+var jr = ((e) => ((e.READ = "read"), (e.WRITE = "write"), e))(jr || {});
+var Vr;
+((r) => {
+  let l;
+  ((u) => ((u.NONE = "none"), (u.USER = "user"), (u.ORGANIZATION = "organization")))((l = r.access_level ||= {}));
+})((Vr ||= {}));
+var Hr;
+((r) => {
+  let l;
+  ((c) => (
+    (c.PUSH = "push"),
+    (c.FORCE_PUSH = "force_push"),
+    (c.BRANCH_DELETION = "branch_deletion"),
+    (c.BRANCH_CREATION = "branch_creation"),
+    (c.PR_MERGE = "pr_merge"),
+    (c.MERGE_QUEUE_MERGE = "merge_queue_merge")
+  ))((l = r.activity_type ||= {}));
+})((Hr ||= {}));
+var Qr = ((n) => ((n.ALL = "all"), (n.LOCAL_ONLY = "local_only"), (n.SELECTED = "selected"), n))(Qr || {});
+var Kr;
+((z) => {
+  let l;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((l = z.actions ||= {}));
+  let r;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((r = z.administration ||= {}));
+  let e;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((e = z.checks ||= {}));
+  let n;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((n = z.contents ||= {}));
+  let s;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((s = z.deployments ||= {}));
+  let u;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((u = z.environments ||= {}));
+  let _;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((_ = z.issues ||= {}));
+  let m;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((m = z.metadata ||= {}));
+  let c;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((c = z.packages ||= {}));
+  let d;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((d = z.pages ||= {}));
+  let v;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((v = z.pull_requests ||= {}));
+  let h;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((h = z.repository_hooks ||= {}));
+  let R;
+  ((q) => ((q.READ = "read"), (q.WRITE = "write"), (q.ADMIN = "admin")))((R = z.repository_projects ||= {}));
+  let k;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((k = z.secret_scanning_alerts ||= {}));
+  let b;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((b = z.secrets ||= {}));
+  let p;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((p = z.security_events ||= {}));
+  let f;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((f = z.single_file ||= {}));
+  let O;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((O = z.statuses ||= {}));
+  let I;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((I = z.vulnerability_alerts ||= {}));
+  let P;
+  ((S) => (S.WRITE = "write"))((P = z.workflows ||= {}));
+  let E;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((E = z.members ||= {}));
+  let D;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((D = z.organization_administration ||= {}));
+  let L;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((L = z.organization_custom_roles ||= {}));
+  let C;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((C = z.organization_announcement_banners ||= {}));
+  let U;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((U = z.organization_hooks ||= {}));
+  let M;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((M = z.organization_personal_access_tokens ||= {}));
+  let G;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((G = z.organization_personal_access_token_requests ||= {}));
+  let B;
+  ((S) => (S.READ = "read"))((B = z.organization_plan ||= {}));
+  let W;
+  ((q) => ((q.READ = "read"), (q.WRITE = "write"), (q.ADMIN = "admin")))((W = z.organization_projects ||= {}));
+  let F;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((F = z.organization_packages ||= {}));
+  let j;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((j = z.organization_secrets ||= {}));
+  let V;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((V = z.organization_self_hosted_runners ||= {}));
+  let H;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((H = z.organization_user_blocking ||= {}));
+  let Q;
+  ((x) => ((x.READ = "read"), (x.WRITE = "write")))((Q = z.team_discussions ||= {}));
+})((Kr ||= {}));
+var Yr;
+((r) => {
+  let l;
+  ((s) => ((s.ALL = "all"), (s.SELECTED = "selected")))((l = r.repository_selection ||= {}));
+})((Yr ||= {}));
+var Zr = ((c) => (
+  (c.COLLABORATOR = "COLLABORATOR"),
+  (c.CONTRIBUTOR = "CONTRIBUTOR"),
+  (c.FIRST_TIMER = "FIRST_TIMER"),
+  (c.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+  (c.MANNEQUIN = "MANNEQUIN"),
+  (c.MEMBER = "MEMBER"),
+  (c.NONE = "NONE"),
+  (c.OWNER = "OWNER"),
+  c
+))(Zr || {});
+var Xr;
+((r) => {
+  let l;
+  ((u) => ((u.MERGE = "merge"), (u.SQUASH = "squash"), (u.REBASE = "rebase")))((l = r.merge_method ||= {}));
+})((Xr ||= {}));
+var $r;
+((e) => {
+  let l;
+  ((_) => ((_.QUEUED = "queued"), (_.IN_PROGRESS = "in_progress"), (_.COMPLETED = "completed")))((l = e.status ||= {}));
+  let r;
+  ((v) => (
+    (v.SUCCESS = "success"),
+    (v.FAILURE = "failure"),
+    (v.NEUTRAL = "neutral"),
+    (v.CANCELLED = "cancelled"),
+    (v.SKIPPED = "skipped"),
+    (v.TIMED_OUT = "timed_out"),
+    (v.ACTION_REQUIRED = "action_required")
+  ))((r = e.conclusion ||= {}));
+})(($r ||= {}));
+var Jr;
+((e) => {
+  let l;
+  ((b) => (
+    (b.WAITING = "waiting"),
+    (b.PENDING = "pending"),
+    (b.STARTUP_FAILURE = "startup_failure"),
+    (b.STALE = "stale"),
+    (b.SUCCESS = "success"),
+    (b.FAILURE = "failure"),
+    (b.NEUTRAL = "neutral"),
+    (b.CANCELLED = "cancelled"),
+    (b.SKIPPED = "skipped"),
+    (b.TIMED_OUT = "timed_out"),
+    (b.ACTION_REQUIRED = "action_required")
+  ))((l = e.conclusion ||= {}));
+  let r;
+  ((m) => (
+    (m.QUEUED = "queued"), (m.IN_PROGRESS = "in_progress"), (m.COMPLETED = "completed"), (m.PENDING = "pending")
+  ))((r = e.status ||= {}));
+})((Jr ||= {}));
+var re;
+((e) => {
+  let l;
+  ((_) => ((_.QUEUED = "queued"), (_.IN_PROGRESS = "in_progress"), (_.COMPLETED = "completed")))((l = e.status ||= {}));
+  let r;
+  ((R) => (
+    (R.SUCCESS = "success"),
+    (R.FAILURE = "failure"),
+    (R.NEUTRAL = "neutral"),
+    (R.CANCELLED = "cancelled"),
+    (R.SKIPPED = "skipped"),
+    (R.TIMED_OUT = "timed_out"),
+    (R.ACTION_REQUIRED = "action_required"),
+    (R.STARTUP_FAILURE = "startup_failure"),
+    (R.STALE = "stale")
+  ))((r = e.conclusion ||= {}));
+})((re ||= {}));
+var ee = ((s) => ((s.SOURCE = "source"), (s.GENERATED = "generated"), (s.TEST = "test"), (s.LIBRARY = "library"), s))(
+  ee || {},
+);
+var te = ((n) => (
+  (n.FALSE_POSITIVE = "false positive"), (n.WON_T_FIX = "won't fix"), (n.USED_IN_TESTS = "used in tests"), n
+))(te || {});
+var ne;
+((e) => {
+  let l;
+  ((m) => ((m.NONE = "none"), (m.NOTE = "note"), (m.WARNING = "warning"), (m.ERROR = "error")))(
+    (l = e.severity ||= {}),
+  );
+  let r;
+  ((m) => ((m.LOW = "low"), (m.MEDIUM = "medium"), (m.HIGH = "high"), (m.CRITICAL = "critical")))(
+    (r = e.security_severity_level ||= {}),
+  );
+})((ne ||= {}));
+var se;
+((r) => {
+  let l;
+  ((_) => ((_.NONE = "none"), (_.NOTE = "note"), (_.WARNING = "warning"), (_.ERROR = "error")))(
+    (l = r.severity ||= {}),
+  );
+})((se ||= {}));
+var ie = ((e) => ((e.OPEN = "open"), (e.DISMISSED = "dismissed"), e))(ie || {});
+var oe = ((m) => (
+  (m.CRITICAL = "critical"),
+  (m.HIGH = "high"),
+  (m.MEDIUM = "medium"),
+  (m.LOW = "low"),
+  (m.WARNING = "warning"),
+  (m.NOTE = "note"),
+  (m.ERROR = "error"),
+  m
+))(oe || {});
+var le = ((n) => ((n.OPEN = "open"), (n.DISMISSED = "dismissed"), (n.FIXED = "fixed"), n))(le || {});
+var ae = ((s) => ((s.OPEN = "open"), (s.CLOSED = "closed"), (s.DISMISSED = "dismissed"), (s.FIXED = "fixed"), s))(
+  ae || {},
+);
+var ue;
+((e) => {
+  let l;
+  ((u) => ((u.CONFIGURED = "configured"), (u.NOT_CONFIGURED = "not-configured")))((l = e.state ||= {}));
+  let r;
+  ((u) => ((u.DEFAULT = "default"), (u.EXTENDED = "extended")))((r = e.query_suite ||= {}));
+})((ue ||= {}));
+var _e;
+((e) => {
+  let l;
+  ((u) => ((u.CONFIGURED = "configured"), (u.NOT_CONFIGURED = "not-configured")))((l = e.state ||= {}));
+  let r;
+  ((u) => ((u.DEFAULT = "default"), (u.EXTENDED = "extended")))((r = e.query_suite ||= {}));
+})((_e ||= {}));
+var ge;
+((r) => {
+  let l;
+  ((u) => ((u.PENDING = "pending"), (u.COMPLETE = "complete"), (u.FAILED = "failed")))(
+    (l = r.processing_status ||= {}),
+  );
+})((ge ||= {}));
+var me;
+((e) => {
+  let l;
+  ((E) => (
+    (E.UNKNOWN = "Unknown"),
+    (E.CREATED = "Created"),
+    (E.QUEUED = "Queued"),
+    (E.PROVISIONING = "Provisioning"),
+    (E.AVAILABLE = "Available"),
+    (E.AWAITING = "Awaiting"),
+    (E.UNAVAILABLE = "Unavailable"),
+    (E.DELETED = "Deleted"),
+    (E.MOVED = "Moved"),
+    (E.SHUTDOWN = "Shutdown"),
+    (E.ARCHIVED = "Archived"),
+    (E.STARTING = "Starting"),
+    (E.SHUTTING_DOWN = "ShuttingDown"),
+    (E.FAILED = "Failed"),
+    (E.EXPORTING = "Exporting"),
+    (E.UPDATING = "Updating"),
+    (E.REBUILDING = "Rebuilding")
+  ))((l = e.state ||= {}));
+  let r;
+  ((m) => (
+    (m.EAST_US = "EastUs"),
+    (m.SOUTH_EAST_ASIA = "SouthEastAsia"),
+    (m.WEST_EUROPE = "WestEurope"),
+    (m.WEST_US2 = "WestUs2")
+  ))((r = e.location ||= {}));
+})((me ||= {}));
+var pe;
+((r) => {
+  let l;
+  ((u) => ((u.NONE = "none"), (u.READY = "ready"), (u.IN_PROGRESS = "in_progress")))(
+    (l = r.prebuild_availability ||= {}),
+  );
+})((pe ||= {}));
+var de;
+((e) => {
+  let l;
+  ((E) => (
+    (E.UNKNOWN = "Unknown"),
+    (E.CREATED = "Created"),
+    (E.QUEUED = "Queued"),
+    (E.PROVISIONING = "Provisioning"),
+    (E.AVAILABLE = "Available"),
+    (E.AWAITING = "Awaiting"),
+    (E.UNAVAILABLE = "Unavailable"),
+    (E.DELETED = "Deleted"),
+    (E.MOVED = "Moved"),
+    (E.SHUTDOWN = "Shutdown"),
+    (E.ARCHIVED = "Archived"),
+    (E.STARTING = "Starting"),
+    (E.SHUTTING_DOWN = "ShuttingDown"),
+    (E.FAILED = "Failed"),
+    (E.EXPORTING = "Exporting"),
+    (E.UPDATING = "Updating"),
+    (E.REBUILDING = "Rebuilding")
+  ))((l = e.state ||= {}));
+  let r;
+  ((m) => (
+    (m.EAST_US = "EastUs"),
+    (m.SOUTH_EAST_ASIA = "SouthEastAsia"),
+    (m.WEST_EUROPE = "WestEurope"),
+    (m.WEST_US2 = "WestUs2")
+  ))((r = e.location ||= {}));
+})((de ||= {}));
+var ce;
+((r) => {
+  let l;
+  ((u) => ((u.ALL = "all"), (u.PRIVATE = "private"), (u.SELECTED = "selected")))((l = r.visibility ||= {}));
+})((ce ||= {}));
+var be;
+((r) => {
+  let l;
+  ((u) => ((u.ALL = "all"), (u.PRIVATE = "private"), (u.SELECTED = "selected")))((l = r.visibility ||= {}));
+})((be ||= {}));
+var he;
+((r) => {
+  let l;
+  ((_) => ((_.DIVERGED = "diverged"), (_.AHEAD = "ahead"), (_.BEHIND = "behind"), (_.IDENTICAL = "identical")))(
+    (l = r.status ||= {}),
+  );
+})((he ||= {}));
+var ye;
+((r) => {
+  let l;
+  ((n) => (n.FILE = "file"))((l = r.type ||= {}));
+})((ye ||= {}));
+var fe;
+((r) => {
+  let l;
+  ((n) => (n.SUBMODULE = "submodule"))((l = r.type ||= {}));
+})((fe ||= {}));
+var we;
+((r) => {
+  let l;
+  ((n) => (n.SYMLINK = "symlink"))((l = r.type ||= {}));
+})((we ||= {}));
+var Ee;
+((n) => {
+  let l;
+  ((c) => ((c.AUTO_DISMISSED = "auto_dismissed"), (c.DISMISSED = "dismissed"), (c.FIXED = "fixed"), (c.OPEN = "open")))(
+    (l = n.state ||= {}),
+  );
+  let r;
+  ((_) => ((_.DEVELOPMENT = "development"), (_.RUNTIME = "runtime")))((r = n.scope ||= {}));
+  let e;
+  ((d) => (
+    (d.FIX_STARTED = "fix_started"),
+    (d.INACCURATE = "inaccurate"),
+    (d.NO_BANDWIDTH = "no_bandwidth"),
+    (d.NOT_USED = "not_used"),
+    (d.TOLERABLE_RISK = "tolerable_risk")
+  ))((e = n.dismissed_reason ||= {}));
+})((Ee ||= {}));
+var ve = ((e) => ((e.DEVELOPMENT = "development"), (e.RUNTIME = "runtime"), e))(ve || {});
+var Re;
+((r) => {
+  let l;
+  ((_) => ((_.LOW = "low"), (_.MEDIUM = "medium"), (_.HIGH = "high"), (_.CRITICAL = "critical")))(
+    (l = r.severity ||= {}),
+  );
+})((Re ||= {}));
+var Te;
+((r) => {
+  let l;
+  ((_) => ((_.LOW = "low"), (_.MEDIUM = "medium"), (_.HIGH = "high"), (_.CRITICAL = "critical")))(
+    (l = r.severity ||= {}),
+  );
+})((Te ||= {}));
+var Ae = ((e) => ((e.CREATED = "created"), (e.UPDATED = "updated"), e))(Ae || {});
+var ke;
+((n) => {
+  let l;
+  ((c) => ((c.AUTO_DISMISSED = "auto_dismissed"), (c.DISMISSED = "dismissed"), (c.FIXED = "fixed"), (c.OPEN = "open")))(
+    (l = n.state ||= {}),
+  );
+  let r;
+  ((_) => ((_.DEVELOPMENT = "development"), (_.RUNTIME = "runtime")))((r = n.scope ||= {}));
+  let e;
+  ((d) => (
+    (d.FIX_STARTED = "fix_started"),
+    (d.INACCURATE = "inaccurate"),
+    (d.NO_BANDWIDTH = "no_bandwidth"),
+    (d.NOT_USED = "not_used"),
+    (d.TOLERABLE_RISK = "tolerable_risk")
+  ))((e = n.dismissed_reason ||= {}));
+})((ke ||= {}));
+var xe;
+((e) => {
+  let l;
+  ((u) => ((u.DIRECT = "direct"), (u.INDIRECT = "indirect")))((l = e.relationship ||= {}));
+  let r;
+  ((u) => ((u.RUNTIME = "runtime"), (u.DEVELOPMENT = "development")))((r = e.scope ||= {}));
+})((xe ||= {}));
+var Ie = ((e) => ((e.USER = "User"), (e.TEAM = "Team"), e))(Ie || {});
+var Oe;
+((r) => {
+  let l;
+  ((d) => (
+    (d.ERROR = "error"),
+    (d.FAILURE = "failure"),
+    (d.INACTIVE = "inactive"),
+    (d.PENDING = "pending"),
+    (d.SUCCESS = "success"),
+    (d.QUEUED = "queued"),
+    (d.IN_PROGRESS = "in_progress")
+  ))((l = r.state ||= {}));
+})((Oe ||= {}));
+var Ne;
+((r) => {
+  let l;
+  ((d) => (
+    (d.ADDED = "added"),
+    (d.REMOVED = "removed"),
+    (d.MODIFIED = "modified"),
+    (d.RENAMED = "renamed"),
+    (d.COPIED = "copied"),
+    (d.CHANGED = "changed"),
+    (d.UNCHANGED = "unchanged")
+  ))((l = r.status ||= {}));
+})((Ne ||= {}));
+var ze = ((e) => ((e.ASC = "asc"), (e.DESC = "desc"), e))(ze || {});
+var Pe;
+((s) => {
+  let l;
+  ((c) => ((c.BOT = "Bot"), (c.USER = "User"), (c.ORGANIZATION = "Organization")))((l = s.type ||= {}));
+  let r;
+  ((k) => (
+    (k.COLLABORATOR = "COLLABORATOR"),
+    (k.CONTRIBUTOR = "CONTRIBUTOR"),
+    (k.FIRST_TIMER = "FIRST_TIMER"),
+    (k.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (k.MANNEQUIN = "MANNEQUIN"),
+    (k.MEMBER = "MEMBER"),
+    (k.NONE = "NONE"),
+    (k.OWNER = "OWNER")
+  ))((r = s.author_association ||= {}));
+  let e;
+  ((v) => (
+    (v.OPEN = "open"),
+    (v.CLOSED = "closed"),
+    (v.LOCKED = "locked"),
+    (v.CONVERTING = "converting"),
+    (v.TRANSFERRING = "transferring")
+  ))((e = s.state ||= {}));
+  let n;
+  ((d) => (
+    (d.RESOLVED = "resolved"), (d.OUTDATED = "outdated"), (d.DUPLICATE = "duplicate"), (d.REOPENED = "reopened")
+  ))((n = s.state_reason ||= {}));
+})((Pe ||= {}));
+var Ce = ((n) => ((n.ALL = "all"), (n.NONE = "none"), (n.SELECTED = "selected"), n))(Ce || {});
+var De;
+((r) => {
+  let l;
+  ((u) => ((u.APPROVED = "approved"), (u.REJECTED = "rejected"), (u.PENDING = "pending")))((l = r.state ||= {}));
+})((De ||= {}));
+var qe;
+((s) => {
+  let l;
+  ((m) => ((m.PR_TITLE = "PR_TITLE"), (m.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (l = s.squash_merge_commit_title ||= {}),
+  );
+  let r;
+  ((c) => ((c.PR_BODY = "PR_BODY"), (c.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (c.BLANK = "BLANK")))(
+    (r = s.squash_merge_commit_message ||= {}),
+  );
+  let e;
+  ((m) => ((m.PR_TITLE = "PR_TITLE"), (m.MERGE_MESSAGE = "MERGE_MESSAGE")))((e = s.merge_commit_title ||= {}));
+  let n;
+  ((c) => ((c.PR_BODY = "PR_BODY"), (c.PR_TITLE = "PR_TITLE"), (c.BLANK = "BLANK")))(
+    (n = s.merge_commit_message ||= {}),
+  );
+})((qe ||= {}));
+var Se;
+((e) => {
+  let l;
+  ((_) => ((_.REVIEWED = "reviewed"), (_.UNREVIEWED = "unreviewed"), (_.MALWARE = "malware")))((l = e.type ||= {}));
+  let r;
+  ((c) => (
+    (c.CRITICAL = "critical"), (c.HIGH = "high"), (c.MEDIUM = "medium"), (c.LOW = "low"), (c.UNKNOWN = "unknown")
+  ))((r = e.severity ||= {}));
+})((Se ||= {}));
+var Le;
+((r) => {
+  let l;
+  ((s) => ((s.ALL = "all"), (s.SELECTED = "selected")))((l = r.repository_selection ||= {}));
+})((Le ||= {}));
+var Ue;
+((r) => {
+  let l;
+  ((s) => ((s.ALL = "all"), (s.SELECTED = "selected")))((l = r.repository_selection ||= {}));
+})((Ue ||= {}));
+var Me = ((u) => (
+  (u.ONE_DAY = "one_day"),
+  (u.THREE_DAYS = "three_days"),
+  (u.ONE_WEEK = "one_week"),
+  (u.ONE_MONTH = "one_month"),
+  (u.SIX_MONTHS = "six_months"),
+  u
+))(Me || {});
+var Ge = ((n) => (
+  (n.EXISTING_USERS = "existing_users"),
+  (n.CONTRIBUTORS_ONLY = "contributors_only"),
+  (n.COLLABORATORS_ONLY = "collaborators_only"),
+  n
+))(Ge || {});
+var Be;
+((r) => {
+  let l;
+  ((u) => ((u.COMPLETED = "completed"), (u.REOPENED = "reopened"), (u.NOT_PLANNED = "not_planned")))(
+    (l = r.state_reason ||= {}),
+  );
+})((Be ||= {}));
+var We;
+((e) => {
+  let l;
+  ((_) => ((_.QUEUED = "queued"), (_.IN_PROGRESS = "in_progress"), (_.COMPLETED = "completed")))((l = e.status ||= {}));
+  let r;
+  ((v) => (
+    (v.SUCCESS = "success"),
+    (v.FAILURE = "failure"),
+    (v.NEUTRAL = "neutral"),
+    (v.CANCELLED = "cancelled"),
+    (v.SKIPPED = "skipped"),
+    (v.TIMED_OUT = "timed_out"),
+    (v.ACTION_REQUIRED = "action_required")
+  ))((r = e.conclusion ||= {}));
+})((We ||= {}));
+var Fe;
+((r) => {
+  let l;
+  ((u) => ((u.FREE = "FREE"), (u.FLAT_RATE = "FLAT_RATE"), (u.PER_UNIT = "PER_UNIT")))((l = r.price_model ||= {}));
+})((Fe ||= {}));
+var je;
+((r) => {
+  let l;
+  ((u) => ((u.MERGE = "merge"), (u.FAST_FORWARD = "fast-forward"), (u.NONE = "none")))((l = r.merge_type ||= {}));
+})((je ||= {}));
+var Ve;
+((r) => {
+  let l;
+  ((s) => ((s.OPEN = "open"), (s.CLOSED = "closed")))((l = r.state ||= {}));
+})((Ve ||= {}));
+var He;
+((r) => {
+  let l;
+  ((u) => ((u.NONE = "none"), (u.READY = "ready"), (u.IN_PROGRESS = "in_progress")))(
+    (l = r.prebuild_availability ||= {}),
+  );
+})((He ||= {}));
+var Qe;
+((r) => {
+  let l;
+  ((u) => ((u.COMPLETED = "completed"), (u.REOPENED = "reopened"), (u.NOT_PLANNED = "not_planned")))(
+    (l = r.state_reason ||= {}),
+  );
+})((Qe ||= {}));
+var Ke;
+((r) => {
+  let l;
+  ((s) => ((s.OPEN = "open"), (s.CLOSED = "closed")))((l = r.state ||= {}));
+})((Ke ||= {}));
+var Ye;
+((s) => {
+  let l;
+  ((m) => ((m.PR_TITLE = "PR_TITLE"), (m.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (l = s.squash_merge_commit_title ||= {}),
+  );
+  let r;
+  ((c) => ((c.PR_BODY = "PR_BODY"), (c.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (c.BLANK = "BLANK")))(
+    (r = s.squash_merge_commit_message ||= {}),
+  );
+  let e;
+  ((m) => ((m.PR_TITLE = "PR_TITLE"), (m.MERGE_MESSAGE = "MERGE_MESSAGE")))((e = s.merge_commit_title ||= {}));
+  let n;
+  ((c) => ((c.PR_BODY = "PR_BODY"), (c.PR_TITLE = "PR_TITLE"), (c.BLANK = "BLANK")))(
+    (n = s.merge_commit_message ||= {}),
+  );
+})((Ye ||= {}));
+var Ze;
+((r) => {
+  let l;
+  ((s) => ((s.ALL = "all"), (s.SELECTED = "selected")))((l = r.repository_selection ||= {}));
+})((Ze ||= {}));
+var Xe = ((e) => ((e.DESC = "desc"), (e.ASC = "asc"), e))(Xe || {});
+var $e;
+((e) => {
+  let l;
+  ((u) => ((u.ACTIVE = "active"), (u.PENDING = "pending")))((l = e.state ||= {}));
+  let r;
+  ((_) => ((_.ADMIN = "admin"), (_.MEMBER = "member"), (_.BILLING_MANAGER = "billing_manager")))((r = e.role ||= {}));
+})(($e ||= {}));
+var Je = ((e) => ((e.ENABLE_ALL = "enable_all"), (e.DISABLE_ALL = "disable_all"), e))(Je || {});
+var rt;
+((r) => {
+  let l;
+  ((u) => ((u.ALL = "all"), (u.PRIVATE = "private"), (u.SELECTED = "selected")))((l = r.visibility ||= {}));
+})((rt ||= {}));
+var et;
+((r) => {
+  let l;
+  ((u) => ((u.ALL = "all"), (u.PRIVATE = "private"), (u.SELECTED = "selected")))((l = r.visibility ||= {}));
+})((et ||= {}));
+var tt;
+((r) => {
+  let l;
+  ((u) => ((u.ALL = "all"), (u.PRIVATE = "private"), (u.SELECTED = "selected")))((l = r.visibility ||= {}));
+})((tt ||= {}));
+var nt;
+((r) => {
+  let l;
+  ((u) => ((u.NONE = "none"), (u.ALL = "all"), (u.SUBSET = "subset")))((l = r.repository_selection ||= {}));
+})((nt ||= {}));
+var st;
+((r) => {
+  let l;
+  ((u) => ((u.NONE = "none"), (u.ALL = "all"), (u.SUBSET = "subset")))((l = r.repository_selection ||= {}));
+})((st ||= {}));
+var it = ((_) => (
+  (_.NPM = "npm"),
+  (_.MAVEN = "maven"),
+  (_.RUBYGEMS = "rubygems"),
+  (_.DOCKER = "docker"),
+  (_.NUGET = "nuget"),
+  (_.CONTAINER = "container"),
+  _
+))(it || {});
+var ot;
+((r) => {
+  let l;
+  ((c) => (
+    (c.NPM = "npm"),
+    (c.MAVEN = "maven"),
+    (c.RUBYGEMS = "rubygems"),
+    (c.DOCKER = "docker"),
+    (c.NUGET = "nuget"),
+    (c.CONTAINER = "container")
+  ))((l = r.package_type ||= {}));
+})((ot ||= {}));
+var lt = ((n) => ((n.PUBLIC = "public"), (n.PRIVATE = "private"), (n.INTERNAL = "internal"), n))(lt || {});
+var at;
+((r) => {
+  let l;
+  ((b) => (
+    (b.NEW = "new"),
+    (b.AUTHORIZATION_CREATED = "authorization_created"),
+    (b.AUTHORIZATION_PENDING = "authorization_pending"),
+    (b.AUTHORIZED = "authorized"),
+    (b.AUTHORIZATION_REVOKED = "authorization_revoked"),
+    (b.ISSUED = "issued"),
+    (b.UPLOADED = "uploaded"),
+    (b.APPROVED = "approved"),
+    (b.ERRORED = "errored"),
+    (b.BAD_AUTHZ = "bad_authz"),
+    (b.DESTROY_PENDING = "destroy_pending"),
+    (b.DNS_CHANGED = "dns_changed")
+  ))((l = r.state ||= {}));
+})((at ||= {}));
+var ut = ((e) => ((e.DAY = "day"), (e.WEEK = "week"), e))(ut || {});
+var _t;
+((r) => {
+  let l;
+  ((u) => ((u.NONE = "none"), (u.ALL = "all"), (u.SUBSET = "subset")))((l = r.repository_selection ||= {}));
+})((_t ||= {}));
+var gt = ((r) => ((r.CREATED_AT = "created_at"), r))(gt || {});
+var mt;
+((r) => {
+  let l;
+  ((_) => ((_.CRITICAL = "critical"), (_.HIGH = "high"), (_.MEDIUM = "medium"), (_.LOW = "low")))(
+    (l = r.severity ||= {}),
+  );
+})((mt ||= {}));
+var pt;
+((r) => {
+  let l;
+  ((_) => ((_.READ = "read"), (_.WRITE = "write"), (_.ADMIN = "admin"), (_.NONE = "none")))(
+    (l = r.organization_permission ||= {}),
+  );
+})((pt ||= {}));
+var dt = ((n) => ((n.ISSUE = "Issue"), (n.PULL_REQUEST = "PullRequest"), (n.DRAFT_ISSUE = "DraftIssue"), n))(dt || {});
+var ct;
+((r) => {
+  let l;
+  ((s) => ((s.OPEN = "open"), (s.CLOSED = "closed")))((l = r.state ||= {}));
+})((ct ||= {}));
+var bt;
+((n) => {
+  let l;
+  ((_) => ((_.LEFT = "LEFT"), (_.RIGHT = "RIGHT")))((l = n.start_side ||= {}));
+  let r;
+  ((_) => ((_.LEFT = "LEFT"), (_.RIGHT = "RIGHT")))((r = n.side ||= {}));
+  let e;
+  ((_) => ((_.LINE = "line"), (_.FILE = "file")))((e = n.subject_type ||= {}));
+})((bt ||= {}));
+var ht;
+((r) => {
+  let l;
+  ((d) => (
+    (d._1 = "-1"),
+    (d.LAUGH = "laugh"),
+    (d.CONFUSED = "confused"),
+    (d.HEART = "heart"),
+    (d.HOORAY = "hooray"),
+    (d.ROCKET = "rocket"),
+    (d.EYES = "eyes")
+  ))((l = r.content ||= {}));
+})((ht ||= {}));
+var yt;
+((r) => {
+  let l;
+  ((s) => ((s.UPLOADED = "uploaded"), (s.OPEN = "open")))((l = r.state ||= {}));
+})((yt ||= {}));
+var ft;
+((s) => {
+  let l;
+  ((m) => ((m.PR_TITLE = "PR_TITLE"), (m.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (l = s.squash_merge_commit_title ||= {}),
+  );
+  let r;
+  ((c) => ((c.PR_BODY = "PR_BODY"), (c.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (c.BLANK = "BLANK")))(
+    (r = s.squash_merge_commit_message ||= {}),
+  );
+  let e;
+  ((m) => ((m.PR_TITLE = "PR_TITLE"), (m.MERGE_MESSAGE = "MERGE_MESSAGE")))((e = s.merge_commit_title ||= {}));
+  let n;
+  ((c) => ((c.PR_BODY = "PR_BODY"), (c.PR_TITLE = "PR_TITLE"), (c.BLANK = "BLANK")))(
+    (n = s.merge_commit_message ||= {}),
+  );
+})((ft ||= {}));
+var wt;
+((e) => {
+  let l;
+  ((m) => ((m.CRITICAL = "critical"), (m.HIGH = "high"), (m.MEDIUM = "medium"), (m.LOW = "low")))(
+    (l = e.severity ||= {}),
+  );
+  let r;
+  ((c) => (
+    (c.PUBLISHED = "published"),
+    (c.CLOSED = "closed"),
+    (c.WITHDRAWN = "withdrawn"),
+    (c.DRAFT = "draft"),
+    (c.TRIAGE = "triage")
+  ))((r = e.state ||= {}));
+})((wt ||= {}));
+var Et;
+((r) => {
+  let l;
+  ((_) => ((_.CRITICAL = "critical"), (_.HIGH = "high"), (_.MEDIUM = "medium"), (_.LOW = "low")))(
+    (l = r.severity ||= {}),
+  );
+})((Et ||= {}));
+var vt;
+((r) => {
+  let l;
+  ((u) => ((u.ACCEPTED = "accepted"), (u.DECLINED = "declined"), (u.PENDING = "pending")))((l = r.state ||= {}));
+})((vt ||= {}));
+var Rt;
+((e) => {
+  let l;
+  ((m) => ((m.CRITICAL = "critical"), (m.HIGH = "high"), (m.MEDIUM = "medium"), (m.LOW = "low")))(
+    (l = e.severity ||= {}),
+  );
+  let r;
+  ((_) => ((_.PUBLISHED = "published"), (_.CLOSED = "closed"), (_.DRAFT = "draft")))((r = e.state ||= {}));
+})((Rt ||= {}));
+var Tt;
+((r) => {
+  let l;
+  ((m) => (
+    (m.READ = "read"), (m.WRITE = "write"), (m.ADMIN = "admin"), (m.TRIAGE = "triage"), (m.MAINTAIN = "maintain")
+  ))((l = r.permissions ||= {}));
+})((Tt ||= {}));
+var At;
+((e) => {
+  let l;
+  ((s) => (s.BRANCH_NAME_PATTERN = "branch_name_pattern"))((l = e.type ||= {}));
+  let r;
+  ((m) => (
+    (m.STARTS_WITH = "starts_with"), (m.ENDS_WITH = "ends_with"), (m.CONTAINS = "contains"), (m.REGEX = "regex")
+  ))((r = e.operator ||= {}));
+})((At ||= {}));
+var kt;
+((e) => {
+  let l;
+  ((s) => (s.COMMIT_AUTHOR_EMAIL_PATTERN = "commit_author_email_pattern"))((l = e.type ||= {}));
+  let r;
+  ((m) => (
+    (m.STARTS_WITH = "starts_with"), (m.ENDS_WITH = "ends_with"), (m.CONTAINS = "contains"), (m.REGEX = "regex")
+  ))((r = e.operator ||= {}));
+})((kt ||= {}));
+var xt;
+((e) => {
+  let l;
+  ((s) => (s.COMMIT_MESSAGE_PATTERN = "commit_message_pattern"))((l = e.type ||= {}));
+  let r;
+  ((m) => (
+    (m.STARTS_WITH = "starts_with"), (m.ENDS_WITH = "ends_with"), (m.CONTAINS = "contains"), (m.REGEX = "regex")
+  ))((r = e.operator ||= {}));
+})((xt ||= {}));
+var It;
+((e) => {
+  let l;
+  ((s) => (s.COMMITTER_EMAIL_PATTERN = "committer_email_pattern"))((l = e.type ||= {}));
+  let r;
+  ((m) => (
+    (m.STARTS_WITH = "starts_with"), (m.ENDS_WITH = "ends_with"), (m.CONTAINS = "contains"), (m.REGEX = "regex")
+  ))((r = e.operator ||= {}));
+})((It ||= {}));
+var Ot;
+((r) => {
+  let l;
+  ((n) => (n.CREATION = "creation"))((l = r.type ||= {}));
+})((Ot ||= {}));
+var Nt;
+((r) => {
+  let l;
+  ((n) => (n.DELETION = "deletion"))((l = r.type ||= {}));
+})((Nt ||= {}));
+var zt = ((n) => ((n.DISABLED = "disabled"), (n.ACTIVE = "active"), (n.EVALUATE = "evaluate"), n))(zt || {});
+var Pt;
+((r) => {
+  let l;
+  ((n) => (n.NON_FAST_FORWARD = "non_fast_forward"))((l = r.type ||= {}));
+})((Pt ||= {}));
+var Ct;
+((r) => {
+  let l;
+  ((n) => (n.PULL_REQUEST = "pull_request"))((l = r.type ||= {}));
+})((Ct ||= {}));
+var Dt;
+((r) => {
+  let l;
+  ((n) => (n.REQUIRED_DEPLOYMENTS = "required_deployments"))((l = r.type ||= {}));
+})((Dt ||= {}));
+var qt;
+((r) => {
+  let l;
+  ((n) => (n.REQUIRED_LINEAR_HISTORY = "required_linear_history"))((l = r.type ||= {}));
+})((qt ||= {}));
+var St;
+((r) => {
+  let l;
+  ((n) => (n.REQUIRED_SIGNATURES = "required_signatures"))((l = r.type ||= {}));
+})((St ||= {}));
+var Lt;
+((r) => {
+  let l;
+  ((n) => (n.REQUIRED_STATUS_CHECKS = "required_status_checks"))((l = r.type ||= {}));
+})((Lt ||= {}));
+var Ut;
+((e) => {
+  let l;
+  ((s) => (s.TAG_NAME_PATTERN = "tag_name_pattern"))((l = e.type ||= {}));
+  let r;
+  ((m) => (
+    (m.STARTS_WITH = "starts_with"), (m.ENDS_WITH = "ends_with"), (m.CONTAINS = "contains"), (m.REGEX = "regex")
+  ))((r = e.operator ||= {}));
+})((Ut ||= {}));
+var Mt;
+((r) => {
+  let l;
+  ((n) => (n.UPDATE = "update"))((l = r.type ||= {}));
+})((Mt ||= {}));
+var Gt;
+((n) => {
+  let l;
+  ((_) => ((_.BRANCH = "branch"), (_.TAG = "tag")))((l = n.target ||= {}));
+  let r;
+  ((_) => ((_.REPOSITORY = "Repository"), (_.ORGANIZATION = "Organization")))((r = n.source_type ||= {}));
+  let e;
+  ((m) => ((m.ALWAYS = "always"), (m.PULL_REQUESTS_ONLY = "pull_requests_only"), (m.NEVER = "never")))(
+    (e = n.current_user_can_bypass ||= {}),
+  );
+})((Gt ||= {}));
+var Bt;
+((e) => {
+  let l;
+  ((m) => (
+    (m.REPOSITORY_ROLE = "RepositoryRole"),
+    (m.TEAM = "Team"),
+    (m.INTEGRATION = "Integration"),
+    (m.ORGANIZATION_ADMIN = "OrganizationAdmin")
+  ))((l = e.actor_type ||= {}));
+  let r;
+  ((u) => ((u.ALWAYS = "always"), (u.PULL_REQUEST = "pull_request")))((r = e.bypass_mode ||= {}));
+})((Bt ||= {}));
+var Wt;
+((e) => {
+  let l;
+  ((u) => ((u.LEFT = "LEFT"), (u.RIGHT = "RIGHT")))((l = e.side ||= {}));
+  let r;
+  ((u) => ((u.LEFT = "LEFT"), (u.RIGHT = "RIGHT")))((r = e.start_side ||= {}));
+})((Wt ||= {}));
+var Ft;
+((r) => {
+  let l;
+  ((s) => ((s.APPROVED = "approved"), (s.REJECTED = "rejected")))((l = r.state ||= {}));
+})((Ft ||= {}));
+var jt;
+((r) => {
+  let l;
+  ((s) => ((s.READ_ONLY = "read-only"), (s.CUSTOM = "custom")))((l = r.type ||= {}));
+})((jt ||= {}));
+var Vt = ((_) => (
+  (_.FALSE_POSITIVE = "false_positive"),
+  (_.WONT_FIX = "wont_fix"),
+  (_.REVOKED = "revoked"),
+  (_.USED_IN_TESTS = "used_in_tests"),
+  (_.PATTERN_DELETED = "pattern_deleted"),
+  (_.PATTERN_EDITED = "pattern_edited"),
+  _
+))(Vt || {});
+var Ht = ((e) => ((e.CREATED = "created"), (e.UPDATED = "updated"), e))(Ht || {});
+var Qt = ((e) => ((e.OPEN = "open"), (e.RESOLVED = "resolved"), e))(Qt || {});
+var Kt;
+((r) => {
+  let l;
+  ((_) => (
+    (_.COMMIT = "commit"),
+    (_.ISSUE_TITLE = "issue_title"),
+    (_.ISSUE_BODY = "issue_body"),
+    (_.ISSUE_COMMENT = "issue_comment")
+  ))((l = r.type ||= {}));
+})((Kt ||= {}));
+var Yt = ((v) => (
+  (v.ANALYST = "analyst"),
+  (v.FINDER = "finder"),
+  (v.REPORTER = "reporter"),
+  (v.COORDINATOR = "coordinator"),
+  (v.REMEDIATION_DEVELOPER = "remediation_developer"),
+  (v.REMEDIATION_REVIEWER = "remediation_reviewer"),
+  (v.REMEDIATION_VERIFIER = "remediation_verifier"),
+  (v.TOOL = "tool"),
+  (v.SPONSOR = "sponsor"),
+  (v.OTHER = "other"),
+  v
+))(Yt || {});
+var Zt = ((k) => (
+  (k.RUBYGEMS = "rubygems"),
+  (k.NPM = "npm"),
+  (k.PIP = "pip"),
+  (k.MAVEN = "maven"),
+  (k.NUGET = "nuget"),
+  (k.COMPOSER = "composer"),
+  (k.GO = "go"),
+  (k.RUST = "rust"),
+  (k.ERLANG = "erlang"),
+  (k.ACTIONS = "actions"),
+  (k.PUB = "pub"),
+  (k.OTHER = "other"),
+  (k.SWIFT = "swift"),
+  k
+))(Zt || {});
+var Xt;
+((r) => {
+  let l;
+  ((s) => ((s.ENABLED = "enabled"), (s.DISABLED = "disabled")))((l = r.status ||= {}));
+})((Xt ||= {}));
+var $t = ((m) => (
+  (m.DEPENDENCY_GRAPH = "dependency_graph"),
+  (m.DEPENDABOT_ALERTS = "dependabot_alerts"),
+  (m.DEPENDABOT_SECURITY_UPDATES = "dependabot_security_updates"),
+  (m.ADVANCED_SECURITY = "advanced_security"),
+  (m.CODE_SCANNING_DEFAULT_SETUP = "code_scanning_default_setup"),
+  (m.SECRET_SCANNING = "secret_scanning"),
+  (m.SECRET_SCANNING_PUSH_PROTECTION = "secret_scanning_push_protection"),
+  m
+))($t || {});
+var Jt;
+((e) => {
+  let l;
+  ((R) => (
+    (R.SUCCESS = "success"),
+    (R.FAILURE = "failure"),
+    (R.NEUTRAL = "neutral"),
+    (R.CANCELLED = "cancelled"),
+    (R.SKIPPED = "skipped"),
+    (R.TIMED_OUT = "timed_out"),
+    (R.ACTION_REQUIRED = "action_required"),
+    (R.STALE = "stale"),
+    (R.STARTUP_FAILURE = "startup_failure")
+  ))((l = e.conclusion ||= {}));
+  let r;
+  ((c) => (
+    (c.QUEUED = "queued"),
+    (c.IN_PROGRESS = "in_progress"),
+    (c.COMPLETED = "completed"),
+    (c.PENDING = "pending"),
+    (c.WAITING = "waiting")
+  ))((r = e.status ||= {}));
+})((Jt ||= {}));
+var rn = ((e) => ((e.CREATED = "created"), (e.UPDATED = "updated"), e))(rn || {});
+var en = ((e) => ((e.CREATED = "created"), (e.UPDATED = "updated"), e))(en || {});
+var tn = ((n) => ((n.QUEUED = "queued"), (n.IN_PROGRESS = "in_progress"), (n.COMPLETED = "completed"), n))(tn || {});
+var nn;
+((e) => {
+  let l;
+  ((u) => ((u.CLOSED = "closed"), (u.SECRET = "secret")))((l = e.privacy ||= {}));
+  let r;
+  ((u) => ((u.NOTIFICATIONS_ENABLED = "notifications_enabled"), (u.NOTIFICATIONS_DISABLED = "notifications_disabled")))(
+    (r = e.notification_setting ||= {}),
+  );
+})((nn ||= {}));
+var sn;
+((e) => {
+  let l;
+  ((u) => ((u.MEMBER = "member"), (u.MAINTAINER = "maintainer")))((l = e.role ||= {}));
+  let r;
+  ((u) => ((u.ACTIVE = "active"), (u.PENDING = "pending")))((r = e.state ||= {}));
+})((sn ||= {}));
+var on;
+((v) => {
+  let l;
+  ((R) => (R.CREATED = "created"))((l = v.action ||= {}));
+  let r;
+  ((b) => ((b.OFF = "off"), (b.NON_ADMINS = "non_admins"), (b.EVERYONE = "everyone")))(
+    (r = v.allow_deletions_enforcement_level ||= {}),
+  );
+  let e;
+  ((b) => ((b.OFF = "off"), (b.NON_ADMINS = "non_admins"), (b.EVERYONE = "everyone")))(
+    (e = v.allow_force_pushes_enforcement_level ||= {}),
+  );
+  let n;
+  ((b) => ((b.OFF = "off"), (b.NON_ADMINS = "non_admins"), (b.EVERYONE = "everyone")))(
+    (n = v.linear_history_requirement_enforcement_level ||= {}),
+  );
+  let s;
+  ((b) => ((b.OFF = "off"), (b.NON_ADMINS = "non_admins"), (b.EVERYONE = "everyone")))(
+    (s = v.merge_queue_enforcement_level ||= {}),
+  );
+  let u;
+  ((b) => ((b.OFF = "off"), (b.NON_ADMINS = "non_admins"), (b.EVERYONE = "everyone")))(
+    (u = v.pull_request_reviews_enforcement_level ||= {}),
+  );
+  let _;
+  ((b) => ((b.OFF = "off"), (b.NON_ADMINS = "non_admins"), (b.EVERYONE = "everyone")))(
+    (_ = v.required_conversation_resolution_level ||= {}),
+  );
+  let m;
+  ((b) => ((b.OFF = "off"), (b.NON_ADMINS = "non_admins"), (b.EVERYONE = "everyone")))(
+    (m = v.required_deployments_enforcement_level ||= {}),
+  );
+  let c;
+  ((b) => ((b.OFF = "off"), (b.NON_ADMINS = "non_admins"), (b.EVERYONE = "everyone")))(
+    (c = v.required_status_checks_enforcement_level ||= {}),
+  );
+  let d;
+  ((b) => ((b.OFF = "off"), (b.NON_ADMINS = "non_admins"), (b.EVERYONE = "everyone")))(
+    (d = v.signature_requirement_enforcement_level ||= {}),
+  );
+})((on ||= {}));
+var ln;
+((v) => {
+  let l;
+  ((R) => (R.DELETED = "deleted"))((l = v.action ||= {}));
+  let r;
+  ((b) => ((b.OFF = "off"), (b.NON_ADMINS = "non_admins"), (b.EVERYONE = "everyone")))(
+    (r = v.allow_deletions_enforcement_level ||= {}),
+  );
+  let e;
+  ((b) => ((b.OFF = "off"), (b.NON_ADMINS = "non_admins"), (b.EVERYONE = "everyone")))(
+    (e = v.allow_force_pushes_enforcement_level ||= {}),
+  );
+  let n;
+  ((b) => ((b.OFF = "off"), (b.NON_ADMINS = "non_admins"), (b.EVERYONE = "everyone")))(
+    (n = v.linear_history_requirement_enforcement_level ||= {}),
+  );
+  let s;
+  ((b) => ((b.OFF = "off"), (b.NON_ADMINS = "non_admins"), (b.EVERYONE = "everyone")))(
+    (s = v.merge_queue_enforcement_level ||= {}),
+  );
+  let u;
+  ((b) => ((b.OFF = "off"), (b.NON_ADMINS = "non_admins"), (b.EVERYONE = "everyone")))(
+    (u = v.pull_request_reviews_enforcement_level ||= {}),
+  );
+  let _;
+  ((b) => ((b.OFF = "off"), (b.NON_ADMINS = "non_admins"), (b.EVERYONE = "everyone")))(
+    (_ = v.required_conversation_resolution_level ||= {}),
+  );
+  let m;
+  ((b) => ((b.OFF = "off"), (b.NON_ADMINS = "non_admins"), (b.EVERYONE = "everyone")))(
+    (m = v.required_deployments_enforcement_level ||= {}),
+  );
+  let c;
+  ((b) => ((b.OFF = "off"), (b.NON_ADMINS = "non_admins"), (b.EVERYONE = "everyone")))(
+    (c = v.required_status_checks_enforcement_level ||= {}),
+  );
+  let d;
+  ((b) => ((b.OFF = "off"), (b.NON_ADMINS = "non_admins"), (b.EVERYONE = "everyone")))(
+    (d = v.signature_requirement_enforcement_level ||= {}),
+  );
+})((ln ||= {}));
+var an;
+((h) => {
+  let l;
+  ((k) => (k.EDITED = "edited"))((l = h.action ||= {}));
+  let r;
+  ((p) => ((p.OFF = "off"), (p.NON_ADMINS = "non_admins"), (p.EVERYONE = "everyone")))((r = h.from ||= {}));
+  let e;
+  ((p) => ((p.OFF = "off"), (p.NON_ADMINS = "non_admins"), (p.EVERYONE = "everyone")))(
+    (e = h.allow_deletions_enforcement_level ||= {}),
+  );
+  let n;
+  ((p) => ((p.OFF = "off"), (p.NON_ADMINS = "non_admins"), (p.EVERYONE = "everyone")))(
+    (n = h.allow_force_pushes_enforcement_level ||= {}),
+  );
+  let s;
+  ((p) => ((p.OFF = "off"), (p.NON_ADMINS = "non_admins"), (p.EVERYONE = "everyone")))(
+    (s = h.linear_history_requirement_enforcement_level ||= {}),
+  );
+  let u;
+  ((p) => ((p.OFF = "off"), (p.NON_ADMINS = "non_admins"), (p.EVERYONE = "everyone")))(
+    (u = h.merge_queue_enforcement_level ||= {}),
+  );
+  let _;
+  ((p) => ((p.OFF = "off"), (p.NON_ADMINS = "non_admins"), (p.EVERYONE = "everyone")))(
+    (_ = h.pull_request_reviews_enforcement_level ||= {}),
+  );
+  let m;
+  ((p) => ((p.OFF = "off"), (p.NON_ADMINS = "non_admins"), (p.EVERYONE = "everyone")))(
+    (m = h.required_conversation_resolution_level ||= {}),
+  );
+  let c;
+  ((p) => ((p.OFF = "off"), (p.NON_ADMINS = "non_admins"), (p.EVERYONE = "everyone")))(
+    (c = h.required_deployments_enforcement_level ||= {}),
+  );
+  let d;
+  ((p) => ((p.OFF = "off"), (p.NON_ADMINS = "non_admins"), (p.EVERYONE = "everyone")))(
+    (d = h.required_status_checks_enforcement_level ||= {}),
+  );
+  let v;
+  ((p) => ((p.OFF = "off"), (p.NON_ADMINS = "non_admins"), (p.EVERYONE = "everyone")))(
+    (v = h.signature_requirement_enforcement_level ||= {}),
+  );
+})((an ||= {}));
+var un;
+((r) => {
+  let l;
+  ((n) => (n.COMPLETED = "completed"))((l = r.action ||= {}));
+})((un ||= {}));
+var _n;
+((r) => {
+  let l;
+  ((n) => (n.CREATED = "created"))((l = r.action ||= {}));
+})((_n ||= {}));
+var gn;
+((r) => {
+  let l;
+  ((n) => (n.REQUESTED_ACTION = "requested_action"))((l = r.action ||= {}));
+})((gn ||= {}));
+var mn;
+((r) => {
+  let l;
+  ((n) => (n.REREQUESTED = "rerequested"))((l = r.action ||= {}));
+})((mn ||= {}));
+var pn;
+((w) => {
+  let l;
+  ((N) => (N.COMPLETED = "completed"))((l = w.action ||= {}));
+  let r;
+  ((t) => ((t.BOT = "Bot"), (t.USER = "User"), (t.ORGANIZATION = "Organization")))((r = w.type ||= {}));
+  let e;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((e = w.actions ||= {}));
+  let n;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((n = w.administration ||= {}));
+  let s;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((s = w.checks ||= {}));
+  let u;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((u = w.content_references ||= {}));
+  let _;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((_ = w.contents ||= {}));
+  let m;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((m = w.deployments ||= {}));
+  let c;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((c = w.discussions ||= {}));
+  let d;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((d = w.emails ||= {}));
+  let v;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((v = w.environments ||= {}));
+  let h;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((h = w.issues ||= {}));
+  let R;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((R = w.keys ||= {}));
+  let k;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((k = w.members ||= {}));
+  let b;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((b = w.metadata ||= {}));
+  let p;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((p = w.organization_administration ||= {}));
+  let f;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((f = w.organization_hooks ||= {}));
+  let O;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((O = w.organization_packages ||= {}));
+  let I;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((I = w.organization_plan ||= {}));
+  let P;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write"), (t.ADMIN = "admin")))((P = w.organization_projects ||= {}));
+  let E;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((E = w.organization_secrets ||= {}));
+  let D;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((D = w.organization_self_hosted_runners ||= {}));
+  let L;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((L = w.organization_user_blocking ||= {}));
+  let C;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((C = w.packages ||= {}));
+  let U;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((U = w.pages ||= {}));
+  let M;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((M = w.pull_requests ||= {}));
+  let G;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((G = w.repository_hooks ||= {}));
+  let B;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write"), (t.ADMIN = "admin")))((B = w.repository_projects ||= {}));
+  let W;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((W = w.secret_scanning_alerts ||= {}));
+  let F;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((F = w.secrets ||= {}));
+  let j;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((j = w.security_events ||= {}));
+  let V;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((V = w.security_scanning_alert ||= {}));
+  let H;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((H = w.single_file ||= {}));
+  let Q;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((Q = w.statuses ||= {}));
+  let z;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((z = w.team_discussions ||= {}));
+  let K;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((K = w.vulnerability_alerts ||= {}));
+  let S;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((S = w.workflows ||= {}));
+  let x;
+  ((T) => (
+    (T.SUCCESS = "success"),
+    (T.FAILURE = "failure"),
+    (T.NEUTRAL = "neutral"),
+    (T.CANCELLED = "cancelled"),
+    (T.TIMED_OUT = "timed_out"),
+    (T.ACTION_REQUIRED = "action_required"),
+    (T.STALE = "stale"),
+    (T.SKIPPED = "skipped"),
+    (T.STARTUP_FAILURE = "startup_failure")
+  ))((x = w.conclusion ||= {}));
+  let q;
+  ((A) => (
+    (A.REQUESTED = "requested"),
+    (A.IN_PROGRESS = "in_progress"),
+    (A.COMPLETED = "completed"),
+    (A.QUEUED = "queued"),
+    (A.PENDING = "pending")
+  ))((q = w.status ||= {}));
+})((pn ||= {}));
+var dn;
+((w) => {
+  let l;
+  ((N) => (N.REQUESTED = "requested"))((l = w.action ||= {}));
+  let r;
+  ((t) => ((t.BOT = "Bot"), (t.USER = "User"), (t.ORGANIZATION = "Organization")))((r = w.type ||= {}));
+  let e;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((e = w.actions ||= {}));
+  let n;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((n = w.administration ||= {}));
+  let s;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((s = w.checks ||= {}));
+  let u;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((u = w.content_references ||= {}));
+  let _;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((_ = w.contents ||= {}));
+  let m;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((m = w.deployments ||= {}));
+  let c;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((c = w.discussions ||= {}));
+  let d;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((d = w.emails ||= {}));
+  let v;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((v = w.environments ||= {}));
+  let h;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((h = w.issues ||= {}));
+  let R;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((R = w.keys ||= {}));
+  let k;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((k = w.members ||= {}));
+  let b;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((b = w.metadata ||= {}));
+  let p;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((p = w.organization_administration ||= {}));
+  let f;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((f = w.organization_hooks ||= {}));
+  let O;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((O = w.organization_packages ||= {}));
+  let I;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((I = w.organization_plan ||= {}));
+  let P;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write"), (t.ADMIN = "admin")))((P = w.organization_projects ||= {}));
+  let E;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((E = w.organization_secrets ||= {}));
+  let D;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((D = w.organization_self_hosted_runners ||= {}));
+  let L;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((L = w.organization_user_blocking ||= {}));
+  let C;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((C = w.packages ||= {}));
+  let U;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((U = w.pages ||= {}));
+  let M;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((M = w.pull_requests ||= {}));
+  let G;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((G = w.repository_hooks ||= {}));
+  let B;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write"), (t.ADMIN = "admin")))((B = w.repository_projects ||= {}));
+  let W;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((W = w.secret_scanning_alerts ||= {}));
+  let F;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((F = w.secrets ||= {}));
+  let j;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((j = w.security_events ||= {}));
+  let V;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((V = w.security_scanning_alert ||= {}));
+  let H;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((H = w.single_file ||= {}));
+  let Q;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((Q = w.statuses ||= {}));
+  let z;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((z = w.team_discussions ||= {}));
+  let K;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((K = w.vulnerability_alerts ||= {}));
+  let S;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((S = w.workflows ||= {}));
+  let x;
+  ((Y) => (
+    (Y.SUCCESS = "success"),
+    (Y.FAILURE = "failure"),
+    (Y.NEUTRAL = "neutral"),
+    (Y.CANCELLED = "cancelled"),
+    (Y.TIMED_OUT = "timed_out"),
+    (Y.ACTION_REQUIRED = "action_required"),
+    (Y.STALE = "stale"),
+    (Y.SKIPPED = "skipped")
+  ))((x = w.conclusion ||= {}));
+  let q;
+  ((y) => (
+    (y.REQUESTED = "requested"), (y.IN_PROGRESS = "in_progress"), (y.COMPLETED = "completed"), (y.QUEUED = "queued")
+  ))((q = w.status ||= {}));
+})((dn ||= {}));
+var cn;
+((w) => {
+  let l;
+  ((N) => (N.REREQUESTED = "rerequested"))((l = w.action ||= {}));
+  let r;
+  ((t) => ((t.BOT = "Bot"), (t.USER = "User"), (t.ORGANIZATION = "Organization")))((r = w.type ||= {}));
+  let e;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((e = w.actions ||= {}));
+  let n;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((n = w.administration ||= {}));
+  let s;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((s = w.checks ||= {}));
+  let u;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((u = w.content_references ||= {}));
+  let _;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((_ = w.contents ||= {}));
+  let m;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((m = w.deployments ||= {}));
+  let c;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((c = w.discussions ||= {}));
+  let d;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((d = w.emails ||= {}));
+  let v;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((v = w.environments ||= {}));
+  let h;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((h = w.issues ||= {}));
+  let R;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((R = w.keys ||= {}));
+  let k;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((k = w.members ||= {}));
+  let b;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((b = w.metadata ||= {}));
+  let p;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((p = w.organization_administration ||= {}));
+  let f;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((f = w.organization_hooks ||= {}));
+  let O;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((O = w.organization_packages ||= {}));
+  let I;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((I = w.organization_plan ||= {}));
+  let P;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write"), (t.ADMIN = "admin")))((P = w.organization_projects ||= {}));
+  let E;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((E = w.organization_secrets ||= {}));
+  let D;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((D = w.organization_self_hosted_runners ||= {}));
+  let L;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((L = w.organization_user_blocking ||= {}));
+  let C;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((C = w.packages ||= {}));
+  let U;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((U = w.pages ||= {}));
+  let M;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((M = w.pull_requests ||= {}));
+  let G;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((G = w.repository_hooks ||= {}));
+  let B;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write"), (t.ADMIN = "admin")))((B = w.repository_projects ||= {}));
+  let W;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((W = w.secret_scanning_alerts ||= {}));
+  let F;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((F = w.secrets ||= {}));
+  let j;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((j = w.security_events ||= {}));
+  let V;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((V = w.security_scanning_alert ||= {}));
+  let H;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((H = w.single_file ||= {}));
+  let Q;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((Q = w.statuses ||= {}));
+  let z;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((z = w.team_discussions ||= {}));
+  let K;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((K = w.vulnerability_alerts ||= {}));
+  let S;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((S = w.workflows ||= {}));
+  let x;
+  (($) => (
+    ($.SUCCESS = "success"),
+    ($.FAILURE = "failure"),
+    ($.NEUTRAL = "neutral"),
+    ($.CANCELLED = "cancelled"),
+    ($.TIMED_OUT = "timed_out"),
+    ($.ACTION_REQUIRED = "action_required"),
+    ($.STALE = "stale")
+  ))((x = w.conclusion ||= {}));
+  let q;
+  ((y) => (
+    (y.REQUESTED = "requested"), (y.IN_PROGRESS = "in_progress"), (y.COMPLETED = "completed"), (y.QUEUED = "queued")
+  ))((q = w.status ||= {}));
+})((cn ||= {}));
+var bn;
+((u) => {
+  let l;
+  ((m) => (m.APPEARED_IN_BRANCH = "appeared_in_branch"))((l = u.action ||= {}));
+  let r;
+  ((d) => ((d.BOT = "Bot"), (d.USER = "User"), (d.ORGANIZATION = "Organization")))((r = u.type ||= {}));
+  let e;
+  ((d) => ((d.FALSE_POSITIVE = "false positive"), (d.WON_T_FIX = "won't fix"), (d.USED_IN_TESTS = "used in tests")))(
+    (e = u.dismissed_reason ||= {}),
+  );
+  let n;
+  ((d) => ((d.OPEN = "open"), (d.DISMISSED = "dismissed"), (d.FIXED = "fixed")))((n = u.state ||= {}));
+  let s;
+  ((v) => ((v.NONE = "none"), (v.NOTE = "note"), (v.WARNING = "warning"), (v.ERROR = "error")))(
+    (s = u.severity ||= {}),
+  );
+})((bn ||= {}));
+var hn;
+((u) => {
+  let l;
+  ((m) => (m.CLOSED_BY_USER = "closed_by_user"))((l = u.action ||= {}));
+  let r;
+  ((d) => ((d.BOT = "Bot"), (d.USER = "User"), (d.ORGANIZATION = "Organization")))((r = u.type ||= {}));
+  let e;
+  ((d) => ((d.FALSE_POSITIVE = "false positive"), (d.WON_T_FIX = "won't fix"), (d.USED_IN_TESTS = "used in tests")))(
+    (e = u.dismissed_reason ||= {}),
+  );
+  let n;
+  ((d) => ((d.OPEN = "open"), (d.DISMISSED = "dismissed"), (d.FIXED = "fixed")))((n = u.state ||= {}));
+  let s;
+  ((v) => ((v.NONE = "none"), (v.NOTE = "note"), (v.WARNING = "warning"), (v.ERROR = "error")))(
+    (s = u.severity ||= {}),
+  );
+})((hn ||= {}));
+var yn;
+((n) => {
+  let l;
+  ((u) => (u.CREATED = "created"))((l = n.action ||= {}));
+  let r;
+  ((m) => ((m.OPEN = "open"), (m.DISMISSED = "dismissed"), (m.FIXED = "fixed")))((r = n.state ||= {}));
+  let e;
+  ((c) => ((c.NONE = "none"), (c.NOTE = "note"), (c.WARNING = "warning"), (c.ERROR = "error")))(
+    (e = n.severity ||= {}),
+  );
+})((yn ||= {}));
+var fn;
+((u) => {
+  let l;
+  ((m) => (m.FIXED = "fixed"))((l = u.action ||= {}));
+  let r;
+  ((d) => ((d.BOT = "Bot"), (d.USER = "User"), (d.ORGANIZATION = "Organization")))((r = u.type ||= {}));
+  let e;
+  ((d) => ((d.FALSE_POSITIVE = "false positive"), (d.WON_T_FIX = "won't fix"), (d.USED_IN_TESTS = "used in tests")))(
+    (e = u.dismissed_reason ||= {}),
+  );
+  let n;
+  ((d) => ((d.OPEN = "open"), (d.DISMISSED = "dismissed"), (d.FIXED = "fixed")))((n = u.state ||= {}));
+  let s;
+  ((v) => ((v.NONE = "none"), (v.NOTE = "note"), (v.WARNING = "warning"), (v.ERROR = "error")))(
+    (s = u.severity ||= {}),
+  );
+})((fn ||= {}));
+var wn;
+((n) => {
+  let l;
+  ((u) => (u.REOPENED = "reopened"))((l = n.action ||= {}));
+  let r;
+  ((m) => ((m.OPEN = "open"), (m.DISMISSED = "dismissed"), (m.FIXED = "fixed")))((r = n.state ||= {}));
+  let e;
+  ((c) => ((c.NONE = "none"), (c.NOTE = "note"), (c.WARNING = "warning"), (c.ERROR = "error")))(
+    (e = n.severity ||= {}),
+  );
+})((wn ||= {}));
+var En;
+((n) => {
+  let l;
+  ((u) => (u.REOPENED_BY_USER = "reopened_by_user"))((l = n.action ||= {}));
+  let r;
+  ((m) => ((m.OPEN = "open"), (m.DISMISSED = "dismissed"), (m.FIXED = "fixed")))((r = n.state ||= {}));
+  let e;
+  ((c) => ((c.NONE = "none"), (c.NOTE = "note"), (c.WARNING = "warning"), (c.ERROR = "error")))(
+    (e = n.severity ||= {}),
+  );
+})((En ||= {}));
+var vn;
+((n) => {
+  let l;
+  ((u) => (u.CREATED = "created"))((l = n.action ||= {}));
+  let r;
+  ((R) => (
+    (R.COLLABORATOR = "COLLABORATOR"),
+    (R.CONTRIBUTOR = "CONTRIBUTOR"),
+    (R.FIRST_TIMER = "FIRST_TIMER"),
+    (R.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (R.MANNEQUIN = "MANNEQUIN"),
+    (R.MEMBER = "MEMBER"),
+    (R.NONE = "NONE"),
+    (R.OWNER = "OWNER")
+  ))((r = n.author_association ||= {}));
+  let e;
+  ((m) => ((m.BOT = "Bot"), (m.USER = "User"), (m.ORGANIZATION = "Organization")))((e = n.type ||= {}));
+})((vn ||= {}));
+var Rn;
+((r) => {
+  let l;
+  ((s) => ((s.TAG = "tag"), (s.BRANCH = "branch")))((l = r.ref_type ||= {}));
+})((Rn ||= {}));
+var Tn;
+((r) => {
+  let l;
+  ((s) => ((s.TAG = "tag"), (s.BRANCH = "branch")))((l = r.ref_type ||= {}));
+})((Tn ||= {}));
+var An;
+((r) => {
+  let l;
+  ((n) => (n.AUTO_DISMISSED = "auto_dismissed"))((l = r.action ||= {}));
+})((An ||= {}));
+var kn;
+((r) => {
+  let l;
+  ((n) => (n.AUTO_REOPENED = "auto_reopened"))((l = r.action ||= {}));
+})((kn ||= {}));
+var xn;
+((r) => {
+  let l;
+  ((n) => (n.CREATED = "created"))((l = r.action ||= {}));
+})((xn ||= {}));
+var In;
+((r) => {
+  let l;
+  ((n) => (n.DISMISSED = "dismissed"))((l = r.action ||= {}));
+})((In ||= {}));
+var On;
+((r) => {
+  let l;
+  ((n) => (n.FIXED = "fixed"))((l = r.action ||= {}));
+})((On ||= {}));
+var Nn;
+((r) => {
+  let l;
+  ((n) => (n.REINTRODUCED = "reintroduced"))((l = r.action ||= {}));
+})((Nn ||= {}));
+var zn;
+((r) => {
+  let l;
+  ((n) => (n.REOPENED = "reopened"))((l = r.action ||= {}));
+})((zn ||= {}));
+var Pn;
+((r) => {
+  let l;
+  ((n) => (n.CREATED = "created"))((l = r.action ||= {}));
+})((Pn ||= {}));
+var Cn;
+((r) => {
+  let l;
+  ((n) => (n.DELETED = "deleted"))((l = r.action ||= {}));
+})((Cn ||= {}));
+var Dn;
+((w) => {
+  let l;
+  ((N) => (N.CREATED = "created"))((l = w.action ||= {}));
+  let r;
+  ((t) => ((t.BOT = "Bot"), (t.USER = "User"), (t.ORGANIZATION = "Organization")))((r = w.type ||= {}));
+  let e;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((e = w.actions ||= {}));
+  let n;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((n = w.administration ||= {}));
+  let s;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((s = w.checks ||= {}));
+  let u;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((u = w.content_references ||= {}));
+  let _;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((_ = w.contents ||= {}));
+  let m;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((m = w.deployments ||= {}));
+  let c;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((c = w.discussions ||= {}));
+  let d;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((d = w.emails ||= {}));
+  let v;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((v = w.environments ||= {}));
+  let h;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((h = w.issues ||= {}));
+  let R;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((R = w.keys ||= {}));
+  let k;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((k = w.members ||= {}));
+  let b;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((b = w.metadata ||= {}));
+  let p;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((p = w.organization_administration ||= {}));
+  let f;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((f = w.organization_hooks ||= {}));
+  let O;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((O = w.organization_packages ||= {}));
+  let I;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((I = w.organization_plan ||= {}));
+  let P;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((P = w.organization_projects ||= {}));
+  let E;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((E = w.organization_secrets ||= {}));
+  let D;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((D = w.organization_self_hosted_runners ||= {}));
+  let L;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((L = w.organization_user_blocking ||= {}));
+  let C;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((C = w.packages ||= {}));
+  let U;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((U = w.pages ||= {}));
+  let M;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((M = w.pull_requests ||= {}));
+  let G;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((G = w.repository_hooks ||= {}));
+  let B;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((B = w.repository_projects ||= {}));
+  let W;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((W = w.secret_scanning_alerts ||= {}));
+  let F;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((F = w.secrets ||= {}));
+  let j;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((j = w.security_events ||= {}));
+  let V;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((V = w.security_scanning_alert ||= {}));
+  let H;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((H = w.single_file ||= {}));
+  let Q;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((Q = w.statuses ||= {}));
+  let z;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((z = w.team_discussions ||= {}));
+  let K;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((K = w.vulnerability_alerts ||= {}));
+  let S;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((S = w.workflows ||= {}));
+  let x;
+  (($) => (
+    ($.SUCCESS = "success"),
+    ($.FAILURE = "failure"),
+    ($.NEUTRAL = "neutral"),
+    ($.CANCELLED = "cancelled"),
+    ($.TIMED_OUT = "timed_out"),
+    ($.ACTION_REQUIRED = "action_required"),
+    ($.STALE = "stale")
+  ))((x = w.conclusion ||= {}));
+  let q;
+  ((X) => (
+    (X.REQUESTED = "requested"),
+    (X.IN_PROGRESS = "in_progress"),
+    (X.COMPLETED = "completed"),
+    (X.QUEUED = "queued"),
+    (X.WAITING = "waiting"),
+    (X.PENDING = "pending")
+  ))((q = w.status ||= {}));
+})((Dn ||= {}));
+var qn;
+((r) => {
+  let l;
+  ((n) => (n.REQUESTED = "requested"))((l = r.action ||= {}));
+})((qn ||= {}));
+var Sn;
+((w) => {
+  let l;
+  ((N) => (N.CREATED = "created"))((l = w.action ||= {}));
+  let r;
+  ((Y) => (
+    (Y.SUCCESS = "success"),
+    (Y.FAILURE = "failure"),
+    (Y.NEUTRAL = "neutral"),
+    (Y.CANCELLED = "cancelled"),
+    (Y.TIMED_OUT = "timed_out"),
+    (Y.ACTION_REQUIRED = "action_required"),
+    (Y.STALE = "stale"),
+    (Y.SKIPPED = "skipped")
+  ))((r = w.conclusion ||= {}));
+  let e;
+  ((A) => (
+    (A.QUEUED = "queued"),
+    (A.IN_PROGRESS = "in_progress"),
+    (A.COMPLETED = "completed"),
+    (A.WAITING = "waiting"),
+    (A.PENDING = "pending")
+  ))((e = w.status ||= {}));
+  let n;
+  ((t) => ((t.BOT = "Bot"), (t.USER = "User"), (t.ORGANIZATION = "Organization")))((n = w.type ||= {}));
+  let s;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((s = w.actions ||= {}));
+  let u;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((u = w.administration ||= {}));
+  let _;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((_ = w.checks ||= {}));
+  let m;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((m = w.content_references ||= {}));
+  let c;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((c = w.contents ||= {}));
+  let d;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((d = w.deployments ||= {}));
+  let v;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((v = w.discussions ||= {}));
+  let h;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((h = w.emails ||= {}));
+  let R;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((R = w.environments ||= {}));
+  let k;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((k = w.issues ||= {}));
+  let b;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((b = w.keys ||= {}));
+  let p;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((p = w.members ||= {}));
+  let f;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((f = w.metadata ||= {}));
+  let O;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((O = w.organization_administration ||= {}));
+  let I;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((I = w.organization_hooks ||= {}));
+  let P;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((P = w.organization_packages ||= {}));
+  let E;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((E = w.organization_plan ||= {}));
+  let D;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((D = w.organization_projects ||= {}));
+  let L;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((L = w.organization_secrets ||= {}));
+  let C;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((C = w.organization_self_hosted_runners ||= {}));
+  let U;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((U = w.organization_user_blocking ||= {}));
+  let M;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((M = w.packages ||= {}));
+  let G;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((G = w.pages ||= {}));
+  let B;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((B = w.pull_requests ||= {}));
+  let W;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((W = w.repository_hooks ||= {}));
+  let F;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((F = w.repository_projects ||= {}));
+  let j;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((j = w.secret_scanning_alerts ||= {}));
+  let V;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((V = w.secrets ||= {}));
+  let H;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((H = w.security_events ||= {}));
+  let Q;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((Q = w.security_scanning_alert ||= {}));
+  let z;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((z = w.single_file ||= {}));
+  let K;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((K = w.statuses ||= {}));
+  let S;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((S = w.team_discussions ||= {}));
+  let x;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((x = w.vulnerability_alerts ||= {}));
+  let q;
+  ((g) => ((g.READ = "read"), (g.WRITE = "write")))((q = w.workflows ||= {}));
+})((Sn ||= {}));
+var Ln;
+((n) => {
+  let l;
+  ((u) => (u.ANSWERED = "answered"))((l = n.action ||= {}));
+  let r;
+  ((R) => (
+    (R.COLLABORATOR = "COLLABORATOR"),
+    (R.CONTRIBUTOR = "CONTRIBUTOR"),
+    (R.FIRST_TIMER = "FIRST_TIMER"),
+    (R.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (R.MANNEQUIN = "MANNEQUIN"),
+    (R.MEMBER = "MEMBER"),
+    (R.NONE = "NONE"),
+    (R.OWNER = "OWNER")
+  ))((r = n.author_association ||= {}));
+  let e;
+  ((m) => ((m.BOT = "Bot"), (m.USER = "User"), (m.ORGANIZATION = "Organization")))((e = n.type ||= {}));
+})((Ln ||= {}));
+var Un;
+((r) => {
+  let l;
+  ((n) => (n.CATEGORY_CHANGED = "category_changed"))((l = r.action ||= {}));
+})((Un ||= {}));
+var Mn;
+((r) => {
+  let l;
+  ((n) => (n.CLOSED = "closed"))((l = r.action ||= {}));
+})((Mn ||= {}));
+var Gn;
+((n) => {
+  let l;
+  ((u) => (u.CREATED = "created"))((l = n.action ||= {}));
+  let r;
+  ((R) => (
+    (R.COLLABORATOR = "COLLABORATOR"),
+    (R.CONTRIBUTOR = "CONTRIBUTOR"),
+    (R.FIRST_TIMER = "FIRST_TIMER"),
+    (R.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (R.MANNEQUIN = "MANNEQUIN"),
+    (R.MEMBER = "MEMBER"),
+    (R.NONE = "NONE"),
+    (R.OWNER = "OWNER")
+  ))((r = n.author_association ||= {}));
+  let e;
+  ((m) => ((m.BOT = "Bot"), (m.USER = "User"), (m.ORGANIZATION = "Organization")))((e = n.type ||= {}));
+})((Gn ||= {}));
+var Bn;
+((n) => {
+  let l;
+  ((u) => (u.DELETED = "deleted"))((l = n.action ||= {}));
+  let r;
+  ((R) => (
+    (R.COLLABORATOR = "COLLABORATOR"),
+    (R.CONTRIBUTOR = "CONTRIBUTOR"),
+    (R.FIRST_TIMER = "FIRST_TIMER"),
+    (R.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (R.MANNEQUIN = "MANNEQUIN"),
+    (R.MEMBER = "MEMBER"),
+    (R.NONE = "NONE"),
+    (R.OWNER = "OWNER")
+  ))((r = n.author_association ||= {}));
+  let e;
+  ((m) => ((m.BOT = "Bot"), (m.USER = "User"), (m.ORGANIZATION = "Organization")))((e = n.type ||= {}));
+})((Bn ||= {}));
+var Wn;
+((n) => {
+  let l;
+  ((u) => (u.EDITED = "edited"))((l = n.action ||= {}));
+  let r;
+  ((R) => (
+    (R.COLLABORATOR = "COLLABORATOR"),
+    (R.CONTRIBUTOR = "CONTRIBUTOR"),
+    (R.FIRST_TIMER = "FIRST_TIMER"),
+    (R.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (R.MANNEQUIN = "MANNEQUIN"),
+    (R.MEMBER = "MEMBER"),
+    (R.NONE = "NONE"),
+    (R.OWNER = "OWNER")
+  ))((r = n.author_association ||= {}));
+  let e;
+  ((m) => ((m.BOT = "Bot"), (m.USER = "User"), (m.ORGANIZATION = "Organization")))((e = n.type ||= {}));
+})((Wn ||= {}));
+var Fn;
+((s) => {
+  let l;
+  ((_) => (_.CREATED = "created"))((l = s.action ||= {}));
+  let r;
+  ((c) => ((c.BOT = "Bot"), (c.USER = "User"), (c.ORGANIZATION = "Organization")))((r = s.type ||= {}));
+  let e;
+  ((k) => (
+    (k.COLLABORATOR = "COLLABORATOR"),
+    (k.CONTRIBUTOR = "CONTRIBUTOR"),
+    (k.FIRST_TIMER = "FIRST_TIMER"),
+    (k.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (k.MANNEQUIN = "MANNEQUIN"),
+    (k.MEMBER = "MEMBER"),
+    (k.NONE = "NONE"),
+    (k.OWNER = "OWNER")
+  ))((e = s.author_association ||= {}));
+  let n;
+  ((d) => ((d.OPEN = "open"), (d.LOCKED = "locked"), (d.CONVERTING = "converting"), (d.TRANSFERRING = "transferring")))(
+    (n = s.state ||= {}),
+  );
+})((Fn ||= {}));
+var jn;
+((r) => {
+  let l;
+  ((n) => (n.DELETED = "deleted"))((l = r.action ||= {}));
+})((jn ||= {}));
+var Vn;
+((r) => {
+  let l;
+  ((n) => (n.EDITED = "edited"))((l = r.action ||= {}));
+})((Vn ||= {}));
+var Hn;
+((r) => {
+  let l;
+  ((n) => (n.LABELED = "labeled"))((l = r.action ||= {}));
+})((Hn ||= {}));
+var Qn;
+((r) => {
+  let l;
+  ((n) => (n.LOCKED = "locked"))((l = r.action ||= {}));
+})((Qn ||= {}));
+var Kn;
+((r) => {
+  let l;
+  ((n) => (n.PINNED = "pinned"))((l = r.action ||= {}));
+})((Kn ||= {}));
+var Yn;
+((r) => {
+  let l;
+  ((n) => (n.REOPENED = "reopened"))((l = r.action ||= {}));
+})((Yn ||= {}));
+var Zn;
+((r) => {
+  let l;
+  ((n) => (n.TRANSFERRED = "transferred"))((l = r.action ||= {}));
+})((Zn ||= {}));
+var Xn;
+((n) => {
+  let l;
+  ((u) => (u.UNANSWERED = "unanswered"))((l = n.action ||= {}));
+  let r;
+  ((R) => (
+    (R.COLLABORATOR = "COLLABORATOR"),
+    (R.CONTRIBUTOR = "CONTRIBUTOR"),
+    (R.FIRST_TIMER = "FIRST_TIMER"),
+    (R.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (R.MANNEQUIN = "MANNEQUIN"),
+    (R.MEMBER = "MEMBER"),
+    (R.NONE = "NONE"),
+    (R.OWNER = "OWNER")
+  ))((r = n.author_association ||= {}));
+  let e;
+  ((m) => ((m.BOT = "Bot"), (m.USER = "User"), (m.ORGANIZATION = "Organization")))((e = n.type ||= {}));
+})((Xn ||= {}));
+var $n;
+((r) => {
+  let l;
+  ((n) => (n.UNLABELED = "unlabeled"))((l = r.action ||= {}));
+})(($n ||= {}));
+var Jn;
+((r) => {
+  let l;
+  ((n) => (n.UNLOCKED = "unlocked"))((l = r.action ||= {}));
+})((Jn ||= {}));
+var rs;
+((r) => {
+  let l;
+  ((n) => (n.UNPINNED = "unpinned"))((l = r.action ||= {}));
+})((rs ||= {}));
+var es;
+((e) => {
+  let l;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((l = e.type ||= {}));
+  let r;
+  ((_) => ((_.PUBLIC = "public"), (_.PRIVATE = "private"), (_.INTERNAL = "internal")))((r = e.visibility ||= {}));
+})((es ||= {}));
+var ts;
+((r) => {
+  let l;
+  ((n) => (n.REVOKED = "revoked"))((l = r.action ||= {}));
+})((ts ||= {}));
+var ns;
+((e) => {
+  let l;
+  ((s) => (s.CREATED = "created"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((ns ||= {}));
+var ss;
+((r) => {
+  let l;
+  ((n) => (n.DELETED = "deleted"))((l = r.action ||= {}));
+})((ss ||= {}));
+var is;
+((r) => {
+  let l;
+  ((n) => (n.NEW_PERMISSIONS_ACCEPTED = "new_permissions_accepted"))((l = r.action ||= {}));
+})((is ||= {}));
+var os;
+((n) => {
+  let l;
+  ((u) => (u.ADDED = "added"))((l = n.action ||= {}));
+  let r;
+  ((_) => ((_.ALL = "all"), (_.SELECTED = "selected")))((r = n.repository_selection ||= {}));
+  let e;
+  ((m) => ((m.BOT = "Bot"), (m.USER = "User"), (m.ORGANIZATION = "Organization")))((e = n.type ||= {}));
+})((os ||= {}));
+var ls;
+((n) => {
+  let l;
+  ((u) => (u.REMOVED = "removed"))((l = n.action ||= {}));
+  let r;
+  ((_) => ((_.ALL = "all"), (_.SELECTED = "selected")))((r = n.repository_selection ||= {}));
+  let e;
+  ((m) => ((m.BOT = "Bot"), (m.USER = "User"), (m.ORGANIZATION = "Organization")))((e = n.type ||= {}));
+})((ls ||= {}));
+var as;
+((r) => {
+  let l;
+  ((n) => (n.SUSPEND = "suspend"))((l = r.action ||= {}));
+})((as ||= {}));
+var us;
+((r) => {
+  let l;
+  ((n) => (n.UNSUSPEND = "unsuspend"))((l = r.action ||= {}));
+})((us ||= {}));
+var _s;
+((a) => {
+  let l;
+  ((g) => (g.CREATED = "created"))((l = a.action ||= {}));
+  let r;
+  ((T) => (
+    (T.COLLABORATOR = "COLLABORATOR"),
+    (T.CONTRIBUTOR = "CONTRIBUTOR"),
+    (T.FIRST_TIMER = "FIRST_TIMER"),
+    (T.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (T.MANNEQUIN = "MANNEQUIN"),
+    (T.MEMBER = "MEMBER"),
+    (T.NONE = "NONE"),
+    (T.OWNER = "OWNER")
+  ))((r = a.author_association ||= {}));
+  let e;
+  ((y) => ((y.BOT = "Bot"), (y.USER = "User"), (y.ORGANIZATION = "Organization")))((e = a.type ||= {}));
+  let n;
+  ((A) => ((A.RESOLVED = "resolved"), (A.OFF_TOPIC = "off-topic"), (A.TOO_HEATED = "too heated"), (A.SPAM = "spam")))(
+    (n = a.active_lock_reason ||= {}),
+  );
+  let s;
+  ((t) => ((t.OPEN = "open"), (t.CLOSED = "closed")))((s = a.state ||= {}));
+  let u;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((u = a.actions ||= {}));
+  let _;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((_ = a.administration ||= {}));
+  let m;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((m = a.checks ||= {}));
+  let c;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((c = a.content_references ||= {}));
+  let d;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((d = a.contents ||= {}));
+  let v;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((v = a.deployments ||= {}));
+  let h;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((h = a.discussions ||= {}));
+  let R;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((R = a.emails ||= {}));
+  let k;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((k = a.environments ||= {}));
+  let b;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((b = a.issues ||= {}));
+  let p;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((p = a.keys ||= {}));
+  let f;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((f = a.members ||= {}));
+  let O;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((O = a.metadata ||= {}));
+  let I;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((I = a.organization_administration ||= {}));
+  let P;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((P = a.organization_hooks ||= {}));
+  let E;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((E = a.organization_packages ||= {}));
+  let D;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((D = a.organization_plan ||= {}));
+  let L;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write"), (y.ADMIN = "admin")))((L = a.organization_projects ||= {}));
+  let C;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((C = a.organization_secrets ||= {}));
+  let U;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((U = a.organization_self_hosted_runners ||= {}));
+  let M;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((M = a.organization_user_blocking ||= {}));
+  let G;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((G = a.packages ||= {}));
+  let B;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((B = a.pages ||= {}));
+  let W;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((W = a.pull_requests ||= {}));
+  let F;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((F = a.repository_hooks ||= {}));
+  let j;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write"), (y.ADMIN = "admin")))((j = a.repository_projects ||= {}));
+  let V;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((V = a.secret_scanning_alerts ||= {}));
+  let H;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((H = a.secrets ||= {}));
+  let Q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((Q = a.security_events ||= {}));
+  let z;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((z = a.security_scanning_alert ||= {}));
+  let K;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((K = a.single_file ||= {}));
+  let S;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((S = a.statuses ||= {}));
+  let x;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((x = a.team_discussions ||= {}));
+  let q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((q = a.vulnerability_alerts ||= {}));
+  let w;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((w = a.workflows ||= {}));
+})((_s ||= {}));
+var gs;
+((a) => {
+  let l;
+  ((g) => (g.DELETED = "deleted"))((l = a.action ||= {}));
+  let r;
+  ((T) => (
+    (T.COLLABORATOR = "COLLABORATOR"),
+    (T.CONTRIBUTOR = "CONTRIBUTOR"),
+    (T.FIRST_TIMER = "FIRST_TIMER"),
+    (T.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (T.MANNEQUIN = "MANNEQUIN"),
+    (T.MEMBER = "MEMBER"),
+    (T.NONE = "NONE"),
+    (T.OWNER = "OWNER")
+  ))((r = a.author_association ||= {}));
+  let e;
+  ((A) => ((A.BOT = "Bot"), (A.USER = "User"), (A.ORGANIZATION = "Organization"), (A.MANNEQUIN = "Mannequin")))(
+    (e = a.type ||= {}),
+  );
+  let n;
+  ((A) => ((A.RESOLVED = "resolved"), (A.OFF_TOPIC = "off-topic"), (A.TOO_HEATED = "too heated"), (A.SPAM = "spam")))(
+    (n = a.active_lock_reason ||= {}),
+  );
+  let s;
+  ((t) => ((t.OPEN = "open"), (t.CLOSED = "closed")))((s = a.state ||= {}));
+  let u;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((u = a.actions ||= {}));
+  let _;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((_ = a.administration ||= {}));
+  let m;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((m = a.checks ||= {}));
+  let c;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((c = a.content_references ||= {}));
+  let d;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((d = a.contents ||= {}));
+  let v;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((v = a.deployments ||= {}));
+  let h;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((h = a.discussions ||= {}));
+  let R;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((R = a.emails ||= {}));
+  let k;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((k = a.environments ||= {}));
+  let b;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((b = a.issues ||= {}));
+  let p;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((p = a.keys ||= {}));
+  let f;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((f = a.members ||= {}));
+  let O;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((O = a.metadata ||= {}));
+  let I;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((I = a.organization_administration ||= {}));
+  let P;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((P = a.organization_hooks ||= {}));
+  let E;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((E = a.organization_packages ||= {}));
+  let D;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((D = a.organization_plan ||= {}));
+  let L;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((L = a.organization_projects ||= {}));
+  let C;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((C = a.organization_secrets ||= {}));
+  let U;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((U = a.organization_self_hosted_runners ||= {}));
+  let M;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((M = a.organization_user_blocking ||= {}));
+  let G;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((G = a.packages ||= {}));
+  let B;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((B = a.pages ||= {}));
+  let W;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((W = a.pull_requests ||= {}));
+  let F;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((F = a.repository_hooks ||= {}));
+  let j;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((j = a.repository_projects ||= {}));
+  let V;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((V = a.secret_scanning_alerts ||= {}));
+  let H;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((H = a.secrets ||= {}));
+  let Q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((Q = a.security_events ||= {}));
+  let z;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((z = a.security_scanning_alert ||= {}));
+  let K;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((K = a.single_file ||= {}));
+  let S;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((S = a.statuses ||= {}));
+  let x;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((x = a.team_discussions ||= {}));
+  let q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((q = a.vulnerability_alerts ||= {}));
+  let w;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((w = a.workflows ||= {}));
+})((gs ||= {}));
+var ms;
+((a) => {
+  let l;
+  ((g) => (g.EDITED = "edited"))((l = a.action ||= {}));
+  let r;
+  ((T) => (
+    (T.COLLABORATOR = "COLLABORATOR"),
+    (T.CONTRIBUTOR = "CONTRIBUTOR"),
+    (T.FIRST_TIMER = "FIRST_TIMER"),
+    (T.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (T.MANNEQUIN = "MANNEQUIN"),
+    (T.MEMBER = "MEMBER"),
+    (T.NONE = "NONE"),
+    (T.OWNER = "OWNER")
+  ))((r = a.author_association ||= {}));
+  let e;
+  ((A) => ((A.BOT = "Bot"), (A.USER = "User"), (A.ORGANIZATION = "Organization"), (A.MANNEQUIN = "Mannequin")))(
+    (e = a.type ||= {}),
+  );
+  let n;
+  ((A) => ((A.RESOLVED = "resolved"), (A.OFF_TOPIC = "off-topic"), (A.TOO_HEATED = "too heated"), (A.SPAM = "spam")))(
+    (n = a.active_lock_reason ||= {}),
+  );
+  let s;
+  ((t) => ((t.OPEN = "open"), (t.CLOSED = "closed")))((s = a.state ||= {}));
+  let u;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((u = a.actions ||= {}));
+  let _;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((_ = a.administration ||= {}));
+  let m;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((m = a.checks ||= {}));
+  let c;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((c = a.content_references ||= {}));
+  let d;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((d = a.contents ||= {}));
+  let v;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((v = a.deployments ||= {}));
+  let h;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((h = a.discussions ||= {}));
+  let R;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((R = a.emails ||= {}));
+  let k;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((k = a.environments ||= {}));
+  let b;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((b = a.issues ||= {}));
+  let p;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((p = a.keys ||= {}));
+  let f;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((f = a.members ||= {}));
+  let O;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((O = a.metadata ||= {}));
+  let I;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((I = a.organization_administration ||= {}));
+  let P;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((P = a.organization_hooks ||= {}));
+  let E;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((E = a.organization_packages ||= {}));
+  let D;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((D = a.organization_plan ||= {}));
+  let L;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write"), (y.ADMIN = "admin")))((L = a.organization_projects ||= {}));
+  let C;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((C = a.organization_secrets ||= {}));
+  let U;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((U = a.organization_self_hosted_runners ||= {}));
+  let M;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((M = a.organization_user_blocking ||= {}));
+  let G;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((G = a.packages ||= {}));
+  let B;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((B = a.pages ||= {}));
+  let W;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((W = a.pull_requests ||= {}));
+  let F;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((F = a.repository_hooks ||= {}));
+  let j;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((j = a.repository_projects ||= {}));
+  let V;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((V = a.secret_scanning_alerts ||= {}));
+  let H;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((H = a.secrets ||= {}));
+  let Q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((Q = a.security_events ||= {}));
+  let z;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((z = a.security_scanning_alert ||= {}));
+  let K;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((K = a.single_file ||= {}));
+  let S;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((S = a.statuses ||= {}));
+  let x;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((x = a.team_discussions ||= {}));
+  let q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((q = a.vulnerability_alerts ||= {}));
+  let w;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((w = a.workflows ||= {}));
+})((ms ||= {}));
+var ps;
+((a) => {
+  let l;
+  ((g) => (g.ASSIGNED = "assigned"))((l = a.action ||= {}));
+  let r;
+  ((y) => ((y.BOT = "Bot"), (y.USER = "User"), (y.ORGANIZATION = "Organization")))((r = a.type ||= {}));
+  let e;
+  ((A) => ((A.RESOLVED = "resolved"), (A.OFF_TOPIC = "off-topic"), (A.TOO_HEATED = "too heated"), (A.SPAM = "spam")))(
+    (e = a.active_lock_reason ||= {}),
+  );
+  let n;
+  ((T) => (
+    (T.COLLABORATOR = "COLLABORATOR"),
+    (T.CONTRIBUTOR = "CONTRIBUTOR"),
+    (T.FIRST_TIMER = "FIRST_TIMER"),
+    (T.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (T.MANNEQUIN = "MANNEQUIN"),
+    (T.MEMBER = "MEMBER"),
+    (T.NONE = "NONE"),
+    (T.OWNER = "OWNER")
+  ))((n = a.author_association ||= {}));
+  let s;
+  ((t) => ((t.OPEN = "open"), (t.CLOSED = "closed")))((s = a.state ||= {}));
+  let u;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((u = a.actions ||= {}));
+  let _;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((_ = a.administration ||= {}));
+  let m;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((m = a.checks ||= {}));
+  let c;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((c = a.content_references ||= {}));
+  let d;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((d = a.contents ||= {}));
+  let v;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((v = a.deployments ||= {}));
+  let h;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((h = a.discussions ||= {}));
+  let R;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((R = a.emails ||= {}));
+  let k;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((k = a.environments ||= {}));
+  let b;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((b = a.issues ||= {}));
+  let p;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((p = a.keys ||= {}));
+  let f;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((f = a.members ||= {}));
+  let O;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((O = a.metadata ||= {}));
+  let I;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((I = a.organization_administration ||= {}));
+  let P;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((P = a.organization_hooks ||= {}));
+  let E;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((E = a.organization_packages ||= {}));
+  let D;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((D = a.organization_plan ||= {}));
+  let L;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write"), (y.ADMIN = "admin")))((L = a.organization_projects ||= {}));
+  let C;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((C = a.organization_secrets ||= {}));
+  let U;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((U = a.organization_self_hosted_runners ||= {}));
+  let M;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((M = a.organization_user_blocking ||= {}));
+  let G;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((G = a.packages ||= {}));
+  let B;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((B = a.pages ||= {}));
+  let W;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((W = a.pull_requests ||= {}));
+  let F;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((F = a.repository_hooks ||= {}));
+  let j;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((j = a.repository_projects ||= {}));
+  let V;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((V = a.secret_scanning_alerts ||= {}));
+  let H;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((H = a.secrets ||= {}));
+  let Q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((Q = a.security_events ||= {}));
+  let z;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((z = a.security_scanning_alert ||= {}));
+  let K;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((K = a.single_file ||= {}));
+  let S;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((S = a.statuses ||= {}));
+  let x;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((x = a.team_discussions ||= {}));
+  let q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((q = a.vulnerability_alerts ||= {}));
+  let w;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((w = a.workflows ||= {}));
+})((ps ||= {}));
+var ds;
+((a) => {
+  let l;
+  ((g) => (g.CLOSED = "closed"))((l = a.action ||= {}));
+  let r;
+  ((A) => ((A.RESOLVED = "resolved"), (A.OFF_TOPIC = "off-topic"), (A.TOO_HEATED = "too heated"), (A.SPAM = "spam")))(
+    (r = a.active_lock_reason ||= {}),
+  );
+  let e;
+  ((A) => ((A.BOT = "Bot"), (A.USER = "User"), (A.ORGANIZATION = "Organization"), (A.MANNEQUIN = "Mannequin")))(
+    (e = a.type ||= {}),
+  );
+  let n;
+  ((T) => (
+    (T.COLLABORATOR = "COLLABORATOR"),
+    (T.CONTRIBUTOR = "CONTRIBUTOR"),
+    (T.FIRST_TIMER = "FIRST_TIMER"),
+    (T.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (T.MANNEQUIN = "MANNEQUIN"),
+    (T.MEMBER = "MEMBER"),
+    (T.NONE = "NONE"),
+    (T.OWNER = "OWNER")
+  ))((n = a.author_association ||= {}));
+  let s;
+  ((t) => ((t.OPEN = "open"), (t.CLOSED = "closed")))((s = a.state ||= {}));
+  let u;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((u = a.actions ||= {}));
+  let _;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((_ = a.administration ||= {}));
+  let m;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((m = a.checks ||= {}));
+  let c;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((c = a.content_references ||= {}));
+  let d;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((d = a.contents ||= {}));
+  let v;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((v = a.deployments ||= {}));
+  let h;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((h = a.discussions ||= {}));
+  let R;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((R = a.emails ||= {}));
+  let k;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((k = a.environments ||= {}));
+  let b;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((b = a.issues ||= {}));
+  let p;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((p = a.keys ||= {}));
+  let f;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((f = a.members ||= {}));
+  let O;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((O = a.metadata ||= {}));
+  let I;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((I = a.organization_administration ||= {}));
+  let P;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((P = a.organization_hooks ||= {}));
+  let E;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((E = a.organization_packages ||= {}));
+  let D;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((D = a.organization_plan ||= {}));
+  let L;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write"), (y.ADMIN = "admin")))((L = a.organization_projects ||= {}));
+  let C;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((C = a.organization_secrets ||= {}));
+  let U;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((U = a.organization_self_hosted_runners ||= {}));
+  let M;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((M = a.organization_user_blocking ||= {}));
+  let G;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((G = a.packages ||= {}));
+  let B;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((B = a.pages ||= {}));
+  let W;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((W = a.pull_requests ||= {}));
+  let F;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((F = a.repository_hooks ||= {}));
+  let j;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((j = a.repository_projects ||= {}));
+  let V;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((V = a.secret_scanning_alerts ||= {}));
+  let H;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((H = a.secrets ||= {}));
+  let Q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((Q = a.security_events ||= {}));
+  let z;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((z = a.security_scanning_alert ||= {}));
+  let K;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((K = a.single_file ||= {}));
+  let S;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((S = a.statuses ||= {}));
+  let x;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((x = a.team_discussions ||= {}));
+  let q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((q = a.vulnerability_alerts ||= {}));
+  let w;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((w = a.workflows ||= {}));
+})((ds ||= {}));
+var cs;
+((a) => {
+  let l;
+  ((g) => (g.DELETED = "deleted"))((l = a.action ||= {}));
+  let r;
+  ((A) => ((A.RESOLVED = "resolved"), (A.OFF_TOPIC = "off-topic"), (A.TOO_HEATED = "too heated"), (A.SPAM = "spam")))(
+    (r = a.active_lock_reason ||= {}),
+  );
+  let e;
+  ((y) => ((y.BOT = "Bot"), (y.USER = "User"), (y.ORGANIZATION = "Organization")))((e = a.type ||= {}));
+  let n;
+  ((T) => (
+    (T.COLLABORATOR = "COLLABORATOR"),
+    (T.CONTRIBUTOR = "CONTRIBUTOR"),
+    (T.FIRST_TIMER = "FIRST_TIMER"),
+    (T.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (T.MANNEQUIN = "MANNEQUIN"),
+    (T.MEMBER = "MEMBER"),
+    (T.NONE = "NONE"),
+    (T.OWNER = "OWNER")
+  ))((n = a.author_association ||= {}));
+  let s;
+  ((t) => ((t.OPEN = "open"), (t.CLOSED = "closed")))((s = a.state ||= {}));
+  let u;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((u = a.actions ||= {}));
+  let _;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((_ = a.administration ||= {}));
+  let m;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((m = a.checks ||= {}));
+  let c;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((c = a.content_references ||= {}));
+  let d;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((d = a.contents ||= {}));
+  let v;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((v = a.deployments ||= {}));
+  let h;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((h = a.discussions ||= {}));
+  let R;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((R = a.emails ||= {}));
+  let k;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((k = a.environments ||= {}));
+  let b;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((b = a.issues ||= {}));
+  let p;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((p = a.keys ||= {}));
+  let f;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((f = a.members ||= {}));
+  let O;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((O = a.metadata ||= {}));
+  let I;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((I = a.organization_administration ||= {}));
+  let P;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((P = a.organization_hooks ||= {}));
+  let E;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((E = a.organization_packages ||= {}));
+  let D;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((D = a.organization_plan ||= {}));
+  let L;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((L = a.organization_projects ||= {}));
+  let C;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((C = a.organization_secrets ||= {}));
+  let U;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((U = a.organization_self_hosted_runners ||= {}));
+  let M;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((M = a.organization_user_blocking ||= {}));
+  let G;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((G = a.packages ||= {}));
+  let B;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((B = a.pages ||= {}));
+  let W;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((W = a.pull_requests ||= {}));
+  let F;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((F = a.repository_hooks ||= {}));
+  let j;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((j = a.repository_projects ||= {}));
+  let V;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((V = a.secret_scanning_alerts ||= {}));
+  let H;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((H = a.secrets ||= {}));
+  let Q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((Q = a.security_events ||= {}));
+  let z;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((z = a.security_scanning_alert ||= {}));
+  let K;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((K = a.single_file ||= {}));
+  let S;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((S = a.statuses ||= {}));
+  let x;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((x = a.team_discussions ||= {}));
+  let q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((q = a.vulnerability_alerts ||= {}));
+  let w;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((w = a.workflows ||= {}));
+})((cs ||= {}));
+var bs;
+((a) => {
+  let l;
+  ((g) => (g.DEMILESTONED = "demilestoned"))((l = a.action ||= {}));
+  let r;
+  ((A) => ((A.RESOLVED = "resolved"), (A.OFF_TOPIC = "off-topic"), (A.TOO_HEATED = "too heated"), (A.SPAM = "spam")))(
+    (r = a.active_lock_reason ||= {}),
+  );
+  let e;
+  ((A) => ((A.BOT = "Bot"), (A.USER = "User"), (A.ORGANIZATION = "Organization"), (A.MANNEQUIN = "Mannequin")))(
+    (e = a.type ||= {}),
+  );
+  let n;
+  ((T) => (
+    (T.COLLABORATOR = "COLLABORATOR"),
+    (T.CONTRIBUTOR = "CONTRIBUTOR"),
+    (T.FIRST_TIMER = "FIRST_TIMER"),
+    (T.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (T.MANNEQUIN = "MANNEQUIN"),
+    (T.MEMBER = "MEMBER"),
+    (T.NONE = "NONE"),
+    (T.OWNER = "OWNER")
+  ))((n = a.author_association ||= {}));
+  let s;
+  ((t) => ((t.OPEN = "open"), (t.CLOSED = "closed")))((s = a.state ||= {}));
+  let u;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((u = a.actions ||= {}));
+  let _;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((_ = a.administration ||= {}));
+  let m;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((m = a.checks ||= {}));
+  let c;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((c = a.content_references ||= {}));
+  let d;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((d = a.contents ||= {}));
+  let v;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((v = a.deployments ||= {}));
+  let h;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((h = a.discussions ||= {}));
+  let R;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((R = a.emails ||= {}));
+  let k;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((k = a.environments ||= {}));
+  let b;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((b = a.issues ||= {}));
+  let p;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((p = a.keys ||= {}));
+  let f;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((f = a.members ||= {}));
+  let O;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((O = a.metadata ||= {}));
+  let I;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((I = a.organization_administration ||= {}));
+  let P;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((P = a.organization_hooks ||= {}));
+  let E;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((E = a.organization_packages ||= {}));
+  let D;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((D = a.organization_plan ||= {}));
+  let L;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write"), (y.ADMIN = "admin")))((L = a.organization_projects ||= {}));
+  let C;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((C = a.organization_secrets ||= {}));
+  let U;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((U = a.organization_self_hosted_runners ||= {}));
+  let M;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((M = a.organization_user_blocking ||= {}));
+  let G;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((G = a.packages ||= {}));
+  let B;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((B = a.pages ||= {}));
+  let W;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((W = a.pull_requests ||= {}));
+  let F;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((F = a.repository_hooks ||= {}));
+  let j;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((j = a.repository_projects ||= {}));
+  let V;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((V = a.secret_scanning_alerts ||= {}));
+  let H;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((H = a.secrets ||= {}));
+  let Q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((Q = a.security_events ||= {}));
+  let z;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((z = a.security_scanning_alert ||= {}));
+  let K;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((K = a.single_file ||= {}));
+  let S;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((S = a.statuses ||= {}));
+  let x;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((x = a.team_discussions ||= {}));
+  let q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((q = a.vulnerability_alerts ||= {}));
+  let w;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((w = a.workflows ||= {}));
+})((bs ||= {}));
+var hs;
+((a) => {
+  let l;
+  ((g) => (g.EDITED = "edited"))((l = a.action ||= {}));
+  let r;
+  ((A) => ((A.RESOLVED = "resolved"), (A.OFF_TOPIC = "off-topic"), (A.TOO_HEATED = "too heated"), (A.SPAM = "spam")))(
+    (r = a.active_lock_reason ||= {}),
+  );
+  let e;
+  ((A) => ((A.BOT = "Bot"), (A.USER = "User"), (A.ORGANIZATION = "Organization"), (A.MANNEQUIN = "Mannequin")))(
+    (e = a.type ||= {}),
+  );
+  let n;
+  ((T) => (
+    (T.COLLABORATOR = "COLLABORATOR"),
+    (T.CONTRIBUTOR = "CONTRIBUTOR"),
+    (T.FIRST_TIMER = "FIRST_TIMER"),
+    (T.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (T.MANNEQUIN = "MANNEQUIN"),
+    (T.MEMBER = "MEMBER"),
+    (T.NONE = "NONE"),
+    (T.OWNER = "OWNER")
+  ))((n = a.author_association ||= {}));
+  let s;
+  ((t) => ((t.OPEN = "open"), (t.CLOSED = "closed")))((s = a.state ||= {}));
+  let u;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((u = a.actions ||= {}));
+  let _;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((_ = a.administration ||= {}));
+  let m;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((m = a.checks ||= {}));
+  let c;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((c = a.content_references ||= {}));
+  let d;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((d = a.contents ||= {}));
+  let v;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((v = a.deployments ||= {}));
+  let h;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((h = a.discussions ||= {}));
+  let R;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((R = a.emails ||= {}));
+  let k;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((k = a.environments ||= {}));
+  let b;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((b = a.issues ||= {}));
+  let p;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((p = a.keys ||= {}));
+  let f;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((f = a.members ||= {}));
+  let O;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((O = a.metadata ||= {}));
+  let I;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((I = a.organization_administration ||= {}));
+  let P;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((P = a.organization_hooks ||= {}));
+  let E;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((E = a.organization_packages ||= {}));
+  let D;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((D = a.organization_plan ||= {}));
+  let L;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write"), (y.ADMIN = "admin")))((L = a.organization_projects ||= {}));
+  let C;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((C = a.organization_secrets ||= {}));
+  let U;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((U = a.organization_self_hosted_runners ||= {}));
+  let M;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((M = a.organization_user_blocking ||= {}));
+  let G;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((G = a.packages ||= {}));
+  let B;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((B = a.pages ||= {}));
+  let W;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((W = a.pull_requests ||= {}));
+  let F;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((F = a.repository_hooks ||= {}));
+  let j;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((j = a.repository_projects ||= {}));
+  let V;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((V = a.secret_scanning_alerts ||= {}));
+  let H;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((H = a.secrets ||= {}));
+  let Q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((Q = a.security_events ||= {}));
+  let z;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((z = a.security_scanning_alert ||= {}));
+  let K;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((K = a.single_file ||= {}));
+  let S;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((S = a.statuses ||= {}));
+  let x;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((x = a.team_discussions ||= {}));
+  let q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((q = a.vulnerability_alerts ||= {}));
+  let w;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((w = a.workflows ||= {}));
+})((hs ||= {}));
+var ys;
+((a) => {
+  let l;
+  ((g) => (g.LABELED = "labeled"))((l = a.action ||= {}));
+  let r;
+  ((A) => ((A.RESOLVED = "resolved"), (A.OFF_TOPIC = "off-topic"), (A.TOO_HEATED = "too heated"), (A.SPAM = "spam")))(
+    (r = a.active_lock_reason ||= {}),
+  );
+  let e;
+  ((A) => ((A.BOT = "Bot"), (A.USER = "User"), (A.ORGANIZATION = "Organization"), (A.MANNEQUIN = "Mannequin")))(
+    (e = a.type ||= {}),
+  );
+  let n;
+  ((T) => (
+    (T.COLLABORATOR = "COLLABORATOR"),
+    (T.CONTRIBUTOR = "CONTRIBUTOR"),
+    (T.FIRST_TIMER = "FIRST_TIMER"),
+    (T.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (T.MANNEQUIN = "MANNEQUIN"),
+    (T.MEMBER = "MEMBER"),
+    (T.NONE = "NONE"),
+    (T.OWNER = "OWNER")
+  ))((n = a.author_association ||= {}));
+  let s;
+  ((t) => ((t.OPEN = "open"), (t.CLOSED = "closed")))((s = a.state ||= {}));
+  let u;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((u = a.actions ||= {}));
+  let _;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((_ = a.administration ||= {}));
+  let m;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((m = a.checks ||= {}));
+  let c;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((c = a.content_references ||= {}));
+  let d;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((d = a.contents ||= {}));
+  let v;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((v = a.deployments ||= {}));
+  let h;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((h = a.discussions ||= {}));
+  let R;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((R = a.emails ||= {}));
+  let k;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((k = a.environments ||= {}));
+  let b;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((b = a.issues ||= {}));
+  let p;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((p = a.keys ||= {}));
+  let f;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((f = a.members ||= {}));
+  let O;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((O = a.metadata ||= {}));
+  let I;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((I = a.organization_administration ||= {}));
+  let P;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((P = a.organization_hooks ||= {}));
+  let E;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((E = a.organization_packages ||= {}));
+  let D;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((D = a.organization_plan ||= {}));
+  let L;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write"), (y.ADMIN = "admin")))((L = a.organization_projects ||= {}));
+  let C;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((C = a.organization_secrets ||= {}));
+  let U;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((U = a.organization_self_hosted_runners ||= {}));
+  let M;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((M = a.organization_user_blocking ||= {}));
+  let G;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((G = a.packages ||= {}));
+  let B;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((B = a.pages ||= {}));
+  let W;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((W = a.pull_requests ||= {}));
+  let F;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((F = a.repository_hooks ||= {}));
+  let j;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((j = a.repository_projects ||= {}));
+  let V;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((V = a.secret_scanning_alerts ||= {}));
+  let H;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((H = a.secrets ||= {}));
+  let Q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((Q = a.security_events ||= {}));
+  let z;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((z = a.security_scanning_alert ||= {}));
+  let K;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((K = a.single_file ||= {}));
+  let S;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((S = a.statuses ||= {}));
+  let x;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((x = a.team_discussions ||= {}));
+  let q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((q = a.vulnerability_alerts ||= {}));
+  let w;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((w = a.workflows ||= {}));
+})((ys ||= {}));
+var fs;
+((a) => {
+  let l;
+  ((g) => (g.LOCKED = "locked"))((l = a.action ||= {}));
+  let r;
+  ((A) => ((A.RESOLVED = "resolved"), (A.OFF_TOPIC = "off-topic"), (A.TOO_HEATED = "too heated"), (A.SPAM = "spam")))(
+    (r = a.active_lock_reason ||= {}),
+  );
+  let e;
+  ((y) => ((y.BOT = "Bot"), (y.USER = "User"), (y.ORGANIZATION = "Organization")))((e = a.type ||= {}));
+  let n;
+  ((T) => (
+    (T.COLLABORATOR = "COLLABORATOR"),
+    (T.CONTRIBUTOR = "CONTRIBUTOR"),
+    (T.FIRST_TIMER = "FIRST_TIMER"),
+    (T.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (T.MANNEQUIN = "MANNEQUIN"),
+    (T.MEMBER = "MEMBER"),
+    (T.NONE = "NONE"),
+    (T.OWNER = "OWNER")
+  ))((n = a.author_association ||= {}));
+  let s;
+  ((t) => ((t.OPEN = "open"), (t.CLOSED = "closed")))((s = a.state ||= {}));
+  let u;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((u = a.actions ||= {}));
+  let _;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((_ = a.administration ||= {}));
+  let m;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((m = a.checks ||= {}));
+  let c;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((c = a.content_references ||= {}));
+  let d;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((d = a.contents ||= {}));
+  let v;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((v = a.deployments ||= {}));
+  let h;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((h = a.discussions ||= {}));
+  let R;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((R = a.emails ||= {}));
+  let k;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((k = a.environments ||= {}));
+  let b;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((b = a.issues ||= {}));
+  let p;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((p = a.keys ||= {}));
+  let f;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((f = a.members ||= {}));
+  let O;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((O = a.metadata ||= {}));
+  let I;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((I = a.organization_administration ||= {}));
+  let P;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((P = a.organization_hooks ||= {}));
+  let E;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((E = a.organization_packages ||= {}));
+  let D;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((D = a.organization_plan ||= {}));
+  let L;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((L = a.organization_projects ||= {}));
+  let C;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((C = a.organization_secrets ||= {}));
+  let U;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((U = a.organization_self_hosted_runners ||= {}));
+  let M;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((M = a.organization_user_blocking ||= {}));
+  let G;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((G = a.packages ||= {}));
+  let B;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((B = a.pages ||= {}));
+  let W;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((W = a.pull_requests ||= {}));
+  let F;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((F = a.repository_hooks ||= {}));
+  let j;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((j = a.repository_projects ||= {}));
+  let V;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((V = a.secret_scanning_alerts ||= {}));
+  let H;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((H = a.secrets ||= {}));
+  let Q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((Q = a.security_events ||= {}));
+  let z;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((z = a.security_scanning_alert ||= {}));
+  let K;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((K = a.single_file ||= {}));
+  let S;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((S = a.statuses ||= {}));
+  let x;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((x = a.team_discussions ||= {}));
+  let q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((q = a.vulnerability_alerts ||= {}));
+  let w;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((w = a.workflows ||= {}));
+})((fs ||= {}));
+var ws;
+((a) => {
+  let l;
+  ((g) => (g.MILESTONED = "milestoned"))((l = a.action ||= {}));
+  let r;
+  ((A) => ((A.RESOLVED = "resolved"), (A.OFF_TOPIC = "off-topic"), (A.TOO_HEATED = "too heated"), (A.SPAM = "spam")))(
+    (r = a.active_lock_reason ||= {}),
+  );
+  let e;
+  ((y) => ((y.BOT = "Bot"), (y.USER = "User"), (y.ORGANIZATION = "Organization")))((e = a.type ||= {}));
+  let n;
+  ((T) => (
+    (T.COLLABORATOR = "COLLABORATOR"),
+    (T.CONTRIBUTOR = "CONTRIBUTOR"),
+    (T.FIRST_TIMER = "FIRST_TIMER"),
+    (T.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (T.MANNEQUIN = "MANNEQUIN"),
+    (T.MEMBER = "MEMBER"),
+    (T.NONE = "NONE"),
+    (T.OWNER = "OWNER")
+  ))((n = a.author_association ||= {}));
+  let s;
+  ((t) => ((t.OPEN = "open"), (t.CLOSED = "closed")))((s = a.state ||= {}));
+  let u;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((u = a.actions ||= {}));
+  let _;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((_ = a.administration ||= {}));
+  let m;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((m = a.checks ||= {}));
+  let c;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((c = a.content_references ||= {}));
+  let d;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((d = a.contents ||= {}));
+  let v;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((v = a.deployments ||= {}));
+  let h;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((h = a.discussions ||= {}));
+  let R;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((R = a.emails ||= {}));
+  let k;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((k = a.environments ||= {}));
+  let b;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((b = a.issues ||= {}));
+  let p;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((p = a.keys ||= {}));
+  let f;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((f = a.members ||= {}));
+  let O;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((O = a.metadata ||= {}));
+  let I;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((I = a.organization_administration ||= {}));
+  let P;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((P = a.organization_hooks ||= {}));
+  let E;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((E = a.organization_packages ||= {}));
+  let D;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((D = a.organization_plan ||= {}));
+  let L;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write"), (y.ADMIN = "admin")))((L = a.organization_projects ||= {}));
+  let C;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((C = a.organization_secrets ||= {}));
+  let U;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((U = a.organization_self_hosted_runners ||= {}));
+  let M;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((M = a.organization_user_blocking ||= {}));
+  let G;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((G = a.packages ||= {}));
+  let B;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((B = a.pages ||= {}));
+  let W;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((W = a.pull_requests ||= {}));
+  let F;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((F = a.repository_hooks ||= {}));
+  let j;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((j = a.repository_projects ||= {}));
+  let V;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((V = a.secret_scanning_alerts ||= {}));
+  let H;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((H = a.secrets ||= {}));
+  let Q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((Q = a.security_events ||= {}));
+  let z;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((z = a.security_scanning_alert ||= {}));
+  let K;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((K = a.single_file ||= {}));
+  let S;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((S = a.statuses ||= {}));
+  let x;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((x = a.team_discussions ||= {}));
+  let q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((q = a.vulnerability_alerts ||= {}));
+  let w;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((w = a.workflows ||= {}));
+})((ws ||= {}));
+var Es;
+((N) => {
+  let l;
+  ((t) => (t.OPENED = "opened"))((l = N.action ||= {}));
+  let r;
+  ((X) => ((X.RESOLVED = "resolved"), (X.OFF_TOPIC = "off-topic"), (X.TOO_HEATED = "too heated"), (X.SPAM = "spam")))(
+    (r = N.active_lock_reason ||= {}),
+  );
+  let e;
+  ((A) => ((A.BOT = "Bot"), (A.USER = "User"), (A.ORGANIZATION = "Organization")))((e = N.type ||= {}));
+  let n;
+  ((Z) => (
+    (Z.COLLABORATOR = "COLLABORATOR"),
+    (Z.CONTRIBUTOR = "CONTRIBUTOR"),
+    (Z.FIRST_TIMER = "FIRST_TIMER"),
+    (Z.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (Z.MANNEQUIN = "MANNEQUIN"),
+    (Z.MEMBER = "MEMBER"),
+    (Z.NONE = "NONE"),
+    (Z.OWNER = "OWNER")
+  ))((n = N.author_association ||= {}));
+  let s;
+  ((y) => ((y.OPEN = "open"), (y.CLOSED = "closed")))((s = N.state ||= {}));
+  let u;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((u = N.actions ||= {}));
+  let _;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((_ = N.administration ||= {}));
+  let m;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((m = N.checks ||= {}));
+  let c;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((c = N.content_references ||= {}));
+  let d;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((d = N.contents ||= {}));
+  let v;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((v = N.deployments ||= {}));
+  let h;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((h = N.discussions ||= {}));
+  let R;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((R = N.emails ||= {}));
+  let k;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((k = N.environments ||= {}));
+  let b;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((b = N.issues ||= {}));
+  let p;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((p = N.keys ||= {}));
+  let f;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((f = N.members ||= {}));
+  let O;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((O = N.metadata ||= {}));
+  let I;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((I = N.organization_administration ||= {}));
+  let P;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((P = N.organization_hooks ||= {}));
+  let E;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((E = N.organization_packages ||= {}));
+  let D;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((D = N.organization_plan ||= {}));
+  let L;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((L = N.organization_projects ||= {}));
+  let C;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((C = N.organization_secrets ||= {}));
+  let U;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((U = N.organization_self_hosted_runners ||= {}));
+  let M;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((M = N.organization_user_blocking ||= {}));
+  let G;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((G = N.packages ||= {}));
+  let B;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((B = N.pages ||= {}));
+  let W;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((W = N.pull_requests ||= {}));
+  let F;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((F = N.repository_hooks ||= {}));
+  let j;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((j = N.repository_projects ||= {}));
+  let V;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((V = N.secret_scanning_alerts ||= {}));
+  let H;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((H = N.secrets ||= {}));
+  let Q;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((Q = N.security_events ||= {}));
+  let z;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((z = N.security_scanning_alert ||= {}));
+  let K;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((K = N.single_file ||= {}));
+  let S;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((S = N.statuses ||= {}));
+  let x;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((x = N.team_discussions ||= {}));
+  let q;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((q = N.vulnerability_alerts ||= {}));
+  let w;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((w = N.workflows ||= {}));
+  let a;
+  ((A) => ((A.PUBLIC = "public"), (A.PRIVATE = "private"), (A.INTERNAL = "internal")))((a = N.visibility ||= {}));
+})((Es ||= {}));
+var vs;
+((a) => {
+  let l;
+  ((g) => (g.PINNED = "pinned"))((l = a.action ||= {}));
+  let r;
+  ((A) => ((A.RESOLVED = "resolved"), (A.OFF_TOPIC = "off-topic"), (A.TOO_HEATED = "too heated"), (A.SPAM = "spam")))(
+    (r = a.active_lock_reason ||= {}),
+  );
+  let e;
+  ((y) => ((y.BOT = "Bot"), (y.USER = "User"), (y.ORGANIZATION = "Organization")))((e = a.type ||= {}));
+  let n;
+  ((T) => (
+    (T.COLLABORATOR = "COLLABORATOR"),
+    (T.CONTRIBUTOR = "CONTRIBUTOR"),
+    (T.FIRST_TIMER = "FIRST_TIMER"),
+    (T.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (T.MANNEQUIN = "MANNEQUIN"),
+    (T.MEMBER = "MEMBER"),
+    (T.NONE = "NONE"),
+    (T.OWNER = "OWNER")
+  ))((n = a.author_association ||= {}));
+  let s;
+  ((t) => ((t.OPEN = "open"), (t.CLOSED = "closed")))((s = a.state ||= {}));
+  let u;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((u = a.actions ||= {}));
+  let _;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((_ = a.administration ||= {}));
+  let m;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((m = a.checks ||= {}));
+  let c;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((c = a.content_references ||= {}));
+  let d;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((d = a.contents ||= {}));
+  let v;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((v = a.deployments ||= {}));
+  let h;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((h = a.discussions ||= {}));
+  let R;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((R = a.emails ||= {}));
+  let k;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((k = a.environments ||= {}));
+  let b;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((b = a.issues ||= {}));
+  let p;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((p = a.keys ||= {}));
+  let f;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((f = a.members ||= {}));
+  let O;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((O = a.metadata ||= {}));
+  let I;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((I = a.organization_administration ||= {}));
+  let P;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((P = a.organization_hooks ||= {}));
+  let E;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((E = a.organization_packages ||= {}));
+  let D;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((D = a.organization_plan ||= {}));
+  let L;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((L = a.organization_projects ||= {}));
+  let C;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((C = a.organization_secrets ||= {}));
+  let U;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((U = a.organization_self_hosted_runners ||= {}));
+  let M;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((M = a.organization_user_blocking ||= {}));
+  let G;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((G = a.packages ||= {}));
+  let B;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((B = a.pages ||= {}));
+  let W;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((W = a.pull_requests ||= {}));
+  let F;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((F = a.repository_hooks ||= {}));
+  let j;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((j = a.repository_projects ||= {}));
+  let V;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((V = a.secret_scanning_alerts ||= {}));
+  let H;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((H = a.secrets ||= {}));
+  let Q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((Q = a.security_events ||= {}));
+  let z;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((z = a.security_scanning_alert ||= {}));
+  let K;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((K = a.single_file ||= {}));
+  let S;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((S = a.statuses ||= {}));
+  let x;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((x = a.team_discussions ||= {}));
+  let q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((q = a.vulnerability_alerts ||= {}));
+  let w;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((w = a.workflows ||= {}));
+})((vs ||= {}));
+var Rs;
+((a) => {
+  let l;
+  ((g) => (g.REOPENED = "reopened"))((l = a.action ||= {}));
+  let r;
+  ((A) => ((A.RESOLVED = "resolved"), (A.OFF_TOPIC = "off-topic"), (A.TOO_HEATED = "too heated"), (A.SPAM = "spam")))(
+    (r = a.active_lock_reason ||= {}),
+  );
+  let e;
+  ((y) => ((y.BOT = "Bot"), (y.USER = "User"), (y.ORGANIZATION = "Organization")))((e = a.type ||= {}));
+  let n;
+  ((T) => (
+    (T.COLLABORATOR = "COLLABORATOR"),
+    (T.CONTRIBUTOR = "CONTRIBUTOR"),
+    (T.FIRST_TIMER = "FIRST_TIMER"),
+    (T.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (T.MANNEQUIN = "MANNEQUIN"),
+    (T.MEMBER = "MEMBER"),
+    (T.NONE = "NONE"),
+    (T.OWNER = "OWNER")
+  ))((n = a.author_association ||= {}));
+  let s;
+  ((t) => ((t.OPEN = "open"), (t.CLOSED = "closed")))((s = a.state ||= {}));
+  let u;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((u = a.actions ||= {}));
+  let _;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((_ = a.administration ||= {}));
+  let m;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((m = a.checks ||= {}));
+  let c;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((c = a.content_references ||= {}));
+  let d;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((d = a.contents ||= {}));
+  let v;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((v = a.deployments ||= {}));
+  let h;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((h = a.discussions ||= {}));
+  let R;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((R = a.emails ||= {}));
+  let k;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((k = a.environments ||= {}));
+  let b;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((b = a.issues ||= {}));
+  let p;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((p = a.keys ||= {}));
+  let f;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((f = a.members ||= {}));
+  let O;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((O = a.metadata ||= {}));
+  let I;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((I = a.organization_administration ||= {}));
+  let P;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((P = a.organization_hooks ||= {}));
+  let E;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((E = a.organization_packages ||= {}));
+  let D;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((D = a.organization_plan ||= {}));
+  let L;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write"), (y.ADMIN = "admin")))((L = a.organization_projects ||= {}));
+  let C;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((C = a.organization_secrets ||= {}));
+  let U;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((U = a.organization_self_hosted_runners ||= {}));
+  let M;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((M = a.organization_user_blocking ||= {}));
+  let G;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((G = a.packages ||= {}));
+  let B;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((B = a.pages ||= {}));
+  let W;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((W = a.pull_requests ||= {}));
+  let F;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((F = a.repository_hooks ||= {}));
+  let j;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write"), (y.ADMIN = "admin")))((j = a.repository_projects ||= {}));
+  let V;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((V = a.secret_scanning_alerts ||= {}));
+  let H;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((H = a.secrets ||= {}));
+  let Q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((Q = a.security_events ||= {}));
+  let z;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((z = a.security_scanning_alert ||= {}));
+  let K;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((K = a.single_file ||= {}));
+  let S;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((S = a.statuses ||= {}));
+  let x;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((x = a.team_discussions ||= {}));
+  let q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((q = a.vulnerability_alerts ||= {}));
+  let w;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((w = a.workflows ||= {}));
+})((Rs ||= {}));
+var Ts;
+((N) => {
+  let l;
+  ((t) => (t.TRANSFERRED = "transferred"))((l = N.action ||= {}));
+  let r;
+  ((X) => ((X.RESOLVED = "resolved"), (X.OFF_TOPIC = "off-topic"), (X.TOO_HEATED = "too heated"), (X.SPAM = "spam")))(
+    (r = N.active_lock_reason ||= {}),
+  );
+  let e;
+  ((A) => ((A.BOT = "Bot"), (A.USER = "User"), (A.ORGANIZATION = "Organization")))((e = N.type ||= {}));
+  let n;
+  ((Z) => (
+    (Z.COLLABORATOR = "COLLABORATOR"),
+    (Z.CONTRIBUTOR = "CONTRIBUTOR"),
+    (Z.FIRST_TIMER = "FIRST_TIMER"),
+    (Z.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (Z.MANNEQUIN = "MANNEQUIN"),
+    (Z.MEMBER = "MEMBER"),
+    (Z.NONE = "NONE"),
+    (Z.OWNER = "OWNER")
+  ))((n = N.author_association ||= {}));
+  let s;
+  ((y) => ((y.OPEN = "open"), (y.CLOSED = "closed")))((s = N.state ||= {}));
+  let u;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((u = N.actions ||= {}));
+  let _;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((_ = N.administration ||= {}));
+  let m;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((m = N.checks ||= {}));
+  let c;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((c = N.content_references ||= {}));
+  let d;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((d = N.contents ||= {}));
+  let v;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((v = N.deployments ||= {}));
+  let h;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((h = N.discussions ||= {}));
+  let R;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((R = N.emails ||= {}));
+  let k;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((k = N.environments ||= {}));
+  let b;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((b = N.issues ||= {}));
+  let p;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((p = N.keys ||= {}));
+  let f;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((f = N.members ||= {}));
+  let O;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((O = N.metadata ||= {}));
+  let I;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((I = N.organization_administration ||= {}));
+  let P;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((P = N.organization_hooks ||= {}));
+  let E;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((E = N.organization_packages ||= {}));
+  let D;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((D = N.organization_plan ||= {}));
+  let L;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((L = N.organization_projects ||= {}));
+  let C;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((C = N.organization_secrets ||= {}));
+  let U;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((U = N.organization_self_hosted_runners ||= {}));
+  let M;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((M = N.organization_user_blocking ||= {}));
+  let G;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((G = N.packages ||= {}));
+  let B;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((B = N.pages ||= {}));
+  let W;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((W = N.pull_requests ||= {}));
+  let F;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((F = N.repository_hooks ||= {}));
+  let j;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((j = N.repository_projects ||= {}));
+  let V;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((V = N.secret_scanning_alerts ||= {}));
+  let H;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((H = N.secrets ||= {}));
+  let Q;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((Q = N.security_events ||= {}));
+  let z;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((z = N.security_scanning_alert ||= {}));
+  let K;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((K = N.single_file ||= {}));
+  let S;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((S = N.statuses ||= {}));
+  let x;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((x = N.team_discussions ||= {}));
+  let q;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((q = N.vulnerability_alerts ||= {}));
+  let w;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write")))((w = N.workflows ||= {}));
+  let a;
+  ((A) => ((A.PUBLIC = "public"), (A.PRIVATE = "private"), (A.INTERNAL = "internal")))((a = N.visibility ||= {}));
+})((Ts ||= {}));
+var As;
+((a) => {
+  let l;
+  ((g) => (g.UNASSIGNED = "unassigned"))((l = a.action ||= {}));
+  let r;
+  ((A) => ((A.BOT = "Bot"), (A.USER = "User"), (A.ORGANIZATION = "Organization"), (A.MANNEQUIN = "Mannequin")))(
+    (r = a.type ||= {}),
+  );
+  let e;
+  ((A) => ((A.RESOLVED = "resolved"), (A.OFF_TOPIC = "off-topic"), (A.TOO_HEATED = "too heated"), (A.SPAM = "spam")))(
+    (e = a.active_lock_reason ||= {}),
+  );
+  let n;
+  ((T) => (
+    (T.COLLABORATOR = "COLLABORATOR"),
+    (T.CONTRIBUTOR = "CONTRIBUTOR"),
+    (T.FIRST_TIMER = "FIRST_TIMER"),
+    (T.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (T.MANNEQUIN = "MANNEQUIN"),
+    (T.MEMBER = "MEMBER"),
+    (T.NONE = "NONE"),
+    (T.OWNER = "OWNER")
+  ))((n = a.author_association ||= {}));
+  let s;
+  ((t) => ((t.OPEN = "open"), (t.CLOSED = "closed")))((s = a.state ||= {}));
+  let u;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((u = a.actions ||= {}));
+  let _;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((_ = a.administration ||= {}));
+  let m;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((m = a.checks ||= {}));
+  let c;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((c = a.content_references ||= {}));
+  let d;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((d = a.contents ||= {}));
+  let v;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((v = a.deployments ||= {}));
+  let h;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((h = a.discussions ||= {}));
+  let R;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((R = a.emails ||= {}));
+  let k;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((k = a.environments ||= {}));
+  let b;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((b = a.issues ||= {}));
+  let p;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((p = a.keys ||= {}));
+  let f;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((f = a.members ||= {}));
+  let O;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((O = a.metadata ||= {}));
+  let I;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((I = a.organization_administration ||= {}));
+  let P;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((P = a.organization_hooks ||= {}));
+  let E;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((E = a.organization_packages ||= {}));
+  let D;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((D = a.organization_plan ||= {}));
+  let L;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write"), (y.ADMIN = "admin")))((L = a.organization_projects ||= {}));
+  let C;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((C = a.organization_secrets ||= {}));
+  let U;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((U = a.organization_self_hosted_runners ||= {}));
+  let M;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((M = a.organization_user_blocking ||= {}));
+  let G;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((G = a.packages ||= {}));
+  let B;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((B = a.pages ||= {}));
+  let W;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((W = a.pull_requests ||= {}));
+  let F;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((F = a.repository_hooks ||= {}));
+  let j;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((j = a.repository_projects ||= {}));
+  let V;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((V = a.secret_scanning_alerts ||= {}));
+  let H;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((H = a.secrets ||= {}));
+  let Q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((Q = a.security_events ||= {}));
+  let z;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((z = a.security_scanning_alert ||= {}));
+  let K;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((K = a.single_file ||= {}));
+  let S;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((S = a.statuses ||= {}));
+  let x;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((x = a.team_discussions ||= {}));
+  let q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((q = a.vulnerability_alerts ||= {}));
+  let w;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((w = a.workflows ||= {}));
+})((As ||= {}));
+var ks;
+((a) => {
+  let l;
+  ((g) => (g.UNLABELED = "unlabeled"))((l = a.action ||= {}));
+  let r;
+  ((A) => ((A.RESOLVED = "resolved"), (A.OFF_TOPIC = "off-topic"), (A.TOO_HEATED = "too heated"), (A.SPAM = "spam")))(
+    (r = a.active_lock_reason ||= {}),
+  );
+  let e;
+  ((A) => ((A.BOT = "Bot"), (A.USER = "User"), (A.ORGANIZATION = "Organization"), (A.MANNEQUIN = "Mannequin")))(
+    (e = a.type ||= {}),
+  );
+  let n;
+  ((T) => (
+    (T.COLLABORATOR = "COLLABORATOR"),
+    (T.CONTRIBUTOR = "CONTRIBUTOR"),
+    (T.FIRST_TIMER = "FIRST_TIMER"),
+    (T.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (T.MANNEQUIN = "MANNEQUIN"),
+    (T.MEMBER = "MEMBER"),
+    (T.NONE = "NONE"),
+    (T.OWNER = "OWNER")
+  ))((n = a.author_association ||= {}));
+  let s;
+  ((t) => ((t.OPEN = "open"), (t.CLOSED = "closed")))((s = a.state ||= {}));
+  let u;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((u = a.actions ||= {}));
+  let _;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((_ = a.administration ||= {}));
+  let m;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((m = a.checks ||= {}));
+  let c;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((c = a.content_references ||= {}));
+  let d;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((d = a.contents ||= {}));
+  let v;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((v = a.deployments ||= {}));
+  let h;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((h = a.discussions ||= {}));
+  let R;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((R = a.emails ||= {}));
+  let k;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((k = a.environments ||= {}));
+  let b;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((b = a.issues ||= {}));
+  let p;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((p = a.keys ||= {}));
+  let f;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((f = a.members ||= {}));
+  let O;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((O = a.metadata ||= {}));
+  let I;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((I = a.organization_administration ||= {}));
+  let P;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((P = a.organization_hooks ||= {}));
+  let E;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((E = a.organization_packages ||= {}));
+  let D;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((D = a.organization_plan ||= {}));
+  let L;
+  ((y) => ((y.READ = "read"), (y.WRITE = "write"), (y.ADMIN = "admin")))((L = a.organization_projects ||= {}));
+  let C;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((C = a.organization_secrets ||= {}));
+  let U;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((U = a.organization_self_hosted_runners ||= {}));
+  let M;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((M = a.organization_user_blocking ||= {}));
+  let G;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((G = a.packages ||= {}));
+  let B;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((B = a.pages ||= {}));
+  let W;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((W = a.pull_requests ||= {}));
+  let F;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((F = a.repository_hooks ||= {}));
+  let j;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((j = a.repository_projects ||= {}));
+  let V;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((V = a.secret_scanning_alerts ||= {}));
+  let H;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((H = a.secrets ||= {}));
+  let Q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((Q = a.security_events ||= {}));
+  let z;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((z = a.security_scanning_alert ||= {}));
+  let K;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((K = a.single_file ||= {}));
+  let S;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((S = a.statuses ||= {}));
+  let x;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((x = a.team_discussions ||= {}));
+  let q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((q = a.vulnerability_alerts ||= {}));
+  let w;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((w = a.workflows ||= {}));
+})((ks ||= {}));
+var xs;
+((a) => {
+  let l;
+  ((g) => (g.UNLOCKED = "unlocked"))((l = a.action ||= {}));
+  let r;
+  ((A) => ((A.RESOLVED = "resolved"), (A.OFF_TOPIC = "off-topic"), (A.TOO_HEATED = "too heated"), (A.SPAM = "spam")))(
+    (r = a.active_lock_reason ||= {}),
+  );
+  let e;
+  ((y) => ((y.BOT = "Bot"), (y.USER = "User"), (y.ORGANIZATION = "Organization")))((e = a.type ||= {}));
+  let n;
+  ((T) => (
+    (T.COLLABORATOR = "COLLABORATOR"),
+    (T.CONTRIBUTOR = "CONTRIBUTOR"),
+    (T.FIRST_TIMER = "FIRST_TIMER"),
+    (T.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (T.MANNEQUIN = "MANNEQUIN"),
+    (T.MEMBER = "MEMBER"),
+    (T.NONE = "NONE"),
+    (T.OWNER = "OWNER")
+  ))((n = a.author_association ||= {}));
+  let s;
+  ((t) => ((t.OPEN = "open"), (t.CLOSED = "closed")))((s = a.state ||= {}));
+  let u;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((u = a.actions ||= {}));
+  let _;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((_ = a.administration ||= {}));
+  let m;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((m = a.checks ||= {}));
+  let c;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((c = a.content_references ||= {}));
+  let d;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((d = a.contents ||= {}));
+  let v;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((v = a.deployments ||= {}));
+  let h;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((h = a.discussions ||= {}));
+  let R;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((R = a.emails ||= {}));
+  let k;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((k = a.environments ||= {}));
+  let b;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((b = a.issues ||= {}));
+  let p;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((p = a.keys ||= {}));
+  let f;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((f = a.members ||= {}));
+  let O;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((O = a.metadata ||= {}));
+  let I;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((I = a.organization_administration ||= {}));
+  let P;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((P = a.organization_hooks ||= {}));
+  let E;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((E = a.organization_packages ||= {}));
+  let D;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((D = a.organization_plan ||= {}));
+  let L;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((L = a.organization_projects ||= {}));
+  let C;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((C = a.organization_secrets ||= {}));
+  let U;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((U = a.organization_self_hosted_runners ||= {}));
+  let M;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((M = a.organization_user_blocking ||= {}));
+  let G;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((G = a.packages ||= {}));
+  let B;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((B = a.pages ||= {}));
+  let W;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((W = a.pull_requests ||= {}));
+  let F;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((F = a.repository_hooks ||= {}));
+  let j;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((j = a.repository_projects ||= {}));
+  let V;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((V = a.secret_scanning_alerts ||= {}));
+  let H;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((H = a.secrets ||= {}));
+  let Q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((Q = a.security_events ||= {}));
+  let z;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((z = a.security_scanning_alert ||= {}));
+  let K;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((K = a.single_file ||= {}));
+  let S;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((S = a.statuses ||= {}));
+  let x;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((x = a.team_discussions ||= {}));
+  let q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((q = a.vulnerability_alerts ||= {}));
+  let w;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((w = a.workflows ||= {}));
+})((xs ||= {}));
+var Is;
+((a) => {
+  let l;
+  ((g) => (g.UNPINNED = "unpinned"))((l = a.action ||= {}));
+  let r;
+  ((A) => ((A.RESOLVED = "resolved"), (A.OFF_TOPIC = "off-topic"), (A.TOO_HEATED = "too heated"), (A.SPAM = "spam")))(
+    (r = a.active_lock_reason ||= {}),
+  );
+  let e;
+  ((y) => ((y.BOT = "Bot"), (y.USER = "User"), (y.ORGANIZATION = "Organization")))((e = a.type ||= {}));
+  let n;
+  ((T) => (
+    (T.COLLABORATOR = "COLLABORATOR"),
+    (T.CONTRIBUTOR = "CONTRIBUTOR"),
+    (T.FIRST_TIMER = "FIRST_TIMER"),
+    (T.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (T.MANNEQUIN = "MANNEQUIN"),
+    (T.MEMBER = "MEMBER"),
+    (T.NONE = "NONE"),
+    (T.OWNER = "OWNER")
+  ))((n = a.author_association ||= {}));
+  let s;
+  ((t) => ((t.OPEN = "open"), (t.CLOSED = "closed")))((s = a.state ||= {}));
+  let u;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((u = a.actions ||= {}));
+  let _;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((_ = a.administration ||= {}));
+  let m;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((m = a.checks ||= {}));
+  let c;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((c = a.content_references ||= {}));
+  let d;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((d = a.contents ||= {}));
+  let v;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((v = a.deployments ||= {}));
+  let h;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((h = a.discussions ||= {}));
+  let R;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((R = a.emails ||= {}));
+  let k;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((k = a.environments ||= {}));
+  let b;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((b = a.issues ||= {}));
+  let p;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((p = a.keys ||= {}));
+  let f;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((f = a.members ||= {}));
+  let O;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((O = a.metadata ||= {}));
+  let I;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((I = a.organization_administration ||= {}));
+  let P;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((P = a.organization_hooks ||= {}));
+  let E;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((E = a.organization_packages ||= {}));
+  let D;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((D = a.organization_plan ||= {}));
+  let L;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((L = a.organization_projects ||= {}));
+  let C;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((C = a.organization_secrets ||= {}));
+  let U;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((U = a.organization_self_hosted_runners ||= {}));
+  let M;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((M = a.organization_user_blocking ||= {}));
+  let G;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((G = a.packages ||= {}));
+  let B;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((B = a.pages ||= {}));
+  let W;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((W = a.pull_requests ||= {}));
+  let F;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((F = a.repository_hooks ||= {}));
+  let j;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((j = a.repository_projects ||= {}));
+  let V;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((V = a.secret_scanning_alerts ||= {}));
+  let H;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((H = a.secrets ||= {}));
+  let Q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((Q = a.security_events ||= {}));
+  let z;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((z = a.security_scanning_alert ||= {}));
+  let K;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((K = a.single_file ||= {}));
+  let S;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((S = a.statuses ||= {}));
+  let x;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((x = a.team_discussions ||= {}));
+  let q;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((q = a.vulnerability_alerts ||= {}));
+  let w;
+  ((t) => ((t.READ = "read"), (t.WRITE = "write")))((w = a.workflows ||= {}));
+})((Is ||= {}));
+var Os;
+((r) => {
+  let l;
+  ((n) => (n.CREATED = "created"))((l = r.action ||= {}));
+})((Os ||= {}));
+var Ns;
+((r) => {
+  let l;
+  ((n) => (n.DELETED = "deleted"))((l = r.action ||= {}));
+})((Ns ||= {}));
+var zs;
+((r) => {
+  let l;
+  ((n) => (n.EDITED = "edited"))((l = r.action ||= {}));
+})((zs ||= {}));
+var Ps;
+((e) => {
+  let l;
+  ((s) => (s.CANCELLED = "cancelled"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.FREE = "FREE"), (_.FLAT_RATE = "FLAT_RATE"), (_.PER_UNIT = "PER_UNIT")))((r = e.price_model ||= {}));
+})((Ps ||= {}));
+var Cs;
+((e) => {
+  let l;
+  ((s) => (s.CHANGED = "changed"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.FREE = "FREE"), (_.FLAT_RATE = "FLAT_RATE"), (_.PER_UNIT = "PER_UNIT")))((r = e.price_model ||= {}));
+})((Cs ||= {}));
+var Ds;
+((e) => {
+  let l;
+  ((s) => (s.PENDING_CHANGE = "pending_change"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.FREE = "FREE"), (_.FLAT_RATE = "FLAT_RATE"), (_.PER_UNIT = "PER_UNIT")))((r = e.price_model ||= {}));
+})((Ds ||= {}));
+var qs;
+((e) => {
+  let l;
+  ((s) => (s.PENDING_CHANGE_CANCELLED = "pending_change_cancelled"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.FREE = "FREE"), (_.FLAT_RATE = "FLAT_RATE"), (_.PER_UNIT = "PER_UNIT")))((r = e.price_model ||= {}));
+})((qs ||= {}));
+var Ss;
+((e) => {
+  let l;
+  ((s) => (s.PURCHASED = "purchased"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.FREE = "FREE"), (_.FLAT_RATE = "FLAT_RATE"), (_.PER_UNIT = "PER_UNIT")))((r = e.price_model ||= {}));
+})((Ss ||= {}));
+var Ls;
+((n) => {
+  let l;
+  ((u) => (u.ADDED = "added"))((l = n.action ||= {}));
+  let r;
+  ((m) => ((m.WRITE = "write"), (m.ADMIN = "admin"), (m.READ = "read")))((r = n.to ||= {}));
+  let e;
+  ((m) => ((m.BOT = "Bot"), (m.USER = "User"), (m.ORGANIZATION = "Organization")))((e = n.type ||= {}));
+})((Ls ||= {}));
+var Us;
+((e) => {
+  let l;
+  ((s) => (s.EDITED = "edited"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((Us ||= {}));
+var Ms;
+((e) => {
+  let l;
+  ((s) => (s.REMOVED = "removed"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((Ms ||= {}));
+var Gs;
+((u) => {
+  let l;
+  ((m) => (m.ADDED = "added"))((l = u.action ||= {}));
+  let r;
+  ((d) => ((d.BOT = "Bot"), (d.USER = "User"), (d.ORGANIZATION = "Organization")))((r = u.type ||= {}));
+  let e;
+  ((m) => (m.TEAM = "team"))((e = u.scope ||= {}));
+  let n;
+  ((d) => ((d.OPEN = "open"), (d.CLOSED = "closed"), (d.SECRET = "secret")))((n = u.privacy ||= {}));
+  let s;
+  ((c) => ((c.NOTIFICATIONS_ENABLED = "notifications_enabled"), (c.NOTIFICATIONS_DISABLED = "notifications_disabled")))(
+    (s = u.notification_setting ||= {}),
+  );
+})((Gs ||= {}));
+var Bs;
+((u) => {
+  let l;
+  ((m) => (m.REMOVED = "removed"))((l = u.action ||= {}));
+  let r;
+  ((d) => ((d.BOT = "Bot"), (d.USER = "User"), (d.ORGANIZATION = "Organization")))((r = u.type ||= {}));
+  let e;
+  ((c) => ((c.TEAM = "team"), (c.ORGANIZATION = "organization")))((e = u.scope ||= {}));
+  let n;
+  ((d) => ((d.OPEN = "open"), (d.CLOSED = "closed"), (d.SECRET = "secret")))((n = u.privacy ||= {}));
+  let s;
+  ((c) => ((c.NOTIFICATIONS_ENABLED = "notifications_enabled"), (c.NOTIFICATIONS_DISABLED = "notifications_disabled")))(
+    (s = u.notification_setting ||= {}),
+  );
+})((Bs ||= {}));
+var Ws;
+((r) => {
+  let l;
+  ((n) => (n.CHECKS_REQUESTED = "checks_requested"))((l = r.action ||= {}));
+})((Ws ||= {}));
+var Fs;
+((e) => {
+  let l;
+  ((s) => (s.DESTROYED = "destroyed"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.MERGED = "merged"), (_.INVALIDATED = "invalidated"), (_.DEQUEUED = "dequeued")))((r = e.reason ||= {}));
+})((Fs ||= {}));
+var js;
+((e) => {
+  let l;
+  ((s) => (s.DELETED = "deleted"))((l = e.action ||= {}));
+  let r;
+  ((u) => ((u.JSON = "json"), (u.FORM = "form")))((r = e.content_type ||= {}));
+})((js ||= {}));
+var Vs;
+((n) => {
+  let l;
+  ((u) => (u.CLOSED = "closed"))((l = n.action ||= {}));
+  let r;
+  ((c) => ((c.BOT = "Bot"), (c.USER = "User"), (c.ORGANIZATION = "Organization"), (c.MANNEQUIN = "Mannequin")))(
+    (r = n.type ||= {}),
+  );
+  let e;
+  ((_) => ((_.OPEN = "open"), (_.CLOSED = "closed")))((e = n.state ||= {}));
+})((Vs ||= {}));
+var Hs;
+((n) => {
+  let l;
+  ((u) => (u.CREATED = "created"))((l = n.action ||= {}));
+  let r;
+  ((m) => ((m.BOT = "Bot"), (m.USER = "User"), (m.ORGANIZATION = "Organization")))((r = n.type ||= {}));
+  let e;
+  ((_) => ((_.OPEN = "open"), (_.CLOSED = "closed")))((e = n.state ||= {}));
+})((Hs ||= {}));
+var Qs;
+((n) => {
+  let l;
+  ((u) => (u.DELETED = "deleted"))((l = n.action ||= {}));
+  let r;
+  ((c) => ((c.BOT = "Bot"), (c.USER = "User"), (c.ORGANIZATION = "Organization"), (c.MANNEQUIN = "Mannequin")))(
+    (r = n.type ||= {}),
+  );
+  let e;
+  ((_) => ((_.OPEN = "open"), (_.CLOSED = "closed")))((e = n.state ||= {}));
+})((Qs ||= {}));
+var Ks;
+((n) => {
+  let l;
+  ((u) => (u.EDITED = "edited"))((l = n.action ||= {}));
+  let r;
+  ((c) => ((c.BOT = "Bot"), (c.USER = "User"), (c.ORGANIZATION = "Organization"), (c.MANNEQUIN = "Mannequin")))(
+    (r = n.type ||= {}),
+  );
+  let e;
+  ((_) => ((_.OPEN = "open"), (_.CLOSED = "closed")))((e = n.state ||= {}));
+})((Ks ||= {}));
+var Ys;
+((n) => {
+  let l;
+  ((u) => (u.OPENED = "opened"))((l = n.action ||= {}));
+  let r;
+  ((m) => ((m.BOT = "Bot"), (m.USER = "User"), (m.ORGANIZATION = "Organization")))((r = n.type ||= {}));
+  let e;
+  ((_) => ((_.OPEN = "open"), (_.CLOSED = "closed")))((e = n.state ||= {}));
+})((Ys ||= {}));
+var Zs;
+((e) => {
+  let l;
+  ((s) => (s.BLOCKED = "blocked"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((Zs ||= {}));
+var Xs;
+((e) => {
+  let l;
+  ((s) => (s.UNBLOCKED = "unblocked"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((Xs ||= {}));
+var $s;
+((e) => {
+  let l;
+  ((s) => (s.DELETED = "deleted"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})(($s ||= {}));
+var Js;
+((e) => {
+  let l;
+  ((s) => (s.MEMBER_ADDED = "member_added"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((Js ||= {}));
+var ri;
+((e) => {
+  let l;
+  ((s) => (s.MEMBER_INVITED = "member_invited"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((ri ||= {}));
+var ei;
+((e) => {
+  let l;
+  ((s) => (s.MEMBER_REMOVED = "member_removed"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((ei ||= {}));
+var ti;
+((e) => {
+  let l;
+  ((s) => (s.RENAMED = "renamed"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((ti ||= {}));
+var ni;
+((e) => {
+  let l;
+  ((s) => (s.PUBLISHED = "published"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((ni ||= {}));
+var si;
+((e) => {
+  let l;
+  ((s) => (s.UPDATED = "updated"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((si ||= {}));
+var ii;
+((r) => {
+  let l;
+  ((u) => ((u.BOT = "Bot"), (u.USER = "User"), (u.ORGANIZATION = "Organization")))((l = r.type ||= {}));
+})((ii ||= {}));
+var oi;
+((r) => {
+  let l;
+  ((n) => (n.APPROVED = "approved"))((l = r.action ||= {}));
+})((oi ||= {}));
+var li;
+((r) => {
+  let l;
+  ((n) => (n.CANCELLED = "cancelled"))((l = r.action ||= {}));
+})((li ||= {}));
+var ai;
+((r) => {
+  let l;
+  ((n) => (n.CREATED = "created"))((l = r.action ||= {}));
+})((ai ||= {}));
+var ui;
+((r) => {
+  let l;
+  ((n) => (n.DENIED = "denied"))((l = r.action ||= {}));
+})((ui ||= {}));
+var _i;
+((r) => {
+  let l;
+  ((n) => (n.WEB = "web"))((l = r.name ||= {}));
+})((_i ||= {}));
+var gi;
+((e) => {
+  let l;
+  ((s) => (s.CONVERTED = "converted"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((gi ||= {}));
+var mi;
+((e) => {
+  let l;
+  ((s) => (s.CREATED = "created"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((mi ||= {}));
+var pi;
+((e) => {
+  let l;
+  ((s) => (s.DELETED = "deleted"))((l = e.action ||= {}));
+  let r;
+  ((m) => ((m.BOT = "Bot"), (m.USER = "User"), (m.ORGANIZATION = "Organization"), (m.MANNEQUIN = "Mannequin")))(
+    (r = e.type ||= {}),
+  );
+})((pi ||= {}));
+var di;
+((e) => {
+  let l;
+  ((s) => (s.EDITED = "edited"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((di ||= {}));
+var ci;
+((e) => {
+  let l;
+  ((s) => (s.MOVED = "moved"))((l = e.action ||= {}));
+  let r;
+  ((m) => ((m.BOT = "Bot"), (m.USER = "User"), (m.ORGANIZATION = "Organization"), (m.MANNEQUIN = "Mannequin")))(
+    (r = e.type ||= {}),
+  );
+})((ci ||= {}));
+var bi;
+((n) => {
+  let l;
+  ((u) => (u.CLOSED = "closed"))((l = n.action ||= {}));
+  let r;
+  ((m) => ((m.BOT = "Bot"), (m.USER = "User"), (m.ORGANIZATION = "Organization")))((r = n.type ||= {}));
+  let e;
+  ((_) => ((_.OPEN = "open"), (_.CLOSED = "closed")))((e = n.state ||= {}));
+})((bi ||= {}));
+var hi;
+((r) => {
+  let l;
+  ((n) => (n.CREATED = "created"))((l = r.action ||= {}));
+})((hi ||= {}));
+var yi;
+((r) => {
+  let l;
+  ((n) => (n.DELETED = "deleted"))((l = r.action ||= {}));
+})((yi ||= {}));
+var fi;
+((r) => {
+  let l;
+  ((n) => (n.EDITED = "edited"))((l = r.action ||= {}));
+})((fi ||= {}));
+var wi;
+((r) => {
+  let l;
+  ((n) => (n.MOVED = "moved"))((l = r.action ||= {}));
+})((wi ||= {}));
+var Ei;
+((n) => {
+  let l;
+  ((u) => (u.CREATED = "created"))((l = n.action ||= {}));
+  let r;
+  ((m) => ((m.BOT = "Bot"), (m.USER = "User"), (m.ORGANIZATION = "Organization")))((r = n.type ||= {}));
+  let e;
+  ((_) => ((_.OPEN = "open"), (_.CLOSED = "closed")))((e = n.state ||= {}));
+})((Ei ||= {}));
+var vi;
+((n) => {
+  let l;
+  ((u) => (u.DELETED = "deleted"))((l = n.action ||= {}));
+  let r;
+  ((m) => ((m.BOT = "Bot"), (m.USER = "User"), (m.ORGANIZATION = "Organization")))((r = n.type ||= {}));
+  let e;
+  ((_) => ((_.OPEN = "open"), (_.CLOSED = "closed")))((e = n.state ||= {}));
+})((vi ||= {}));
+var Ri;
+((n) => {
+  let l;
+  ((u) => (u.EDITED = "edited"))((l = n.action ||= {}));
+  let r;
+  ((m) => ((m.BOT = "Bot"), (m.USER = "User"), (m.ORGANIZATION = "Organization")))((r = n.type ||= {}));
+  let e;
+  ((_) => ((_.OPEN = "open"), (_.CLOSED = "closed")))((e = n.state ||= {}));
+})((Ri ||= {}));
+var Ti;
+((n) => {
+  let l;
+  ((u) => (u.REOPENED = "reopened"))((l = n.action ||= {}));
+  let r;
+  ((m) => ((m.BOT = "Bot"), (m.USER = "User"), (m.ORGANIZATION = "Organization")))((r = n.type ||= {}));
+  let e;
+  ((_) => ((_.OPEN = "open"), (_.CLOSED = "closed")))((e = n.state ||= {}));
+})((Ti ||= {}));
+var Ai;
+((r) => {
+  let l;
+  ((n) => (n.ARCHIVED = "archived"))((l = r.action ||= {}));
+})((Ai ||= {}));
+var ki;
+((r) => {
+  let l;
+  ((n) => (n.CONVERTED = "converted"))((l = r.action ||= {}));
+})((ki ||= {}));
+var xi;
+((r) => {
+  let l;
+  ((n) => (n.CREATED = "created"))((l = r.action ||= {}));
+})((xi ||= {}));
+var Ii;
+((r) => {
+  let l;
+  ((n) => (n.DELETED = "deleted"))((l = r.action ||= {}));
+})((Ii ||= {}));
+var Oi;
+((r) => {
+  let l;
+  ((n) => (n.EDITED = "edited"))((l = r.action ||= {}));
+})((Oi ||= {}));
+var Ni;
+((r) => {
+  let l;
+  ((n) => (n.REORDERED = "reordered"))((l = r.action ||= {}));
+})((Ni ||= {}));
+var zi;
+((r) => {
+  let l;
+  ((n) => (n.RESTORED = "restored"))((l = r.action ||= {}));
+})((zi ||= {}));
+var Pi;
+((r) => {
+  let l;
+  ((n) => (n.CLOSED = "closed"))((l = r.action ||= {}));
+})((Pi ||= {}));
+var Ci;
+((r) => {
+  let l;
+  ((n) => (n.CREATED = "created"))((l = r.action ||= {}));
+})((Ci ||= {}));
+var Di;
+((r) => {
+  let l;
+  ((n) => (n.DELETED = "deleted"))((l = r.action ||= {}));
+})((Di ||= {}));
+var qi;
+((r) => {
+  let l;
+  ((n) => (n.EDITED = "edited"))((l = r.action ||= {}));
+})((qi ||= {}));
+var Si;
+((r) => {
+  let l;
+  ((n) => (n.REOPENED = "reopened"))((l = r.action ||= {}));
+})((Si ||= {}));
+var Li;
+((h) => {
+  let l;
+  ((k) => (k.ASSIGNED = "assigned"))((l = h.action ||= {}));
+  let r;
+  ((p) => ((p.BOT = "Bot"), (p.USER = "User"), (p.ORGANIZATION = "Organization")))((r = h.type ||= {}));
+  let e;
+  ((f) => ((f.RESOLVED = "resolved"), (f.OFF_TOPIC = "off-topic"), (f.TOO_HEATED = "too heated"), (f.SPAM = "spam")))(
+    (e = h.active_lock_reason ||= {}),
+  );
+  let n;
+  ((E) => (
+    (E.COLLABORATOR = "COLLABORATOR"),
+    (E.CONTRIBUTOR = "CONTRIBUTOR"),
+    (E.FIRST_TIMER = "FIRST_TIMER"),
+    (E.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (E.MANNEQUIN = "MANNEQUIN"),
+    (E.MEMBER = "MEMBER"),
+    (E.NONE = "NONE"),
+    (E.OWNER = "OWNER")
+  ))((n = h.author_association ||= {}));
+  let s;
+  ((p) => ((p.MERGE = "merge"), (p.SQUASH = "squash"), (p.REBASE = "rebase")))((s = h.merge_method ||= {}));
+  let u;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.PR_TITLE = "PR_TITLE"), (p.BLANK = "BLANK")))(
+    (u = h.merge_commit_message ||= {}),
+  );
+  let _;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.MERGE_MESSAGE = "MERGE_MESSAGE")))((_ = h.merge_commit_title ||= {}));
+  let m;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (p.BLANK = "BLANK")))(
+    (m = h.squash_merge_commit_message ||= {}),
+  );
+  let c;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (c = h.squash_merge_commit_title ||= {}),
+  );
+  let d;
+  ((p) => ((p.PUBLIC = "public"), (p.PRIVATE = "private"), (p.INTERNAL = "internal")))((d = h.visibility ||= {}));
+  let v;
+  ((b) => ((b.OPEN = "open"), (b.CLOSED = "closed")))((v = h.state ||= {}));
+})((Li ||= {}));
+var Ui;
+((h) => {
+  let l;
+  ((k) => (k.AUTO_MERGE_DISABLED = "auto_merge_disabled"))((l = h.action ||= {}));
+  let r;
+  ((f) => ((f.RESOLVED = "resolved"), (f.OFF_TOPIC = "off-topic"), (f.TOO_HEATED = "too heated"), (f.SPAM = "spam")))(
+    (r = h.active_lock_reason ||= {}),
+  );
+  let e;
+  ((p) => ((p.BOT = "Bot"), (p.USER = "User"), (p.ORGANIZATION = "Organization")))((e = h.type ||= {}));
+  let n;
+  ((E) => (
+    (E.COLLABORATOR = "COLLABORATOR"),
+    (E.CONTRIBUTOR = "CONTRIBUTOR"),
+    (E.FIRST_TIMER = "FIRST_TIMER"),
+    (E.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (E.MANNEQUIN = "MANNEQUIN"),
+    (E.MEMBER = "MEMBER"),
+    (E.NONE = "NONE"),
+    (E.OWNER = "OWNER")
+  ))((n = h.author_association ||= {}));
+  let s;
+  ((p) => ((p.MERGE = "merge"), (p.SQUASH = "squash"), (p.REBASE = "rebase")))((s = h.merge_method ||= {}));
+  let u;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.PR_TITLE = "PR_TITLE"), (p.BLANK = "BLANK")))(
+    (u = h.merge_commit_message ||= {}),
+  );
+  let _;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.MERGE_MESSAGE = "MERGE_MESSAGE")))((_ = h.merge_commit_title ||= {}));
+  let m;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (p.BLANK = "BLANK")))(
+    (m = h.squash_merge_commit_message ||= {}),
+  );
+  let c;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (c = h.squash_merge_commit_title ||= {}),
+  );
+  let d;
+  ((p) => ((p.PUBLIC = "public"), (p.PRIVATE = "private"), (p.INTERNAL = "internal")))((d = h.visibility ||= {}));
+  let v;
+  ((b) => ((b.OPEN = "open"), (b.CLOSED = "closed")))((v = h.state ||= {}));
+})((Ui ||= {}));
+var Mi;
+((h) => {
+  let l;
+  ((k) => (k.AUTO_MERGE_ENABLED = "auto_merge_enabled"))((l = h.action ||= {}));
+  let r;
+  ((f) => ((f.RESOLVED = "resolved"), (f.OFF_TOPIC = "off-topic"), (f.TOO_HEATED = "too heated"), (f.SPAM = "spam")))(
+    (r = h.active_lock_reason ||= {}),
+  );
+  let e;
+  ((p) => ((p.BOT = "Bot"), (p.USER = "User"), (p.ORGANIZATION = "Organization")))((e = h.type ||= {}));
+  let n;
+  ((E) => (
+    (E.COLLABORATOR = "COLLABORATOR"),
+    (E.CONTRIBUTOR = "CONTRIBUTOR"),
+    (E.FIRST_TIMER = "FIRST_TIMER"),
+    (E.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (E.MANNEQUIN = "MANNEQUIN"),
+    (E.MEMBER = "MEMBER"),
+    (E.NONE = "NONE"),
+    (E.OWNER = "OWNER")
+  ))((n = h.author_association ||= {}));
+  let s;
+  ((p) => ((p.MERGE = "merge"), (p.SQUASH = "squash"), (p.REBASE = "rebase")))((s = h.merge_method ||= {}));
+  let u;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.PR_TITLE = "PR_TITLE"), (p.BLANK = "BLANK")))(
+    (u = h.merge_commit_message ||= {}),
+  );
+  let _;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.MERGE_MESSAGE = "MERGE_MESSAGE")))((_ = h.merge_commit_title ||= {}));
+  let m;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (p.BLANK = "BLANK")))(
+    (m = h.squash_merge_commit_message ||= {}),
+  );
+  let c;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (c = h.squash_merge_commit_title ||= {}),
+  );
+  let d;
+  ((p) => ((p.PUBLIC = "public"), (p.PRIVATE = "private"), (p.INTERNAL = "internal")))((d = h.visibility ||= {}));
+  let v;
+  ((b) => ((b.OPEN = "open"), (b.CLOSED = "closed")))((v = h.state ||= {}));
+})((Mi ||= {}));
+var Gi;
+((u) => {
+  let l;
+  ((m) => (m.CLOSED = "closed"))((l = u.action ||= {}));
+  let r;
+  ((d) => ((d.PR_BODY = "PR_BODY"), (d.PR_TITLE = "PR_TITLE"), (d.BLANK = "BLANK")))(
+    (r = u.merge_commit_message ||= {}),
+  );
+  let e;
+  ((c) => ((c.PR_TITLE = "PR_TITLE"), (c.MERGE_MESSAGE = "MERGE_MESSAGE")))((e = u.merge_commit_title ||= {}));
+  let n;
+  ((d) => ((d.PR_BODY = "PR_BODY"), (d.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (d.BLANK = "BLANK")))(
+    (n = u.squash_merge_commit_message ||= {}),
+  );
+  let s;
+  ((c) => ((c.PR_TITLE = "PR_TITLE"), (c.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (s = u.squash_merge_commit_title ||= {}),
+  );
+})((Gi ||= {}));
+var Bi;
+((u) => {
+  let l;
+  ((m) => (m.CONVERTED_TO_DRAFT = "converted_to_draft"))((l = u.action ||= {}));
+  let r;
+  ((d) => ((d.PR_BODY = "PR_BODY"), (d.PR_TITLE = "PR_TITLE"), (d.BLANK = "BLANK")))(
+    (r = u.merge_commit_message ||= {}),
+  );
+  let e;
+  ((c) => ((c.PR_TITLE = "PR_TITLE"), (c.MERGE_MESSAGE = "MERGE_MESSAGE")))((e = u.merge_commit_title ||= {}));
+  let n;
+  ((d) => ((d.PR_BODY = "PR_BODY"), (d.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (d.BLANK = "BLANK")))(
+    (n = u.squash_merge_commit_message ||= {}),
+  );
+  let s;
+  ((c) => ((c.PR_TITLE = "PR_TITLE"), (c.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (s = u.squash_merge_commit_title ||= {}),
+  );
+})((Bi ||= {}));
+var Wi;
+((h) => {
+  let l;
+  ((k) => (k.DEMILESTONED = "demilestoned"))((l = h.action ||= {}));
+  let r;
+  ((f) => ((f.RESOLVED = "resolved"), (f.OFF_TOPIC = "off-topic"), (f.TOO_HEATED = "too heated"), (f.SPAM = "spam")))(
+    (r = h.active_lock_reason ||= {}),
+  );
+  let e;
+  ((f) => ((f.BOT = "Bot"), (f.USER = "User"), (f.ORGANIZATION = "Organization"), (f.MANNEQUIN = "Mannequin")))(
+    (e = h.type ||= {}),
+  );
+  let n;
+  ((E) => (
+    (E.COLLABORATOR = "COLLABORATOR"),
+    (E.CONTRIBUTOR = "CONTRIBUTOR"),
+    (E.FIRST_TIMER = "FIRST_TIMER"),
+    (E.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (E.MANNEQUIN = "MANNEQUIN"),
+    (E.MEMBER = "MEMBER"),
+    (E.NONE = "NONE"),
+    (E.OWNER = "OWNER")
+  ))((n = h.author_association ||= {}));
+  let s;
+  ((p) => ((p.MERGE = "merge"), (p.SQUASH = "squash"), (p.REBASE = "rebase")))((s = h.merge_method ||= {}));
+  let u;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.PR_TITLE = "PR_TITLE"), (p.BLANK = "BLANK")))(
+    (u = h.merge_commit_message ||= {}),
+  );
+  let _;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.MERGE_MESSAGE = "MERGE_MESSAGE")))((_ = h.merge_commit_title ||= {}));
+  let m;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (p.BLANK = "BLANK")))(
+    (m = h.squash_merge_commit_message ||= {}),
+  );
+  let c;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (c = h.squash_merge_commit_title ||= {}),
+  );
+  let d;
+  ((p) => ((p.PUBLIC = "public"), (p.PRIVATE = "private"), (p.INTERNAL = "internal")))((d = h.visibility ||= {}));
+  let v;
+  ((b) => ((b.OPEN = "open"), (b.CLOSED = "closed")))((v = h.state ||= {}));
+})((Wi ||= {}));
+var Fi;
+((h) => {
+  let l;
+  ((k) => (k.DEQUEUED = "dequeued"))((l = h.action ||= {}));
+  let r;
+  ((f) => ((f.RESOLVED = "resolved"), (f.OFF_TOPIC = "off-topic"), (f.TOO_HEATED = "too heated"), (f.SPAM = "spam")))(
+    (r = h.active_lock_reason ||= {}),
+  );
+  let e;
+  ((p) => ((p.BOT = "Bot"), (p.USER = "User"), (p.ORGANIZATION = "Organization")))((e = h.type ||= {}));
+  let n;
+  ((E) => (
+    (E.COLLABORATOR = "COLLABORATOR"),
+    (E.CONTRIBUTOR = "CONTRIBUTOR"),
+    (E.FIRST_TIMER = "FIRST_TIMER"),
+    (E.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (E.MANNEQUIN = "MANNEQUIN"),
+    (E.MEMBER = "MEMBER"),
+    (E.NONE = "NONE"),
+    (E.OWNER = "OWNER")
+  ))((n = h.author_association ||= {}));
+  let s;
+  ((p) => ((p.MERGE = "merge"), (p.SQUASH = "squash"), (p.REBASE = "rebase")))((s = h.merge_method ||= {}));
+  let u;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.PR_TITLE = "PR_TITLE"), (p.BLANK = "BLANK")))(
+    (u = h.merge_commit_message ||= {}),
+  );
+  let _;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.MERGE_MESSAGE = "MERGE_MESSAGE")))((_ = h.merge_commit_title ||= {}));
+  let m;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (p.BLANK = "BLANK")))(
+    (m = h.squash_merge_commit_message ||= {}),
+  );
+  let c;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (c = h.squash_merge_commit_title ||= {}),
+  );
+  let d;
+  ((p) => ((p.PUBLIC = "public"), (p.PRIVATE = "private"), (p.INTERNAL = "internal")))((d = h.visibility ||= {}));
+  let v;
+  ((b) => ((b.OPEN = "open"), (b.CLOSED = "closed")))((v = h.state ||= {}));
+})((Fi ||= {}));
+var ji;
+((u) => {
+  let l;
+  ((m) => (m.EDITED = "edited"))((l = u.action ||= {}));
+  let r;
+  ((d) => ((d.PR_BODY = "PR_BODY"), (d.PR_TITLE = "PR_TITLE"), (d.BLANK = "BLANK")))(
+    (r = u.merge_commit_message ||= {}),
+  );
+  let e;
+  ((c) => ((c.PR_TITLE = "PR_TITLE"), (c.MERGE_MESSAGE = "MERGE_MESSAGE")))((e = u.merge_commit_title ||= {}));
+  let n;
+  ((d) => ((d.PR_BODY = "PR_BODY"), (d.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (d.BLANK = "BLANK")))(
+    (n = u.squash_merge_commit_message ||= {}),
+  );
+  let s;
+  ((c) => ((c.PR_TITLE = "PR_TITLE"), (c.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (s = u.squash_merge_commit_title ||= {}),
+  );
+})((ji ||= {}));
+var Vi;
+((h) => {
+  let l;
+  ((k) => (k.ENQUEUED = "enqueued"))((l = h.action ||= {}));
+  let r;
+  ((f) => ((f.RESOLVED = "resolved"), (f.OFF_TOPIC = "off-topic"), (f.TOO_HEATED = "too heated"), (f.SPAM = "spam")))(
+    (r = h.active_lock_reason ||= {}),
+  );
+  let e;
+  ((p) => ((p.BOT = "Bot"), (p.USER = "User"), (p.ORGANIZATION = "Organization")))((e = h.type ||= {}));
+  let n;
+  ((E) => (
+    (E.COLLABORATOR = "COLLABORATOR"),
+    (E.CONTRIBUTOR = "CONTRIBUTOR"),
+    (E.FIRST_TIMER = "FIRST_TIMER"),
+    (E.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (E.MANNEQUIN = "MANNEQUIN"),
+    (E.MEMBER = "MEMBER"),
+    (E.NONE = "NONE"),
+    (E.OWNER = "OWNER")
+  ))((n = h.author_association ||= {}));
+  let s;
+  ((p) => ((p.MERGE = "merge"), (p.SQUASH = "squash"), (p.REBASE = "rebase")))((s = h.merge_method ||= {}));
+  let u;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.PR_TITLE = "PR_TITLE"), (p.BLANK = "BLANK")))(
+    (u = h.merge_commit_message ||= {}),
+  );
+  let _;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.MERGE_MESSAGE = "MERGE_MESSAGE")))((_ = h.merge_commit_title ||= {}));
+  let m;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (p.BLANK = "BLANK")))(
+    (m = h.squash_merge_commit_message ||= {}),
+  );
+  let c;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (c = h.squash_merge_commit_title ||= {}),
+  );
+  let d;
+  ((p) => ((p.PUBLIC = "public"), (p.PRIVATE = "private"), (p.INTERNAL = "internal")))((d = h.visibility ||= {}));
+  let v;
+  ((b) => ((b.OPEN = "open"), (b.CLOSED = "closed")))((v = h.state ||= {}));
+})((Vi ||= {}));
+var Hi;
+((h) => {
+  let l;
+  ((k) => (k.LABELED = "labeled"))((l = h.action ||= {}));
+  let r;
+  ((f) => ((f.RESOLVED = "resolved"), (f.OFF_TOPIC = "off-topic"), (f.TOO_HEATED = "too heated"), (f.SPAM = "spam")))(
+    (r = h.active_lock_reason ||= {}),
+  );
+  let e;
+  ((f) => ((f.BOT = "Bot"), (f.USER = "User"), (f.ORGANIZATION = "Organization"), (f.MANNEQUIN = "Mannequin")))(
+    (e = h.type ||= {}),
+  );
+  let n;
+  ((E) => (
+    (E.COLLABORATOR = "COLLABORATOR"),
+    (E.CONTRIBUTOR = "CONTRIBUTOR"),
+    (E.FIRST_TIMER = "FIRST_TIMER"),
+    (E.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (E.MANNEQUIN = "MANNEQUIN"),
+    (E.MEMBER = "MEMBER"),
+    (E.NONE = "NONE"),
+    (E.OWNER = "OWNER")
+  ))((n = h.author_association ||= {}));
+  let s;
+  ((p) => ((p.MERGE = "merge"), (p.SQUASH = "squash"), (p.REBASE = "rebase")))((s = h.merge_method ||= {}));
+  let u;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.PR_TITLE = "PR_TITLE"), (p.BLANK = "BLANK")))(
+    (u = h.merge_commit_message ||= {}),
+  );
+  let _;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.MERGE_MESSAGE = "MERGE_MESSAGE")))((_ = h.merge_commit_title ||= {}));
+  let m;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (p.BLANK = "BLANK")))(
+    (m = h.squash_merge_commit_message ||= {}),
+  );
+  let c;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (c = h.squash_merge_commit_title ||= {}),
+  );
+  let d;
+  ((p) => ((p.PUBLIC = "public"), (p.PRIVATE = "private"), (p.INTERNAL = "internal")))((d = h.visibility ||= {}));
+  let v;
+  ((b) => ((b.OPEN = "open"), (b.CLOSED = "closed")))((v = h.state ||= {}));
+})((Hi ||= {}));
+var Qi;
+((h) => {
+  let l;
+  ((k) => (k.LOCKED = "locked"))((l = h.action ||= {}));
+  let r;
+  ((f) => ((f.RESOLVED = "resolved"), (f.OFF_TOPIC = "off-topic"), (f.TOO_HEATED = "too heated"), (f.SPAM = "spam")))(
+    (r = h.active_lock_reason ||= {}),
+  );
+  let e;
+  ((p) => ((p.BOT = "Bot"), (p.USER = "User"), (p.ORGANIZATION = "Organization")))((e = h.type ||= {}));
+  let n;
+  ((E) => (
+    (E.COLLABORATOR = "COLLABORATOR"),
+    (E.CONTRIBUTOR = "CONTRIBUTOR"),
+    (E.FIRST_TIMER = "FIRST_TIMER"),
+    (E.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (E.MANNEQUIN = "MANNEQUIN"),
+    (E.MEMBER = "MEMBER"),
+    (E.NONE = "NONE"),
+    (E.OWNER = "OWNER")
+  ))((n = h.author_association ||= {}));
+  let s;
+  ((p) => ((p.MERGE = "merge"), (p.SQUASH = "squash"), (p.REBASE = "rebase")))((s = h.merge_method ||= {}));
+  let u;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.PR_TITLE = "PR_TITLE"), (p.BLANK = "BLANK")))(
+    (u = h.merge_commit_message ||= {}),
+  );
+  let _;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.MERGE_MESSAGE = "MERGE_MESSAGE")))((_ = h.merge_commit_title ||= {}));
+  let m;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (p.BLANK = "BLANK")))(
+    (m = h.squash_merge_commit_message ||= {}),
+  );
+  let c;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (c = h.squash_merge_commit_title ||= {}),
+  );
+  let d;
+  ((p) => ((p.PUBLIC = "public"), (p.PRIVATE = "private"), (p.INTERNAL = "internal")))((d = h.visibility ||= {}));
+  let v;
+  ((b) => ((b.OPEN = "open"), (b.CLOSED = "closed")))((v = h.state ||= {}));
+})((Qi ||= {}));
+var Ki;
+((h) => {
+  let l;
+  ((k) => (k.MILESTONED = "milestoned"))((l = h.action ||= {}));
+  let r;
+  ((f) => ((f.RESOLVED = "resolved"), (f.OFF_TOPIC = "off-topic"), (f.TOO_HEATED = "too heated"), (f.SPAM = "spam")))(
+    (r = h.active_lock_reason ||= {}),
+  );
+  let e;
+  ((f) => ((f.BOT = "Bot"), (f.USER = "User"), (f.ORGANIZATION = "Organization"), (f.MANNEQUIN = "Mannequin")))(
+    (e = h.type ||= {}),
+  );
+  let n;
+  ((E) => (
+    (E.COLLABORATOR = "COLLABORATOR"),
+    (E.CONTRIBUTOR = "CONTRIBUTOR"),
+    (E.FIRST_TIMER = "FIRST_TIMER"),
+    (E.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (E.MANNEQUIN = "MANNEQUIN"),
+    (E.MEMBER = "MEMBER"),
+    (E.NONE = "NONE"),
+    (E.OWNER = "OWNER")
+  ))((n = h.author_association ||= {}));
+  let s;
+  ((p) => ((p.MERGE = "merge"), (p.SQUASH = "squash"), (p.REBASE = "rebase")))((s = h.merge_method ||= {}));
+  let u;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.PR_TITLE = "PR_TITLE"), (p.BLANK = "BLANK")))(
+    (u = h.merge_commit_message ||= {}),
+  );
+  let _;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.MERGE_MESSAGE = "MERGE_MESSAGE")))((_ = h.merge_commit_title ||= {}));
+  let m;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (p.BLANK = "BLANK")))(
+    (m = h.squash_merge_commit_message ||= {}),
+  );
+  let c;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (c = h.squash_merge_commit_title ||= {}),
+  );
+  let d;
+  ((p) => ((p.PUBLIC = "public"), (p.PRIVATE = "private"), (p.INTERNAL = "internal")))((d = h.visibility ||= {}));
+  let v;
+  ((b) => ((b.OPEN = "open"), (b.CLOSED = "closed")))((v = h.state ||= {}));
+})((Ki ||= {}));
+var Yi;
+((u) => {
+  let l;
+  ((m) => (m.OPENED = "opened"))((l = u.action ||= {}));
+  let r;
+  ((d) => ((d.PR_BODY = "PR_BODY"), (d.PR_TITLE = "PR_TITLE"), (d.BLANK = "BLANK")))(
+    (r = u.merge_commit_message ||= {}),
+  );
+  let e;
+  ((c) => ((c.PR_TITLE = "PR_TITLE"), (c.MERGE_MESSAGE = "MERGE_MESSAGE")))((e = u.merge_commit_title ||= {}));
+  let n;
+  ((d) => ((d.PR_BODY = "PR_BODY"), (d.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (d.BLANK = "BLANK")))(
+    (n = u.squash_merge_commit_message ||= {}),
+  );
+  let s;
+  ((c) => ((c.PR_TITLE = "PR_TITLE"), (c.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (s = u.squash_merge_commit_title ||= {}),
+  );
+})((Yi ||= {}));
+var Zi;
+((u) => {
+  let l;
+  ((m) => (m.READY_FOR_REVIEW = "ready_for_review"))((l = u.action ||= {}));
+  let r;
+  ((d) => ((d.PR_BODY = "PR_BODY"), (d.PR_TITLE = "PR_TITLE"), (d.BLANK = "BLANK")))(
+    (r = u.merge_commit_message ||= {}),
+  );
+  let e;
+  ((c) => ((c.PR_TITLE = "PR_TITLE"), (c.MERGE_MESSAGE = "MERGE_MESSAGE")))((e = u.merge_commit_title ||= {}));
+  let n;
+  ((d) => ((d.PR_BODY = "PR_BODY"), (d.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (d.BLANK = "BLANK")))(
+    (n = u.squash_merge_commit_message ||= {}),
+  );
+  let s;
+  ((c) => ((c.PR_TITLE = "PR_TITLE"), (c.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (s = u.squash_merge_commit_title ||= {}),
+  );
+})((Zi ||= {}));
+var Xi;
+((u) => {
+  let l;
+  ((m) => (m.REOPENED = "reopened"))((l = u.action ||= {}));
+  let r;
+  ((d) => ((d.PR_BODY = "PR_BODY"), (d.PR_TITLE = "PR_TITLE"), (d.BLANK = "BLANK")))(
+    (r = u.merge_commit_message ||= {}),
+  );
+  let e;
+  ((c) => ((c.PR_TITLE = "PR_TITLE"), (c.MERGE_MESSAGE = "MERGE_MESSAGE")))((e = u.merge_commit_title ||= {}));
+  let n;
+  ((d) => ((d.PR_BODY = "PR_BODY"), (d.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (d.BLANK = "BLANK")))(
+    (n = u.squash_merge_commit_message ||= {}),
+  );
+  let s;
+  ((c) => ((c.PR_TITLE = "PR_TITLE"), (c.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (s = u.squash_merge_commit_title ||= {}),
+  );
+})((Xi ||= {}));
+var $i;
+((b) => {
+  let l;
+  ((f) => (f.CREATED = "created"))((l = b.action ||= {}));
+  let r;
+  ((C) => (
+    (C.COLLABORATOR = "COLLABORATOR"),
+    (C.CONTRIBUTOR = "CONTRIBUTOR"),
+    (C.FIRST_TIMER = "FIRST_TIMER"),
+    (C.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (C.MANNEQUIN = "MANNEQUIN"),
+    (C.MEMBER = "MEMBER"),
+    (C.NONE = "NONE"),
+    (C.OWNER = "OWNER")
+  ))((r = b.author_association ||= {}));
+  let e;
+  ((O) => ((O.LEFT = "LEFT"), (O.RIGHT = "RIGHT")))((e = b.side ||= {}));
+  let n;
+  ((O) => ((O.LEFT = "LEFT"), (O.RIGHT = "RIGHT")))((n = b.start_side ||= {}));
+  let s;
+  ((O) => ((O.LINE = "line"), (O.FILE = "file")))((s = b.subject_type ||= {}));
+  let u;
+  ((I) => ((I.BOT = "Bot"), (I.USER = "User"), (I.ORGANIZATION = "Organization")))((u = b.type ||= {}));
+  let _;
+  ((P) => ((P.RESOLVED = "resolved"), (P.OFF_TOPIC = "off-topic"), (P.TOO_HEATED = "too heated"), (P.SPAM = "spam")))(
+    (_ = b.active_lock_reason ||= {}),
+  );
+  let m;
+  ((I) => ((I.MERGE = "merge"), (I.SQUASH = "squash"), (I.REBASE = "rebase")))((m = b.merge_method ||= {}));
+  let c;
+  ((I) => ((I.PR_BODY = "PR_BODY"), (I.PR_TITLE = "PR_TITLE"), (I.BLANK = "BLANK")))(
+    (c = b.merge_commit_message ||= {}),
+  );
+  let d;
+  ((O) => ((O.PR_TITLE = "PR_TITLE"), (O.MERGE_MESSAGE = "MERGE_MESSAGE")))((d = b.merge_commit_title ||= {}));
+  let v;
+  ((I) => ((I.PR_BODY = "PR_BODY"), (I.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (I.BLANK = "BLANK")))(
+    (v = b.squash_merge_commit_message ||= {}),
+  );
+  let h;
+  ((O) => ((O.PR_TITLE = "PR_TITLE"), (O.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (h = b.squash_merge_commit_title ||= {}),
+  );
+  let R;
+  ((I) => ((I.PUBLIC = "public"), (I.PRIVATE = "private"), (I.INTERNAL = "internal")))((R = b.visibility ||= {}));
+  let k;
+  ((O) => ((O.OPEN = "open"), (O.CLOSED = "closed")))((k = b.state ||= {}));
+})(($i ||= {}));
+var Ji;
+((b) => {
+  let l;
+  ((f) => (f.DELETED = "deleted"))((l = b.action ||= {}));
+  let r;
+  ((C) => (
+    (C.COLLABORATOR = "COLLABORATOR"),
+    (C.CONTRIBUTOR = "CONTRIBUTOR"),
+    (C.FIRST_TIMER = "FIRST_TIMER"),
+    (C.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (C.MANNEQUIN = "MANNEQUIN"),
+    (C.MEMBER = "MEMBER"),
+    (C.NONE = "NONE"),
+    (C.OWNER = "OWNER")
+  ))((r = b.author_association ||= {}));
+  let e;
+  ((O) => ((O.LEFT = "LEFT"), (O.RIGHT = "RIGHT")))((e = b.side ||= {}));
+  let n;
+  ((O) => ((O.LEFT = "LEFT"), (O.RIGHT = "RIGHT")))((n = b.start_side ||= {}));
+  let s;
+  ((O) => ((O.LINE = "line"), (O.FILE = "file")))((s = b.subject_type ||= {}));
+  let u;
+  ((I) => ((I.BOT = "Bot"), (I.USER = "User"), (I.ORGANIZATION = "Organization")))((u = b.type ||= {}));
+  let _;
+  ((P) => ((P.RESOLVED = "resolved"), (P.OFF_TOPIC = "off-topic"), (P.TOO_HEATED = "too heated"), (P.SPAM = "spam")))(
+    (_ = b.active_lock_reason ||= {}),
+  );
+  let m;
+  ((I) => ((I.MERGE = "merge"), (I.SQUASH = "squash"), (I.REBASE = "rebase")))((m = b.merge_method ||= {}));
+  let c;
+  ((I) => ((I.PR_BODY = "PR_BODY"), (I.PR_TITLE = "PR_TITLE"), (I.BLANK = "BLANK")))(
+    (c = b.merge_commit_message ||= {}),
+  );
+  let d;
+  ((O) => ((O.PR_TITLE = "PR_TITLE"), (O.MERGE_MESSAGE = "MERGE_MESSAGE")))((d = b.merge_commit_title ||= {}));
+  let v;
+  ((I) => ((I.PR_BODY = "PR_BODY"), (I.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (I.BLANK = "BLANK")))(
+    (v = b.squash_merge_commit_message ||= {}),
+  );
+  let h;
+  ((O) => ((O.PR_TITLE = "PR_TITLE"), (O.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (h = b.squash_merge_commit_title ||= {}),
+  );
+  let R;
+  ((I) => ((I.PUBLIC = "public"), (I.PRIVATE = "private"), (I.INTERNAL = "internal")))((R = b.visibility ||= {}));
+  let k;
+  ((O) => ((O.OPEN = "open"), (O.CLOSED = "closed")))((k = b.state ||= {}));
+})((Ji ||= {}));
+var ro;
+((b) => {
+  let l;
+  ((f) => (f.EDITED = "edited"))((l = b.action ||= {}));
+  let r;
+  ((C) => (
+    (C.COLLABORATOR = "COLLABORATOR"),
+    (C.CONTRIBUTOR = "CONTRIBUTOR"),
+    (C.FIRST_TIMER = "FIRST_TIMER"),
+    (C.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (C.MANNEQUIN = "MANNEQUIN"),
+    (C.MEMBER = "MEMBER"),
+    (C.NONE = "NONE"),
+    (C.OWNER = "OWNER")
+  ))((r = b.author_association ||= {}));
+  let e;
+  ((O) => ((O.LEFT = "LEFT"), (O.RIGHT = "RIGHT")))((e = b.side ||= {}));
+  let n;
+  ((O) => ((O.LEFT = "LEFT"), (O.RIGHT = "RIGHT")))((n = b.start_side ||= {}));
+  let s;
+  ((O) => ((O.LINE = "line"), (O.FILE = "file")))((s = b.subject_type ||= {}));
+  let u;
+  ((I) => ((I.BOT = "Bot"), (I.USER = "User"), (I.ORGANIZATION = "Organization")))((u = b.type ||= {}));
+  let _;
+  ((P) => ((P.RESOLVED = "resolved"), (P.OFF_TOPIC = "off-topic"), (P.TOO_HEATED = "too heated"), (P.SPAM = "spam")))(
+    (_ = b.active_lock_reason ||= {}),
+  );
+  let m;
+  ((I) => ((I.MERGE = "merge"), (I.SQUASH = "squash"), (I.REBASE = "rebase")))((m = b.merge_method ||= {}));
+  let c;
+  ((I) => ((I.PR_BODY = "PR_BODY"), (I.PR_TITLE = "PR_TITLE"), (I.BLANK = "BLANK")))(
+    (c = b.merge_commit_message ||= {}),
+  );
+  let d;
+  ((O) => ((O.PR_TITLE = "PR_TITLE"), (O.MERGE_MESSAGE = "MERGE_MESSAGE")))((d = b.merge_commit_title ||= {}));
+  let v;
+  ((I) => ((I.PR_BODY = "PR_BODY"), (I.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (I.BLANK = "BLANK")))(
+    (v = b.squash_merge_commit_message ||= {}),
+  );
+  let h;
+  ((O) => ((O.PR_TITLE = "PR_TITLE"), (O.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (h = b.squash_merge_commit_title ||= {}),
+  );
+  let R;
+  ((I) => ((I.PUBLIC = "public"), (I.PRIVATE = "private"), (I.INTERNAL = "internal")))((R = b.visibility ||= {}));
+  let k;
+  ((O) => ((O.OPEN = "open"), (O.CLOSED = "closed")))((k = b.state ||= {}));
+})((ro ||= {}));
+var eo;
+((h) => {
+  let l;
+  ((k) => (k.DISMISSED = "dismissed"))((l = h.action ||= {}));
+  let r;
+  ((f) => ((f.RESOLVED = "resolved"), (f.OFF_TOPIC = "off-topic"), (f.TOO_HEATED = "too heated"), (f.SPAM = "spam")))(
+    (r = h.active_lock_reason ||= {}),
+  );
+  let e;
+  ((f) => ((f.BOT = "Bot"), (f.USER = "User"), (f.ORGANIZATION = "Organization"), (f.MANNEQUIN = "Mannequin")))(
+    (e = h.type ||= {}),
+  );
+  let n;
+  ((E) => (
+    (E.COLLABORATOR = "COLLABORATOR"),
+    (E.CONTRIBUTOR = "CONTRIBUTOR"),
+    (E.FIRST_TIMER = "FIRST_TIMER"),
+    (E.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (E.MANNEQUIN = "MANNEQUIN"),
+    (E.MEMBER = "MEMBER"),
+    (E.NONE = "NONE"),
+    (E.OWNER = "OWNER")
+  ))((n = h.author_association ||= {}));
+  let s;
+  ((p) => ((p.MERGE = "merge"), (p.SQUASH = "squash"), (p.REBASE = "rebase")))((s = h.merge_method ||= {}));
+  let u;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.PR_TITLE = "PR_TITLE"), (p.BLANK = "BLANK")))(
+    (u = h.merge_commit_message ||= {}),
+  );
+  let _;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.MERGE_MESSAGE = "MERGE_MESSAGE")))((_ = h.merge_commit_title ||= {}));
+  let m;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (p.BLANK = "BLANK")))(
+    (m = h.squash_merge_commit_message ||= {}),
+  );
+  let c;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (c = h.squash_merge_commit_title ||= {}),
+  );
+  let d;
+  ((p) => ((p.PUBLIC = "public"), (p.PRIVATE = "private"), (p.INTERNAL = "internal")))((d = h.visibility ||= {}));
+  let v;
+  ((b) => ((b.OPEN = "open"), (b.CLOSED = "closed")))((v = h.state ||= {}));
+})((eo ||= {}));
+var to;
+((m) => {
+  let l;
+  ((d) => (d.EDITED = "edited"))((l = m.action ||= {}));
+  let r;
+  ((R) => ((R.RESOLVED = "resolved"), (R.OFF_TOPIC = "off-topic"), (R.TOO_HEATED = "too heated"), (R.SPAM = "spam")))(
+    (r = m.active_lock_reason ||= {}),
+  );
+  let e;
+  ((R) => ((R.BOT = "Bot"), (R.USER = "User"), (R.ORGANIZATION = "Organization"), (R.MANNEQUIN = "Mannequin")))(
+    (e = m.type ||= {}),
+  );
+  let n;
+  ((f) => (
+    (f.COLLABORATOR = "COLLABORATOR"),
+    (f.CONTRIBUTOR = "CONTRIBUTOR"),
+    (f.FIRST_TIMER = "FIRST_TIMER"),
+    (f.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (f.MANNEQUIN = "MANNEQUIN"),
+    (f.MEMBER = "MEMBER"),
+    (f.NONE = "NONE"),
+    (f.OWNER = "OWNER")
+  ))((n = m.author_association ||= {}));
+  let s;
+  ((h) => ((h.MERGE = "merge"), (h.SQUASH = "squash"), (h.REBASE = "rebase")))((s = m.merge_method ||= {}));
+  let u;
+  ((h) => ((h.PUBLIC = "public"), (h.PRIVATE = "private"), (h.INTERNAL = "internal")))((u = m.visibility ||= {}));
+  let _;
+  ((v) => ((v.OPEN = "open"), (v.CLOSED = "closed")))((_ = m.state ||= {}));
+})((to ||= {}));
+var no;
+((R) => {
+  let l;
+  ((b) => (b.REVIEW_REQUEST_REMOVED = "review_request_removed"))((l = R.action ||= {}));
+  let r;
+  ((O) => ((O.RESOLVED = "resolved"), (O.OFF_TOPIC = "off-topic"), (O.TOO_HEATED = "too heated"), (O.SPAM = "spam")))(
+    (r = R.active_lock_reason ||= {}),
+  );
+  let e;
+  ((f) => ((f.BOT = "Bot"), (f.USER = "User"), (f.ORGANIZATION = "Organization")))((e = R.type ||= {}));
+  let n;
+  ((D) => (
+    (D.COLLABORATOR = "COLLABORATOR"),
+    (D.CONTRIBUTOR = "CONTRIBUTOR"),
+    (D.FIRST_TIMER = "FIRST_TIMER"),
+    (D.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (D.MANNEQUIN = "MANNEQUIN"),
+    (D.MEMBER = "MEMBER"),
+    (D.NONE = "NONE"),
+    (D.OWNER = "OWNER")
+  ))((n = R.author_association ||= {}));
+  let s;
+  ((f) => ((f.MERGE = "merge"), (f.SQUASH = "squash"), (f.REBASE = "rebase")))((s = R.merge_method ||= {}));
+  let u;
+  ((f) => ((f.PR_BODY = "PR_BODY"), (f.PR_TITLE = "PR_TITLE"), (f.BLANK = "BLANK")))(
+    (u = R.merge_commit_message ||= {}),
+  );
+  let _;
+  ((p) => ((p.PR_TITLE = "PR_TITLE"), (p.MERGE_MESSAGE = "MERGE_MESSAGE")))((_ = R.merge_commit_title ||= {}));
+  let m;
+  ((f) => ((f.PR_BODY = "PR_BODY"), (f.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (f.BLANK = "BLANK")))(
+    (m = R.squash_merge_commit_message ||= {}),
+  );
+  let c;
+  ((p) => ((p.PR_TITLE = "PR_TITLE"), (p.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (c = R.squash_merge_commit_title ||= {}),
+  );
+  let d;
+  ((f) => ((f.PUBLIC = "public"), (f.PRIVATE = "private"), (f.INTERNAL = "internal")))((d = R.visibility ||= {}));
+  let v;
+  ((p) => ((p.OPEN = "open"), (p.CLOSED = "closed")))((v = R.state ||= {}));
+  let h;
+  ((f) => ((f.OPEN = "open"), (f.CLOSED = "closed"), (f.SECRET = "secret")))((h = R.privacy ||= {}));
+})((no ||= {}));
+var so;
+((R) => {
+  let l;
+  ((b) => (b.REVIEW_REQUESTED = "review_requested"))((l = R.action ||= {}));
+  let r;
+  ((O) => ((O.RESOLVED = "resolved"), (O.OFF_TOPIC = "off-topic"), (O.TOO_HEATED = "too heated"), (O.SPAM = "spam")))(
+    (r = R.active_lock_reason ||= {}),
+  );
+  let e;
+  ((O) => ((O.BOT = "Bot"), (O.USER = "User"), (O.ORGANIZATION = "Organization"), (O.MANNEQUIN = "Mannequin")))(
+    (e = R.type ||= {}),
+  );
+  let n;
+  ((D) => (
+    (D.COLLABORATOR = "COLLABORATOR"),
+    (D.CONTRIBUTOR = "CONTRIBUTOR"),
+    (D.FIRST_TIMER = "FIRST_TIMER"),
+    (D.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (D.MANNEQUIN = "MANNEQUIN"),
+    (D.MEMBER = "MEMBER"),
+    (D.NONE = "NONE"),
+    (D.OWNER = "OWNER")
+  ))((n = R.author_association ||= {}));
+  let s;
+  ((f) => ((f.MERGE = "merge"), (f.SQUASH = "squash"), (f.REBASE = "rebase")))((s = R.merge_method ||= {}));
+  let u;
+  ((f) => ((f.PR_BODY = "PR_BODY"), (f.PR_TITLE = "PR_TITLE"), (f.BLANK = "BLANK")))(
+    (u = R.merge_commit_message ||= {}),
+  );
+  let _;
+  ((p) => ((p.PR_TITLE = "PR_TITLE"), (p.MERGE_MESSAGE = "MERGE_MESSAGE")))((_ = R.merge_commit_title ||= {}));
+  let m;
+  ((f) => ((f.PR_BODY = "PR_BODY"), (f.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (f.BLANK = "BLANK")))(
+    (m = R.squash_merge_commit_message ||= {}),
+  );
+  let c;
+  ((p) => ((p.PR_TITLE = "PR_TITLE"), (p.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (c = R.squash_merge_commit_title ||= {}),
+  );
+  let d;
+  ((f) => ((f.PUBLIC = "public"), (f.PRIVATE = "private"), (f.INTERNAL = "internal")))((d = R.visibility ||= {}));
+  let v;
+  ((p) => ((p.OPEN = "open"), (p.CLOSED = "closed")))((v = R.state ||= {}));
+  let h;
+  ((f) => ((f.OPEN = "open"), (f.CLOSED = "closed"), (f.SECRET = "secret")))((h = R.privacy ||= {}));
+})((so ||= {}));
+var io;
+((h) => {
+  let l;
+  ((k) => (k.SUBMITTED = "submitted"))((l = h.action ||= {}));
+  let r;
+  ((f) => ((f.RESOLVED = "resolved"), (f.OFF_TOPIC = "off-topic"), (f.TOO_HEATED = "too heated"), (f.SPAM = "spam")))(
+    (r = h.active_lock_reason ||= {}),
+  );
+  let e;
+  ((f) => ((f.BOT = "Bot"), (f.USER = "User"), (f.ORGANIZATION = "Organization"), (f.MANNEQUIN = "Mannequin")))(
+    (e = h.type ||= {}),
+  );
+  let n;
+  ((E) => (
+    (E.COLLABORATOR = "COLLABORATOR"),
+    (E.CONTRIBUTOR = "CONTRIBUTOR"),
+    (E.FIRST_TIMER = "FIRST_TIMER"),
+    (E.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (E.MANNEQUIN = "MANNEQUIN"),
+    (E.MEMBER = "MEMBER"),
+    (E.NONE = "NONE"),
+    (E.OWNER = "OWNER")
+  ))((n = h.author_association ||= {}));
+  let s;
+  ((p) => ((p.MERGE = "merge"), (p.SQUASH = "squash"), (p.REBASE = "rebase")))((s = h.merge_method ||= {}));
+  let u;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.PR_TITLE = "PR_TITLE"), (p.BLANK = "BLANK")))(
+    (u = h.merge_commit_message ||= {}),
+  );
+  let _;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.MERGE_MESSAGE = "MERGE_MESSAGE")))((_ = h.merge_commit_title ||= {}));
+  let m;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (p.BLANK = "BLANK")))(
+    (m = h.squash_merge_commit_message ||= {}),
+  );
+  let c;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (c = h.squash_merge_commit_title ||= {}),
+  );
+  let d;
+  ((p) => ((p.PUBLIC = "public"), (p.PRIVATE = "private"), (p.INTERNAL = "internal")))((d = h.visibility ||= {}));
+  let v;
+  ((b) => ((b.OPEN = "open"), (b.CLOSED = "closed")))((v = h.state ||= {}));
+})((io ||= {}));
+var oo;
+((m) => {
+  let l;
+  ((d) => (d.RESOLVED = "resolved"))((l = m.action ||= {}));
+  let r;
+  ((R) => ((R.RESOLVED = "resolved"), (R.OFF_TOPIC = "off-topic"), (R.TOO_HEATED = "too heated"), (R.SPAM = "spam")))(
+    (r = m.active_lock_reason ||= {}),
+  );
+  let e;
+  ((h) => ((h.BOT = "Bot"), (h.USER = "User"), (h.ORGANIZATION = "Organization")))((e = m.type ||= {}));
+  let n;
+  ((f) => (
+    (f.COLLABORATOR = "COLLABORATOR"),
+    (f.CONTRIBUTOR = "CONTRIBUTOR"),
+    (f.FIRST_TIMER = "FIRST_TIMER"),
+    (f.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (f.MANNEQUIN = "MANNEQUIN"),
+    (f.MEMBER = "MEMBER"),
+    (f.NONE = "NONE"),
+    (f.OWNER = "OWNER")
+  ))((n = m.author_association ||= {}));
+  let s;
+  ((h) => ((h.MERGE = "merge"), (h.SQUASH = "squash"), (h.REBASE = "rebase")))((s = m.merge_method ||= {}));
+  let u;
+  ((h) => ((h.PUBLIC = "public"), (h.PRIVATE = "private"), (h.INTERNAL = "internal")))((u = m.visibility ||= {}));
+  let _;
+  ((v) => ((v.OPEN = "open"), (v.CLOSED = "closed")))((_ = m.state ||= {}));
+})((oo ||= {}));
+var lo;
+((m) => {
+  let l;
+  ((d) => (d.UNRESOLVED = "unresolved"))((l = m.action ||= {}));
+  let r;
+  ((R) => ((R.RESOLVED = "resolved"), (R.OFF_TOPIC = "off-topic"), (R.TOO_HEATED = "too heated"), (R.SPAM = "spam")))(
+    (r = m.active_lock_reason ||= {}),
+  );
+  let e;
+  ((h) => ((h.BOT = "Bot"), (h.USER = "User"), (h.ORGANIZATION = "Organization")))((e = m.type ||= {}));
+  let n;
+  ((f) => (
+    (f.COLLABORATOR = "COLLABORATOR"),
+    (f.CONTRIBUTOR = "CONTRIBUTOR"),
+    (f.FIRST_TIMER = "FIRST_TIMER"),
+    (f.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (f.MANNEQUIN = "MANNEQUIN"),
+    (f.MEMBER = "MEMBER"),
+    (f.NONE = "NONE"),
+    (f.OWNER = "OWNER")
+  ))((n = m.author_association ||= {}));
+  let s;
+  ((h) => ((h.MERGE = "merge"), (h.SQUASH = "squash"), (h.REBASE = "rebase")))((s = m.merge_method ||= {}));
+  let u;
+  ((h) => ((h.PUBLIC = "public"), (h.PRIVATE = "private"), (h.INTERNAL = "internal")))((u = m.visibility ||= {}));
+  let _;
+  ((v) => ((v.OPEN = "open"), (v.CLOSED = "closed")))((_ = m.state ||= {}));
+})((lo ||= {}));
+var ao;
+((h) => {
+  let l;
+  ((k) => (k.SYNCHRONIZE = "synchronize"))((l = h.action ||= {}));
+  let r;
+  ((f) => ((f.RESOLVED = "resolved"), (f.OFF_TOPIC = "off-topic"), (f.TOO_HEATED = "too heated"), (f.SPAM = "spam")))(
+    (r = h.active_lock_reason ||= {}),
+  );
+  let e;
+  ((f) => ((f.BOT = "Bot"), (f.USER = "User"), (f.ORGANIZATION = "Organization"), (f.MANNEQUIN = "Mannequin")))(
+    (e = h.type ||= {}),
+  );
+  let n;
+  ((E) => (
+    (E.COLLABORATOR = "COLLABORATOR"),
+    (E.CONTRIBUTOR = "CONTRIBUTOR"),
+    (E.FIRST_TIMER = "FIRST_TIMER"),
+    (E.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (E.MANNEQUIN = "MANNEQUIN"),
+    (E.MEMBER = "MEMBER"),
+    (E.NONE = "NONE"),
+    (E.OWNER = "OWNER")
+  ))((n = h.author_association ||= {}));
+  let s;
+  ((p) => ((p.MERGE = "merge"), (p.SQUASH = "squash"), (p.REBASE = "rebase")))((s = h.merge_method ||= {}));
+  let u;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.PR_TITLE = "PR_TITLE"), (p.BLANK = "BLANK")))(
+    (u = h.merge_commit_message ||= {}),
+  );
+  let _;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.MERGE_MESSAGE = "MERGE_MESSAGE")))((_ = h.merge_commit_title ||= {}));
+  let m;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (p.BLANK = "BLANK")))(
+    (m = h.squash_merge_commit_message ||= {}),
+  );
+  let c;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (c = h.squash_merge_commit_title ||= {}),
+  );
+  let d;
+  ((p) => ((p.PUBLIC = "public"), (p.PRIVATE = "private"), (p.INTERNAL = "internal")))((d = h.visibility ||= {}));
+  let v;
+  ((b) => ((b.OPEN = "open"), (b.CLOSED = "closed")))((v = h.state ||= {}));
+})((ao ||= {}));
+var uo;
+((h) => {
+  let l;
+  ((k) => (k.UNASSIGNED = "unassigned"))((l = h.action ||= {}));
+  let r;
+  ((f) => ((f.BOT = "Bot"), (f.USER = "User"), (f.ORGANIZATION = "Organization"), (f.MANNEQUIN = "Mannequin")))(
+    (r = h.type ||= {}),
+  );
+  let e;
+  ((f) => ((f.RESOLVED = "resolved"), (f.OFF_TOPIC = "off-topic"), (f.TOO_HEATED = "too heated"), (f.SPAM = "spam")))(
+    (e = h.active_lock_reason ||= {}),
+  );
+  let n;
+  ((E) => (
+    (E.COLLABORATOR = "COLLABORATOR"),
+    (E.CONTRIBUTOR = "CONTRIBUTOR"),
+    (E.FIRST_TIMER = "FIRST_TIMER"),
+    (E.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (E.MANNEQUIN = "MANNEQUIN"),
+    (E.MEMBER = "MEMBER"),
+    (E.NONE = "NONE"),
+    (E.OWNER = "OWNER")
+  ))((n = h.author_association ||= {}));
+  let s;
+  ((p) => ((p.MERGE = "merge"), (p.SQUASH = "squash"), (p.REBASE = "rebase")))((s = h.merge_method ||= {}));
+  let u;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.PR_TITLE = "PR_TITLE"), (p.BLANK = "BLANK")))(
+    (u = h.merge_commit_message ||= {}),
+  );
+  let _;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.MERGE_MESSAGE = "MERGE_MESSAGE")))((_ = h.merge_commit_title ||= {}));
+  let m;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (p.BLANK = "BLANK")))(
+    (m = h.squash_merge_commit_message ||= {}),
+  );
+  let c;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (c = h.squash_merge_commit_title ||= {}),
+  );
+  let d;
+  ((p) => ((p.PUBLIC = "public"), (p.PRIVATE = "private"), (p.INTERNAL = "internal")))((d = h.visibility ||= {}));
+  let v;
+  ((b) => ((b.OPEN = "open"), (b.CLOSED = "closed")))((v = h.state ||= {}));
+})((uo ||= {}));
+var _o;
+((h) => {
+  let l;
+  ((k) => (k.UNLABELED = "unlabeled"))((l = h.action ||= {}));
+  let r;
+  ((f) => ((f.RESOLVED = "resolved"), (f.OFF_TOPIC = "off-topic"), (f.TOO_HEATED = "too heated"), (f.SPAM = "spam")))(
+    (r = h.active_lock_reason ||= {}),
+  );
+  let e;
+  ((f) => ((f.BOT = "Bot"), (f.USER = "User"), (f.ORGANIZATION = "Organization"), (f.MANNEQUIN = "Mannequin")))(
+    (e = h.type ||= {}),
+  );
+  let n;
+  ((E) => (
+    (E.COLLABORATOR = "COLLABORATOR"),
+    (E.CONTRIBUTOR = "CONTRIBUTOR"),
+    (E.FIRST_TIMER = "FIRST_TIMER"),
+    (E.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (E.MANNEQUIN = "MANNEQUIN"),
+    (E.MEMBER = "MEMBER"),
+    (E.NONE = "NONE"),
+    (E.OWNER = "OWNER")
+  ))((n = h.author_association ||= {}));
+  let s;
+  ((p) => ((p.MERGE = "merge"), (p.SQUASH = "squash"), (p.REBASE = "rebase")))((s = h.merge_method ||= {}));
+  let u;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.PR_TITLE = "PR_TITLE"), (p.BLANK = "BLANK")))(
+    (u = h.merge_commit_message ||= {}),
+  );
+  let _;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.MERGE_MESSAGE = "MERGE_MESSAGE")))((_ = h.merge_commit_title ||= {}));
+  let m;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (p.BLANK = "BLANK")))(
+    (m = h.squash_merge_commit_message ||= {}),
+  );
+  let c;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (c = h.squash_merge_commit_title ||= {}),
+  );
+  let d;
+  ((p) => ((p.PUBLIC = "public"), (p.PRIVATE = "private"), (p.INTERNAL = "internal")))((d = h.visibility ||= {}));
+  let v;
+  ((b) => ((b.OPEN = "open"), (b.CLOSED = "closed")))((v = h.state ||= {}));
+})((_o ||= {}));
+var go;
+((h) => {
+  let l;
+  ((k) => (k.UNLOCKED = "unlocked"))((l = h.action ||= {}));
+  let r;
+  ((f) => ((f.RESOLVED = "resolved"), (f.OFF_TOPIC = "off-topic"), (f.TOO_HEATED = "too heated"), (f.SPAM = "spam")))(
+    (r = h.active_lock_reason ||= {}),
+  );
+  let e;
+  ((p) => ((p.BOT = "Bot"), (p.USER = "User"), (p.ORGANIZATION = "Organization")))((e = h.type ||= {}));
+  let n;
+  ((E) => (
+    (E.COLLABORATOR = "COLLABORATOR"),
+    (E.CONTRIBUTOR = "CONTRIBUTOR"),
+    (E.FIRST_TIMER = "FIRST_TIMER"),
+    (E.FIRST_TIME_CONTRIBUTOR = "FIRST_TIME_CONTRIBUTOR"),
+    (E.MANNEQUIN = "MANNEQUIN"),
+    (E.MEMBER = "MEMBER"),
+    (E.NONE = "NONE"),
+    (E.OWNER = "OWNER")
+  ))((n = h.author_association ||= {}));
+  let s;
+  ((p) => ((p.MERGE = "merge"), (p.SQUASH = "squash"), (p.REBASE = "rebase")))((s = h.merge_method ||= {}));
+  let u;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.PR_TITLE = "PR_TITLE"), (p.BLANK = "BLANK")))(
+    (u = h.merge_commit_message ||= {}),
+  );
+  let _;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.MERGE_MESSAGE = "MERGE_MESSAGE")))((_ = h.merge_commit_title ||= {}));
+  let m;
+  ((p) => ((p.PR_BODY = "PR_BODY"), (p.COMMIT_MESSAGES = "COMMIT_MESSAGES"), (p.BLANK = "BLANK")))(
+    (m = h.squash_merge_commit_message ||= {}),
+  );
+  let c;
+  ((b) => ((b.PR_TITLE = "PR_TITLE"), (b.COMMIT_OR_PR_TITLE = "COMMIT_OR_PR_TITLE")))(
+    (c = h.squash_merge_commit_title ||= {}),
+  );
+  let d;
+  ((p) => ((p.PUBLIC = "public"), (p.PRIVATE = "private"), (p.INTERNAL = "internal")))((d = h.visibility ||= {}));
+  let v;
+  ((b) => ((b.OPEN = "open"), (b.CLOSED = "closed")))((v = h.state ||= {}));
+})((go ||= {}));
+var mo;
+((e) => {
+  let l;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((l = e.type ||= {}));
+  let r;
+  ((_) => ((_.PUBLIC = "public"), (_.PRIVATE = "private"), (_.INTERNAL = "internal")))((r = e.visibility ||= {}));
+})((mo ||= {}));
+var po;
+((r) => {
+  let l;
+  ((n) => (n.PUBLISHED = "published"))((l = r.action ||= {}));
+})((po ||= {}));
+var co;
+((e) => {
+  let l;
+  ((s) => (s.CREATED = "created"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((co ||= {}));
+var bo;
+((e) => {
+  let l;
+  ((s) => (s.DELETED = "deleted"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((bo ||= {}));
+var ho;
+((e) => {
+  let l;
+  ((s) => (s.EDITED = "edited"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((ho ||= {}));
+var yo;
+((e) => {
+  let l;
+  ((s) => (s.PRERELEASED = "prereleased"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((yo ||= {}));
+var fo;
+((e) => {
+  let l;
+  ((s) => (s.PUBLISHED = "published"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((fo ||= {}));
+var wo;
+((e) => {
+  let l;
+  ((s) => (s.RELEASED = "released"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((wo ||= {}));
+var Eo;
+((e) => {
+  let l;
+  ((s) => (s.UNPUBLISHED = "unpublished"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((Eo ||= {}));
+var vo;
+((r) => {
+  let l;
+  ((n) => (n.PUBLISHED = "published"))((l = r.action ||= {}));
+})((vo ||= {}));
+var Ro;
+((r) => {
+  let l;
+  ((n) => (n.REPORTED = "reported"))((l = r.action ||= {}));
+})((Ro ||= {}));
+var To;
+((r) => {
+  let l;
+  ((n) => (n.ARCHIVED = "archived"))((l = r.action ||= {}));
+})((To ||= {}));
+var Ao;
+((r) => {
+  let l;
+  ((n) => (n.CREATED = "created"))((l = r.action ||= {}));
+})((Ao ||= {}));
+var ko;
+((r) => {
+  let l;
+  ((n) => (n.DELETED = "deleted"))((l = r.action ||= {}));
+})((ko ||= {}));
+var xo;
+((r) => {
+  let l;
+  ((n) => (n.EDITED = "edited"))((l = r.action ||= {}));
+})((xo ||= {}));
+var Io;
+((r) => {
+  let l;
+  ((u) => ((u.SUCCESS = "success"), (u.CANCELLED = "cancelled"), (u.FAILURE = "failure")))((l = r.status ||= {}));
+})((Io ||= {}));
+var Oo;
+((r) => {
+  let l;
+  ((n) => (n.PRIVATIZED = "privatized"))((l = r.action ||= {}));
+})((Oo ||= {}));
+var No;
+((r) => {
+  let l;
+  ((n) => (n.PUBLICIZED = "publicized"))((l = r.action ||= {}));
+})((No ||= {}));
+var zo;
+((r) => {
+  let l;
+  ((n) => (n.RENAMED = "renamed"))((l = r.action ||= {}));
+})((zo ||= {}));
+var Po;
+((e) => {
+  let l;
+  ((s) => (s.TRANSFERRED = "transferred"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((Po ||= {}));
+var Co;
+((r) => {
+  let l;
+  ((n) => (n.UNARCHIVED = "unarchived"))((l = r.action ||= {}));
+})((Co ||= {}));
+var Do;
+((n) => {
+  let l;
+  ((u) => (u.CREATE = "create"))((l = n.action ||= {}));
+  let r;
+  ((m) => ((m.BOT = "Bot"), (m.USER = "User"), (m.ORGANIZATION = "Organization")))((r = n.type ||= {}));
+  let e;
+  ((m) => ((m.OPEN = "open"), (m.DISMISSED = "dismissed"), (m.FIXED = "fixed")))((e = n.state ||= {}));
+})((Do ||= {}));
+var qo;
+((n) => {
+  let l;
+  ((u) => (u.DISMISS = "dismiss"))((l = n.action ||= {}));
+  let r;
+  ((m) => ((m.BOT = "Bot"), (m.USER = "User"), (m.ORGANIZATION = "Organization")))((r = n.type ||= {}));
+  let e;
+  ((m) => ((m.OPEN = "open"), (m.DISMISSED = "dismissed"), (m.FIXED = "fixed")))((e = n.state ||= {}));
+})((qo ||= {}));
+var So;
+((n) => {
+  let l;
+  ((u) => (u.REOPEN = "reopen"))((l = n.action ||= {}));
+  let r;
+  ((m) => ((m.BOT = "Bot"), (m.USER = "User"), (m.ORGANIZATION = "Organization")))((r = n.type ||= {}));
+  let e;
+  ((m) => ((m.OPEN = "open"), (m.DISMISSED = "dismissed"), (m.FIXED = "fixed")))((e = n.state ||= {}));
+})((So ||= {}));
+var Lo;
+((n) => {
+  let l;
+  ((u) => (u.RESOLVE = "resolve"))((l = n.action ||= {}));
+  let r;
+  ((m) => ((m.BOT = "Bot"), (m.USER = "User"), (m.ORGANIZATION = "Organization")))((r = n.type ||= {}));
+  let e;
+  ((m) => ((m.OPEN = "open"), (m.DISMISSED = "dismissed"), (m.FIXED = "fixed")))((e = n.state ||= {}));
+})((Lo ||= {}));
+var Uo;
+((r) => {
+  let l;
+  ((n) => (n.CREATED = "created"))((l = r.action ||= {}));
+})((Uo ||= {}));
+var Mo;
+((r) => {
+  let l;
+  ((n) => (n.CREATED = "created"))((l = r.action ||= {}));
+})((Mo ||= {}));
+var Go;
+((r) => {
+  let l;
+  ((n) => (n.REOPENED = "reopened"))((l = r.action ||= {}));
+})((Go ||= {}));
+var Bo;
+((r) => {
+  let l;
+  ((n) => (n.RESOLVED = "resolved"))((l = r.action ||= {}));
+})((Bo ||= {}));
+var Wo;
+((r) => {
+  let l;
+  ((n) => (n.REVOKED = "revoked"))((l = r.action ||= {}));
+})((Wo ||= {}));
+var Fo;
+((r) => {
+  let l;
+  ((n) => (n.PUBLISHED = "published"))((l = r.action ||= {}));
+})((Fo ||= {}));
+var jo;
+((r) => {
+  let l;
+  ((n) => (n.UPDATED = "updated"))((l = r.action ||= {}));
+})((jo ||= {}));
+var Vo;
+((r) => {
+  let l;
+  ((n) => (n.WITHDRAWN = "withdrawn"))((l = r.action ||= {}));
+})((Vo ||= {}));
+var Ho;
+((e) => {
+  let l;
+  ((s) => (s.CANCELLED = "cancelled"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((Ho ||= {}));
+var Qo;
+((e) => {
+  let l;
+  ((s) => (s.CREATED = "created"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((Qo ||= {}));
+var Ko;
+((e) => {
+  let l;
+  ((s) => (s.EDITED = "edited"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((Ko ||= {}));
+var Yo;
+((e) => {
+  let l;
+  ((s) => (s.PENDING_CANCELLATION = "pending_cancellation"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((Yo ||= {}));
+var Zo;
+((e) => {
+  let l;
+  ((s) => (s.PENDING_TIER_CHANGE = "pending_tier_change"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((Zo ||= {}));
+var Xo;
+((e) => {
+  let l;
+  ((s) => (s.TIER_CHANGED = "tier_changed"))((l = e.action ||= {}));
+  let r;
+  ((_) => ((_.BOT = "Bot"), (_.USER = "User"), (_.ORGANIZATION = "Organization")))((r = e.type ||= {}));
+})((Xo ||= {}));
+var $o;
+((r) => {
+  let l;
+  ((n) => (n.CREATED = "created"))((l = r.action ||= {}));
+})(($o ||= {}));
+var Jo;
+((r) => {
+  let l;
+  ((n) => (n.DELETED = "deleted"))((l = r.action ||= {}));
+})((Jo ||= {}));
+var rl;
+((n) => {
+  let l;
+  ((m) => ((m.BOT = "Bot"), (m.USER = "User"), (m.ORGANIZATION = "Organization")))((l = n.type ||= {}));
+  let r;
+  ((P) => (
+    (P.EXPIRED_KEY = "expired_key"),
+    (P.NOT_SIGNING_KEY = "not_signing_key"),
+    (P.GPGVERIFY_ERROR = "gpgverify_error"),
+    (P.GPGVERIFY_UNAVAILABLE = "gpgverify_unavailable"),
+    (P.UNSIGNED = "unsigned"),
+    (P.UNKNOWN_SIGNATURE_TYPE = "unknown_signature_type"),
+    (P.NO_USER = "no_user"),
+    (P.UNVERIFIED_EMAIL = "unverified_email"),
+    (P.BAD_EMAIL = "bad_email"),
+    (P.UNKNOWN_KEY = "unknown_key"),
+    (P.MALFORMED_SIGNATURE = "malformed_signature"),
+    (P.INVALID = "invalid"),
+    (P.VALID = "valid"),
+    (P.BAD_CERT = "bad_cert"),
+    (P.OCSP_PENDING = "ocsp_pending")
+  ))((r = n.reason ||= {}));
+  let e;
+  ((c) => ((c.PENDING = "pending"), (c.SUCCESS = "success"), (c.FAILURE = "failure"), (c.ERROR = "error")))(
+    (e = n.state ||= {}),
+  );
+})((rl ||= {}));
+var el;
+((e) => {
+  let l;
+  ((_) => ((_.OPEN = "open"), (_.CLOSED = "closed"), (_.SECRET = "secret")))((l = e.privacy ||= {}));
+  let r;
+  ((u) => ((u.NOTIFICATIONS_ENABLED = "notifications_enabled"), (u.NOTIFICATIONS_DISABLED = "notifications_disabled")))(
+    (r = e.notification_setting ||= {}),
+  );
+})((el ||= {}));
+var tl;
+((u) => {
+  let l;
+  ((m) => (m.ADDED_TO_REPOSITORY = "added_to_repository"))((l = u.action ||= {}));
+  let r;
+  ((d) => ((d.BOT = "Bot"), (d.USER = "User"), (d.ORGANIZATION = "Organization")))((r = u.type ||= {}));
+  let e;
+  ((d) => ((d.PUBLIC = "public"), (d.PRIVATE = "private"), (d.INTERNAL = "internal")))((e = u.visibility ||= {}));
+  let n;
+  ((d) => ((d.OPEN = "open"), (d.CLOSED = "closed"), (d.SECRET = "secret")))((n = u.privacy ||= {}));
+  let s;
+  ((c) => ((c.NOTIFICATIONS_ENABLED = "notifications_enabled"), (c.NOTIFICATIONS_DISABLED = "notifications_disabled")))(
+    (s = u.notification_setting ||= {}),
+  );
+})((tl ||= {}));
+var nl;
+((u) => {
+  let l;
+  ((m) => (m.CREATED = "created"))((l = u.action ||= {}));
+  let r;
+  ((d) => ((d.BOT = "Bot"), (d.USER = "User"), (d.ORGANIZATION = "Organization")))((r = u.type ||= {}));
+  let e;
+  ((d) => ((d.PUBLIC = "public"), (d.PRIVATE = "private"), (d.INTERNAL = "internal")))((e = u.visibility ||= {}));
+  let n;
+  ((d) => ((d.OPEN = "open"), (d.CLOSED = "closed"), (d.SECRET = "secret")))((n = u.privacy ||= {}));
+  let s;
+  ((c) => ((c.NOTIFICATIONS_ENABLED = "notifications_enabled"), (c.NOTIFICATIONS_DISABLED = "notifications_disabled")))(
+    (s = u.notification_setting ||= {}),
+  );
+})((nl ||= {}));
+var sl;
+((u) => {
+  let l;
+  ((m) => (m.DELETED = "deleted"))((l = u.action ||= {}));
+  let r;
+  ((d) => ((d.BOT = "Bot"), (d.USER = "User"), (d.ORGANIZATION = "Organization")))((r = u.type ||= {}));
+  let e;
+  ((d) => ((d.PUBLIC = "public"), (d.PRIVATE = "private"), (d.INTERNAL = "internal")))((e = u.visibility ||= {}));
+  let n;
+  ((d) => ((d.OPEN = "open"), (d.CLOSED = "closed"), (d.SECRET = "secret")))((n = u.privacy ||= {}));
+  let s;
+  ((c) => ((c.NOTIFICATIONS_ENABLED = "notifications_enabled"), (c.NOTIFICATIONS_DISABLED = "notifications_disabled")))(
+    (s = u.notification_setting ||= {}),
+  );
+})((sl ||= {}));
+var il;
+((u) => {
+  let l;
+  ((m) => (m.EDITED = "edited"))((l = u.action ||= {}));
+  let r;
+  ((d) => ((d.BOT = "Bot"), (d.USER = "User"), (d.ORGANIZATION = "Organization")))((r = u.type ||= {}));
+  let e;
+  ((d) => ((d.PUBLIC = "public"), (d.PRIVATE = "private"), (d.INTERNAL = "internal")))((e = u.visibility ||= {}));
+  let n;
+  ((d) => ((d.OPEN = "open"), (d.CLOSED = "closed"), (d.SECRET = "secret")))((n = u.privacy ||= {}));
+  let s;
+  ((c) => ((c.NOTIFICATIONS_ENABLED = "notifications_enabled"), (c.NOTIFICATIONS_DISABLED = "notifications_disabled")))(
+    (s = u.notification_setting ||= {}),
+  );
+})((il ||= {}));
+var ol;
+((u) => {
+  let l;
+  ((m) => (m.REMOVED_FROM_REPOSITORY = "removed_from_repository"))((l = u.action ||= {}));
+  let r;
+  ((d) => ((d.BOT = "Bot"), (d.USER = "User"), (d.ORGANIZATION = "Organization")))((r = u.type ||= {}));
+  let e;
+  ((d) => ((d.PUBLIC = "public"), (d.PRIVATE = "private"), (d.INTERNAL = "internal")))((e = u.visibility ||= {}));
+  let n;
+  ((d) => ((d.OPEN = "open"), (d.CLOSED = "closed"), (d.SECRET = "secret")))((n = u.privacy ||= {}));
+  let s;
+  ((c) => ((c.NOTIFICATIONS_ENABLED = "notifications_enabled"), (c.NOTIFICATIONS_DISABLED = "notifications_disabled")))(
+    (s = u.notification_setting ||= {}),
+  );
+})((ol ||= {}));
+var ll;
+((r) => {
+  let l;
+  ((n) => (n.STARTED = "started"))((l = r.action ||= {}));
+})((ll ||= {}));
+var al;
+((n) => {
+  let l;
+  ((u) => (u.COMPLETED = "completed"))((l = n.action ||= {}));
+  let r;
+  ((h) => (
+    (h.SUCCESS = "success"),
+    (h.FAILURE = "failure"),
+    (h.SKIPPED = "skipped"),
+    (h.CANCELLED = "cancelled"),
+    (h.ACTION_REQUIRED = "action_required"),
+    (h.NEUTRAL = "neutral"),
+    (h.TIMED_OUT = "timed_out")
+  ))((r = n.conclusion ||= {}));
+  let e;
+  ((c) => (
+    (c.QUEUED = "queued"), (c.IN_PROGRESS = "in_progress"), (c.COMPLETED = "completed"), (c.WAITING = "waiting")
+  ))((e = n.status ||= {}));
+})((al ||= {}));
+var ul;
+((n) => {
+  let l;
+  ((u) => (u.IN_PROGRESS = "in_progress"))((l = n.action ||= {}));
+  let r;
+  ((c) => ((c.SUCCESS = "success"), (c.FAILURE = "failure"), (c.CANCELLED = "cancelled"), (c.NEUTRAL = "neutral")))(
+    (r = n.conclusion ||= {}),
+  );
+  let e;
+  ((m) => ((m.QUEUED = "queued"), (m.IN_PROGRESS = "in_progress"), (m.COMPLETED = "completed")))((e = n.status ||= {}));
+})((ul ||= {}));
+var _l;
+((e) => {
+  let l;
+  ((s) => (s.QUEUED = "queued"))((l = e.action ||= {}));
+  let r;
+  ((m) => (
+    (m.QUEUED = "queued"), (m.IN_PROGRESS = "in_progress"), (m.COMPLETED = "completed"), (m.WAITING = "waiting")
+  ))((r = e.status ||= {}));
+})((_l ||= {}));
+var gl;
+((e) => {
+  let l;
+  ((s) => (s.WAITING = "waiting"))((l = e.action ||= {}));
+  let r;
+  ((m) => (
+    (m.QUEUED = "queued"), (m.IN_PROGRESS = "in_progress"), (m.COMPLETED = "completed"), (m.WAITING = "waiting")
+  ))((r = e.status ||= {}));
+})((gl ||= {}));
+var ml;
+((s) => {
+  let l;
+  ((_) => (_.COMPLETED = "completed"))((l = s.action ||= {}));
+  let r;
+  ((c) => ((c.BOT = "Bot"), (c.USER = "User"), (c.ORGANIZATION = "Organization")))((r = s.type ||= {}));
+  let e;
+  ((k) => (
+    (k.SUCCESS = "success"),
+    (k.FAILURE = "failure"),
+    (k.NEUTRAL = "neutral"),
+    (k.CANCELLED = "cancelled"),
+    (k.TIMED_OUT = "timed_out"),
+    (k.ACTION_REQUIRED = "action_required"),
+    (k.STALE = "stale"),
+    (k.SKIPPED = "skipped")
+  ))((e = s.conclusion ||= {}));
+  let n;
+  ((h) => (
+    (h.REQUESTED = "requested"),
+    (h.IN_PROGRESS = "in_progress"),
+    (h.COMPLETED = "completed"),
+    (h.QUEUED = "queued"),
+    (h.PENDING = "pending"),
+    (h.WAITING = "waiting")
+  ))((n = s.status ||= {}));
+})((ml ||= {}));
+var pl;
+((s) => {
+  let l;
+  ((_) => (_.IN_PROGRESS = "in_progress"))((l = s.action ||= {}));
+  let r;
+  ((c) => ((c.BOT = "Bot"), (c.USER = "User"), (c.ORGANIZATION = "Organization")))((r = s.type ||= {}));
+  let e;
+  ((k) => (
+    (k.SUCCESS = "success"),
+    (k.FAILURE = "failure"),
+    (k.NEUTRAL = "neutral"),
+    (k.CANCELLED = "cancelled"),
+    (k.TIMED_OUT = "timed_out"),
+    (k.ACTION_REQUIRED = "action_required"),
+    (k.STALE = "stale"),
+    (k.SKIPPED = "skipped")
+  ))((e = s.conclusion ||= {}));
+  let n;
+  ((v) => (
+    (v.REQUESTED = "requested"),
+    (v.IN_PROGRESS = "in_progress"),
+    (v.COMPLETED = "completed"),
+    (v.QUEUED = "queued"),
+    (v.PENDING = "pending")
+  ))((n = s.status ||= {}));
+})((pl ||= {}));
+var dl;
+((s) => {
+  let l;
+  ((_) => (_.REQUESTED = "requested"))((l = s.action ||= {}));
+  let r;
+  ((c) => ((c.BOT = "Bot"), (c.USER = "User"), (c.ORGANIZATION = "Organization")))((r = s.type ||= {}));
+  let e;
+  ((b) => (
+    (b.SUCCESS = "success"),
+    (b.FAILURE = "failure"),
+    (b.NEUTRAL = "neutral"),
+    (b.CANCELLED = "cancelled"),
+    (b.TIMED_OUT = "timed_out"),
+    (b.ACTION_REQUIRED = "action_required"),
+    (b.STALE = "stale"),
+    (b.SKIPPED = "skipped"),
+    (b.STARTUP_FAILURE = "startup_failure")
+  ))((e = s.conclusion ||= {}));
+  let n;
+  ((h) => (
+    (h.REQUESTED = "requested"),
+    (h.IN_PROGRESS = "in_progress"),
+    (h.COMPLETED = "completed"),
+    (h.QUEUED = "queued"),
+    (h.PENDING = "pending"),
+    (h.WAITING = "waiting")
+  ))((n = s.status ||= {}));
+})((dl ||= {}));
+var cl;
+((r) => {
+  let l;
+  ((m) => (
+    (m.ACTIVE = "active"),
+    (m.DELETED = "deleted"),
+    (m.DISABLED_FORK = "disabled_fork"),
+    (m.DISABLED_INACTIVITY = "disabled_inactivity"),
+    (m.DISABLED_MANUALLY = "disabled_manually")
+  ))((l = r.state ||= {}));
+})((cl ||= {}));
+var bl = ((b) => (
+  (b.COMPLETED = "completed"),
+  (b.ACTION_REQUIRED = "action_required"),
+  (b.CANCELLED = "cancelled"),
+  (b.FAILURE = "failure"),
+  (b.NEUTRAL = "neutral"),
+  (b.SKIPPED = "skipped"),
+  (b.STALE = "stale"),
+  (b.SUCCESS = "success"),
+  (b.TIMED_OUT = "timed_out"),
+  (b.IN_PROGRESS = "in_progress"),
+  (b.QUEUED = "queued"),
+  (b.REQUESTED = "requested"),
+  (b.WAITING = "waiting"),
+  (b.PENDING = "pending"),
+  b
+))(bl || {});
+var ir = (l) => l != null,
+  er = (l) => typeof l == "string",
+  sr = (l) => er(l) && l !== "",
+  or = (l) =>
+    typeof l == "object" &&
+    typeof l.type == "string" &&
+    typeof l.stream == "function" &&
+    typeof l.arrayBuffer == "function" &&
+    typeof l.constructor == "function" &&
+    typeof l.constructor.name == "string" &&
+    /^(Blob|File)$/.test(l.constructor.name) &&
+    /^(Blob|File)$/.test(l[Symbol.toStringTag]),
+  hl = (l) => l instanceof FormData,
+  yl = (l) => {
+    try {
+      return btoa(l);
+    } catch {
+      return Buffer.from(l).toString("base64");
+    }
+  },
+  fl = (l) => {
+    let r = [],
+      e = (s, u) => {
+        r.push(`${encodeURIComponent(s)}=${encodeURIComponent(String(u))}`);
+      },
+      n = (s, u) => {
+        ir(u) &&
+          (Array.isArray(u)
+            ? u.forEach((_) => {
+                n(s, _);
+              })
+            : typeof u == "object"
+              ? Object.entries(u).forEach(([_, m]) => {
+                  n(`${s}[${_}]`, m);
+                })
+              : e(s, u));
+      };
+    return (
+      Object.entries(l).forEach(([s, u]) => {
+        n(s, u);
+      }),
+      r.length > 0 ? `?${r.join("&")}` : ""
+    );
+  },
+  wl = (l, r) => {
+    let e = l.ENCODE_PATH || encodeURI,
+      n = r.url
+        .replace("{api-version}", l.VERSION)
+        .replace(/{(.*?)}/g, (u, _) => (r.path?.hasOwnProperty(_) ? e(String(r.path[_])) : u)),
+      s = `${l.BASE}${n}`;
+    return r.query ? `${s}${fl(r.query)}` : s;
+  },
+  El = (l) => {
+    if (l.formData) {
+      let r = new FormData(),
+        e = (n, s) => {
+          er(s) || or(s) ? r.append(n, s) : r.append(n, JSON.stringify(s));
+        };
+      return (
+        Object.entries(l.formData)
+          .filter(([n, s]) => ir(s))
+          .forEach(([n, s]) => {
+            Array.isArray(s) ? s.forEach((u) => e(n, u)) : e(n, s);
+          }),
+        r
+      );
+    }
+  },
+  nr = async (l, r) => (typeof r == "function" ? r(l) : r),
+  vl = async (l, r) => {
+    let e = await nr(r, l.TOKEN),
+      n = await nr(r, l.USERNAME),
+      s = await nr(r, l.PASSWORD),
+      u = await nr(r, l.HEADERS),
+      _ = Object.entries({ Accept: "application/json", ...u, ...r.headers })
+        .filter(([m, c]) => ir(c))
+        .reduce((m, [c, d]) => ({ ...m, [c]: String(d) }), {});
+    if ((sr(e) && (_.Authorization = `Bearer ${e}`), sr(n) && sr(s))) {
+      let m = yl(`${n}:${s}`);
+      _.Authorization = `Basic ${m}`;
+    }
+    return (
+      r.body &&
+        (r.mediaType
+          ? (_["Content-Type"] = r.mediaType)
+          : or(r.body)
+            ? (_["Content-Type"] = r.body.type || "application/octet-stream")
+            : er(r.body)
+              ? (_["Content-Type"] = "text/plain")
+              : hl(r.body) || (_["Content-Type"] = "application/json")),
+      new Headers(_)
+    );
+  },
+  Rl = (l) => {
+    if (l.body !== void 0)
+      return l.mediaType?.includes("/json")
+        ? JSON.stringify(l.body)
+        : er(l.body) || or(l.body) || hl(l.body)
+          ? l.body
+          : JSON.stringify(l.body);
+  },
+  Tl = async (l, r, e, n, s, u, _) => {
+    let m = new AbortController(),
+      c = { headers: u, body: n ?? s, method: r.method, signal: m.signal };
+    return l.WITH_CREDENTIALS && (c.credentials = l.CREDENTIALS), _(() => m.abort()), await fetch(e, c);
+  },
+  Al = (l, r) => {
+    if (r) {
+      let e = l.headers.get(r);
+      if (er(e)) return e;
+    }
+  },
+  kl = async (l) => {
+    if (l.status !== 204)
+      try {
+        let r = l.headers.get("Content-Type");
+        if (r)
+          return ["application/json", "application/problem+json"].some((s) => r.toLowerCase().startsWith(s))
+            ? await l.json()
+            : await l.text();
+      } catch (r) {
+        console.error(r);
+      }
+  },
+  xl = (l, r) => {
+    let n = {
+      400: "Bad Request",
+      401: "Unauthorized",
+      403: "Forbidden",
+      404: "Not Found",
+      500: "Internal Server Error",
+      502: "Bad Gateway",
+      503: "Service Unavailable",
+      ...l.errors,
+    }[r.status];
+    if (n) throw new J(l, r, n);
+    if (!r.ok) {
+      let s = r.status ?? "unknown",
+        u = r.statusText ?? "unknown",
+        _ = (() => {
+          try {
+            return JSON.stringify(r.body, null, 2);
+          } catch {
+            return;
+          }
+        })();
+      throw new J(l, r, `Generic Error: status: ${s}; status text: ${u}; body: ${_}`);
+    }
+  },
+  o = (l, r) =>
+    new rr(async (e, n, s) => {
+      try {
+        let u = wl(l, r),
+          _ = El(r),
+          m = Rl(r),
+          c = await vl(l, r);
+        if (!s.isCancelled) {
+          let d = await Tl(l, r, u, m, _, c, s),
+            v = await kl(d),
+            h = Al(d, r.responseHeader),
+            R = { url: u, ok: d.ok, status: d.status, statusText: d.statusText, body: h ?? v };
+          xl(r, R), e(R.body);
+        }
+      } catch (u) {
+        n(u);
+      }
+    });
+var lr = class {
+  static actionsGetActionsCacheUsageForOrg(r) {
+    return o(i, { method: "GET", url: "/orgs/{org}/actions/cache/usage", path: { org: r } });
+  }
+  static actionsGetActionsCacheUsageByRepoForOrg(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/actions/cache/usage-by-repository",
+      path: { org: r },
+      query: { per_page: e, page: n },
+    });
+  }
+  static actionsGetGithubActionsPermissionsOrganization(r) {
+    return o(i, { method: "GET", url: "/orgs/{org}/actions/permissions", path: { org: r } });
+  }
+  static actionsSetGithubActionsPermissionsOrganization(r, e) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/actions/permissions",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+    });
+  }
+  static actionsListSelectedRepositoriesEnabledGithubActionsOrganization(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/actions/permissions/repositories",
+      path: { org: r },
+      query: { per_page: e, page: n },
+    });
+  }
+  static actionsSetSelectedRepositoriesEnabledGithubActionsOrganization(r, e) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/actions/permissions/repositories",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+    });
+  }
+  static actionsEnableSelectedRepositoryGithubActionsOrganization(r, e) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/actions/permissions/repositories/{repository_id}",
+      path: { org: r, repository_id: e },
+    });
+  }
+  static actionsDisableSelectedRepositoryGithubActionsOrganization(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/actions/permissions/repositories/{repository_id}",
+      path: { org: r, repository_id: e },
+    });
+  }
+  static actionsGetAllowedActionsOrganization(r) {
+    return o(i, { method: "GET", url: "/orgs/{org}/actions/permissions/selected-actions", path: { org: r } });
+  }
+  static actionsSetAllowedActionsOrganization(r, e) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/actions/permissions/selected-actions",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+    });
+  }
+  static actionsGetGithubActionsDefaultWorkflowPermissionsOrganization(r) {
+    return o(i, { method: "GET", url: "/orgs/{org}/actions/permissions/workflow", path: { org: r } });
+  }
+  static actionsSetGithubActionsDefaultWorkflowPermissionsOrganization(r, e) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/actions/permissions/workflow",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+    });
+  }
+  static actionsListSelfHostedRunnersForOrg(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/actions/runners",
+      path: { org: r },
+      query: { per_page: e, page: n },
+    });
+  }
+  static actionsListRunnerApplicationsForOrg(r) {
+    return o(i, { method: "GET", url: "/orgs/{org}/actions/runners/downloads", path: { org: r } });
+  }
+  static actionsGenerateRunnerJitconfigForOrg(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/actions/runners/generate-jitconfig",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static actionsCreateRegistrationTokenForOrg(r) {
+    return o(i, { method: "POST", url: "/orgs/{org}/actions/runners/registration-token", path: { org: r } });
+  }
+  static actionsCreateRemoveTokenForOrg(r) {
+    return o(i, { method: "POST", url: "/orgs/{org}/actions/runners/remove-token", path: { org: r } });
+  }
+  static actionsGetSelfHostedRunnerForOrg(r, e) {
+    return o(i, { method: "GET", url: "/orgs/{org}/actions/runners/{runner_id}", path: { org: r, runner_id: e } });
+  }
+  static actionsDeleteSelfHostedRunnerFromOrg(r, e) {
+    return o(i, { method: "DELETE", url: "/orgs/{org}/actions/runners/{runner_id}", path: { org: r, runner_id: e } });
+  }
+  static actionsListLabelsForSelfHostedRunnerForOrg(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/actions/runners/{runner_id}/labels",
+      path: { org: r, runner_id: e },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static actionsAddCustomLabelsToSelfHostedRunnerForOrg(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/actions/runners/{runner_id}/labels",
+      path: { org: r, runner_id: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static actionsSetCustomLabelsForSelfHostedRunnerForOrg(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/actions/runners/{runner_id}/labels",
+      path: { org: r, runner_id: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static actionsRemoveAllCustomLabelsFromSelfHostedRunnerForOrg(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/actions/runners/{runner_id}/labels",
+      path: { org: r, runner_id: e },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static actionsRemoveCustomLabelFromSelfHostedRunnerForOrg(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/actions/runners/{runner_id}/labels/{name}",
+      path: { org: r, runner_id: e, name: n },
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static actionsListOrgSecrets(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/actions/secrets",
+      path: { org: r },
+      query: { per_page: e, page: n },
+    });
+  }
+  static actionsGetOrgPublicKey(r) {
+    return o(i, { method: "GET", url: "/orgs/{org}/actions/secrets/public-key", path: { org: r } });
+  }
+  static actionsGetOrgSecret(r, e) {
+    return o(i, { method: "GET", url: "/orgs/{org}/actions/secrets/{secret_name}", path: { org: r, secret_name: e } });
+  }
+  static actionsCreateOrUpdateOrgSecret(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/actions/secrets/{secret_name}",
+      path: { org: r, secret_name: e },
+      body: n,
+      mediaType: "application/json",
+    });
+  }
+  static actionsDeleteOrgSecret(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/actions/secrets/{secret_name}",
+      path: { org: r, secret_name: e },
+    });
+  }
+  static actionsListSelectedReposForOrgSecret(r, e, n = 1, s = 30) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/actions/secrets/{secret_name}/repositories",
+      path: { org: r, secret_name: e },
+      query: { page: n, per_page: s },
+    });
+  }
+  static actionsSetSelectedReposForOrgSecret(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/actions/secrets/{secret_name}/repositories",
+      path: { org: r, secret_name: e },
+      body: n,
+      mediaType: "application/json",
+    });
+  }
+  static actionsAddSelectedRepoToOrgSecret(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}",
+      path: { org: r, secret_name: e, repository_id: n },
+      errors: { 409: "Conflict when visibility type is not set to selected" },
+    });
+  }
+  static actionsRemoveSelectedRepoFromOrgSecret(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}",
+      path: { org: r, secret_name: e, repository_id: n },
+      errors: { 409: "Conflict when visibility type not set to selected" },
+    });
+  }
+  static actionsListOrgVariables(r, e = 10, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/actions/variables",
+      path: { org: r },
+      query: { per_page: e, page: n },
+    });
+  }
+  static actionsCreateOrgVariable(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/actions/variables",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+    });
+  }
+  static actionsGetOrgVariable(r, e) {
+    return o(i, { method: "GET", url: "/orgs/{org}/actions/variables/{name}", path: { org: r, name: e } });
+  }
+  static actionsUpdateOrgVariable(r, e, n) {
+    return o(i, {
+      method: "PATCH",
+      url: "/orgs/{org}/actions/variables/{name}",
+      path: { org: r, name: e },
+      body: n,
+      mediaType: "application/json",
+    });
+  }
+  static actionsDeleteOrgVariable(r, e) {
+    return o(i, { method: "DELETE", url: "/orgs/{org}/actions/variables/{name}", path: { org: r, name: e } });
+  }
+  static actionsListSelectedReposForOrgVariable(r, e, n = 1, s = 30) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/actions/variables/{name}/repositories",
+      path: { org: r, name: e },
+      query: { page: n, per_page: s },
+      errors: { 409: "Response when the visibility of the variable is not set to `selected`" },
+    });
+  }
+  static actionsSetSelectedReposForOrgVariable(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/actions/variables/{name}/repositories",
+      path: { org: r, name: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 409: "Response when the visibility of the variable is not set to `selected`" },
+    });
+  }
+  static actionsAddSelectedRepoToOrgVariable(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/actions/variables/{name}/repositories/{repository_id}",
+      path: { org: r, name: e, repository_id: n },
+      errors: { 409: "Response when the visibility of the variable is not set to `selected`" },
+    });
+  }
+  static actionsRemoveSelectedRepoFromOrgVariable(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/actions/variables/{name}/repositories/{repository_id}",
+      path: { org: r, name: e, repository_id: n },
+      errors: { 409: "Response when the visibility of the variable is not set to `selected`" },
+    });
+  }
+  static actionsListArtifactsForRepo(r, e, n = 30, s = 1, u) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/artifacts",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s, name: u },
+    });
+  }
+  static actionsGetArtifact(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/artifacts/{artifact_id}",
+      path: { owner: r, repo: e, artifact_id: n },
+    });
+  }
+  static actionsDeleteArtifact(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/actions/artifacts/{artifact_id}",
+      path: { owner: r, repo: e, artifact_id: n },
+    });
+  }
+  static actionsDownloadArtifact(r, e, n, s) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}",
+      path: { owner: r, repo: e, artifact_id: n, archive_format: s },
+      errors: { 302: "Response", 410: "Gone" },
+    });
+  }
+  static actionsGetActionsCacheUsage(r, e) {
+    return o(i, { method: "GET", url: "/repos/{owner}/{repo}/actions/cache/usage", path: { owner: r, repo: e } });
+  }
+  static actionsGetActionsCacheList(r, e, n = 30, s = 1, u, _, m = "last_accessed_at", c = "desc") {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/caches",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s, ref: u, key: _, sort: m, direction: c },
+    });
+  }
+  static actionsDeleteActionsCacheByKey(r, e, n, s) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/actions/caches",
+      path: { owner: r, repo: e },
+      query: { key: n, ref: s },
+    });
+  }
+  static actionsDeleteActionsCacheById(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/actions/caches/{cache_id}",
+      path: { owner: r, repo: e, cache_id: n },
+    });
+  }
+  static actionsGetJobForWorkflowRun(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/jobs/{job_id}",
+      path: { owner: r, repo: e, job_id: n },
+    });
+  }
+  static actionsDownloadJobLogsForWorkflowRun(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/jobs/{job_id}/logs",
+      path: { owner: r, repo: e, job_id: n },
+      errors: { 302: "Response" },
+    });
+  }
+  static actionsReRunJobForWorkflowRun(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/actions/jobs/{job_id}/rerun",
+      path: { owner: r, repo: e, job_id: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 403: "Forbidden" },
+    });
+  }
+  static actionsGetCustomOidcSubClaimForRepo(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/oidc/customization/sub",
+      path: { owner: r, repo: e },
+      errors: { 400: "Bad Request", 404: "Resource not found" },
+    });
+  }
+  static actionsSetCustomOidcSubClaimForRepo(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/actions/oidc/customization/sub",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        400: "Bad Request",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static actionsListRepoOrganizationSecrets(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/organization-secrets",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+    });
+  }
+  static actionsListRepoOrganizationVariables(r, e, n = 10, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/organization-variables",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+    });
+  }
+  static actionsGetGithubActionsPermissionsRepository(r, e) {
+    return o(i, { method: "GET", url: "/repos/{owner}/{repo}/actions/permissions", path: { owner: r, repo: e } });
+  }
+  static actionsSetGithubActionsPermissionsRepository(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/actions/permissions",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+    });
+  }
+  static actionsGetWorkflowAccessToRepository(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/permissions/access",
+      path: { owner: r, repo: e },
+    });
+  }
+  static actionsSetWorkflowAccessToRepository(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/actions/permissions/access",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+    });
+  }
+  static actionsGetAllowedActionsRepository(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/permissions/selected-actions",
+      path: { owner: r, repo: e },
+    });
+  }
+  static actionsSetAllowedActionsRepository(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/actions/permissions/selected-actions",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+    });
+  }
+  static actionsGetGithubActionsDefaultWorkflowPermissionsRepository(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/permissions/workflow",
+      path: { owner: r, repo: e },
+    });
+  }
+  static actionsSetGithubActionsDefaultWorkflowPermissionsRepository(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/actions/permissions/workflow",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 409: "Conflict response when changing a setting is prevented by the owning organization" },
+    });
+  }
+  static actionsListSelfHostedRunnersForRepo(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/runners",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+    });
+  }
+  static actionsListRunnerApplicationsForRepo(r, e) {
+    return o(i, { method: "GET", url: "/repos/{owner}/{repo}/actions/runners/downloads", path: { owner: r, repo: e } });
+  }
+  static actionsGenerateRunnerJitconfigForRepo(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/actions/runners/generate-jitconfig",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static actionsCreateRegistrationTokenForRepo(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/actions/runners/registration-token",
+      path: { owner: r, repo: e },
+    });
+  }
+  static actionsCreateRemoveTokenForRepo(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/actions/runners/remove-token",
+      path: { owner: r, repo: e },
+    });
+  }
+  static actionsGetSelfHostedRunnerForRepo(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/runners/{runner_id}",
+      path: { owner: r, repo: e, runner_id: n },
+    });
+  }
+  static actionsDeleteSelfHostedRunnerFromRepo(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/actions/runners/{runner_id}",
+      path: { owner: r, repo: e, runner_id: n },
+    });
+  }
+  static actionsListLabelsForSelfHostedRunnerForRepo(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/runners/{runner_id}/labels",
+      path: { owner: r, repo: e, runner_id: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static actionsAddCustomLabelsToSelfHostedRunnerForRepo(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/actions/runners/{runner_id}/labels",
+      path: { owner: r, repo: e, runner_id: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static actionsSetCustomLabelsForSelfHostedRunnerForRepo(r, e, n, s) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/actions/runners/{runner_id}/labels",
+      path: { owner: r, repo: e, runner_id: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static actionsRemoveAllCustomLabelsFromSelfHostedRunnerForRepo(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/actions/runners/{runner_id}/labels",
+      path: { owner: r, repo: e, runner_id: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static actionsRemoveCustomLabelFromSelfHostedRunnerForRepo(r, e, n, s) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/actions/runners/{runner_id}/labels/{name}",
+      path: { owner: r, repo: e, runner_id: n, name: s },
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static actionsListWorkflowRunsForRepo(r, e, n, s, u, _, m = 30, c = 1, d, v = !1, h, R) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/runs",
+      path: { owner: r, repo: e },
+      query: {
+        actor: n,
+        branch: s,
+        event: u,
+        status: _,
+        per_page: m,
+        page: c,
+        created: d,
+        exclude_pull_requests: v,
+        check_suite_id: h,
+        head_sha: R,
+      },
+    });
+  }
+  static actionsGetWorkflowRun(r, e, n, s = !1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/runs/{run_id}",
+      path: { owner: r, repo: e, run_id: n },
+      query: { exclude_pull_requests: s },
+    });
+  }
+  static actionsDeleteWorkflowRun(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/actions/runs/{run_id}",
+      path: { owner: r, repo: e, run_id: n },
+    });
+  }
+  static actionsGetReviewsForRun(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/runs/{run_id}/approvals",
+      path: { owner: r, repo: e, run_id: n },
+    });
+  }
+  static actionsApproveWorkflowRun(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/actions/runs/{run_id}/approve",
+      path: { owner: r, repo: e, run_id: n },
+      errors: { 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static actionsListWorkflowRunArtifacts(r, e, n, s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/runs/{run_id}/artifacts",
+      path: { owner: r, repo: e, run_id: n },
+      query: { per_page: s, page: u },
+    });
+  }
+  static actionsGetWorkflowRunAttempt(r, e, n, s, u = !1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}",
+      path: { owner: r, repo: e, run_id: n, attempt_number: s },
+      query: { exclude_pull_requests: u },
+    });
+  }
+  static actionsListJobsForWorkflowRunAttempt(r, e, n, s, u = 30, _ = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs",
+      path: { owner: r, repo: e, run_id: n, attempt_number: s },
+      query: { per_page: u, page: _ },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static actionsDownloadWorkflowRunAttemptLogs(r, e, n, s) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/logs",
+      path: { owner: r, repo: e, run_id: n, attempt_number: s },
+      errors: { 302: "Response" },
+    });
+  }
+  static actionsCancelWorkflowRun(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/actions/runs/{run_id}/cancel",
+      path: { owner: r, repo: e, run_id: n },
+      errors: { 409: "Conflict" },
+    });
+  }
+  static actionsReviewCustomGatesForRun(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/actions/runs/{run_id}/deployment_protection_rule",
+      path: { owner: r, repo: e, run_id: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static actionsListJobsForWorkflowRun(r, e, n, s = "latest", u = 30, _ = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
+      path: { owner: r, repo: e, run_id: n },
+      query: { filter: s, per_page: u, page: _ },
+    });
+  }
+  static actionsDownloadWorkflowRunLogs(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/runs/{run_id}/logs",
+      path: { owner: r, repo: e, run_id: n },
+      errors: { 302: "Response" },
+    });
+  }
+  static actionsDeleteWorkflowRunLogs(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/actions/runs/{run_id}/logs",
+      path: { owner: r, repo: e, run_id: n },
+      errors: { 403: "Forbidden", 500: "Internal Error" },
+    });
+  }
+  static actionsGetPendingDeploymentsForRun(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/runs/{run_id}/pending_deployments",
+      path: { owner: r, repo: e, run_id: n },
+    });
+  }
+  static actionsReviewPendingDeploymentsForRun(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/actions/runs/{run_id}/pending_deployments",
+      path: { owner: r, repo: e, run_id: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static actionsReRunWorkflow(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/actions/runs/{run_id}/rerun",
+      path: { owner: r, repo: e, run_id: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static actionsReRunWorkflowFailedJobs(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs",
+      path: { owner: r, repo: e, run_id: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static actionsGetWorkflowRunUsage(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/runs/{run_id}/timing",
+      path: { owner: r, repo: e, run_id: n },
+    });
+  }
+  static actionsListRepoSecrets(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/secrets",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+    });
+  }
+  static actionsGetRepoPublicKey(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/secrets/public-key",
+      path: { owner: r, repo: e },
+    });
+  }
+  static actionsGetRepoSecret(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/secrets/{secret_name}",
+      path: { owner: r, repo: e, secret_name: n },
+    });
+  }
+  static actionsCreateOrUpdateRepoSecret(r, e, n, s) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/actions/secrets/{secret_name}",
+      path: { owner: r, repo: e, secret_name: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static actionsDeleteRepoSecret(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/actions/secrets/{secret_name}",
+      path: { owner: r, repo: e, secret_name: n },
+    });
+  }
+  static actionsListRepoVariables(r, e, n = 10, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/variables",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+    });
+  }
+  static actionsCreateRepoVariable(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/actions/variables",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+    });
+  }
+  static actionsGetRepoVariable(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/variables/{name}",
+      path: { owner: r, repo: e, name: n },
+    });
+  }
+  static actionsUpdateRepoVariable(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/actions/variables/{name}",
+      path: { owner: r, repo: e, name: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static actionsDeleteRepoVariable(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/actions/variables/{name}",
+      path: { owner: r, repo: e, name: n },
+    });
+  }
+  static actionsListRepoWorkflows(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/workflows",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+    });
+  }
+  static actionsGetWorkflow(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/workflows/{workflow_id}",
+      path: { owner: r, repo: e, workflow_id: n },
+    });
+  }
+  static actionsDisableWorkflow(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/actions/workflows/{workflow_id}/disable",
+      path: { owner: r, repo: e, workflow_id: n },
+    });
+  }
+  static actionsCreateWorkflowDispatch(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
+      path: { owner: r, repo: e, workflow_id: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static actionsEnableWorkflow(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/actions/workflows/{workflow_id}/enable",
+      path: { owner: r, repo: e, workflow_id: n },
+    });
+  }
+  static actionsListWorkflowRuns(r, e, n, s, u, _, m, c = 30, d = 1, v, h = !1, R, k) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs",
+      path: { owner: r, repo: e, workflow_id: n },
+      query: {
+        actor: s,
+        branch: u,
+        event: _,
+        status: m,
+        per_page: c,
+        page: d,
+        created: v,
+        exclude_pull_requests: h,
+        check_suite_id: R,
+        head_sha: k,
+      },
+    });
+  }
+  static actionsGetWorkflowUsage(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/actions/workflows/{workflow_id}/timing",
+      path: { owner: r, repo: e, workflow_id: n },
+    });
+  }
+  static actionsListEnvironmentSecrets(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repositories/{repository_id}/environments/{environment_name}/secrets",
+      path: { repository_id: r, environment_name: e },
+      query: { per_page: n, page: s },
+    });
+  }
+  static actionsGetEnvironmentPublicKey(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/repositories/{repository_id}/environments/{environment_name}/secrets/public-key",
+      path: { repository_id: r, environment_name: e },
+    });
+  }
+  static actionsGetEnvironmentSecret(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}",
+      path: { repository_id: r, environment_name: e, secret_name: n },
+    });
+  }
+  static actionsCreateOrUpdateEnvironmentSecret(r, e, n, s) {
+    return o(i, {
+      method: "PUT",
+      url: "/repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}",
+      path: { repository_id: r, environment_name: e, secret_name: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static actionsDeleteEnvironmentSecret(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}",
+      path: { repository_id: r, environment_name: e, secret_name: n },
+    });
+  }
+  static actionsListEnvironmentVariables(r, e, n = 10, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repositories/{repository_id}/environments/{environment_name}/variables",
+      path: { repository_id: r, environment_name: e },
+      query: { per_page: n, page: s },
+    });
+  }
+  static actionsCreateEnvironmentVariable(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repositories/{repository_id}/environments/{environment_name}/variables",
+      path: { repository_id: r, environment_name: e },
+      body: n,
+      mediaType: "application/json",
+    });
+  }
+  static actionsGetEnvironmentVariable(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repositories/{repository_id}/environments/{environment_name}/variables/{name}",
+      path: { repository_id: r, environment_name: e, name: n },
+    });
+  }
+  static actionsUpdateEnvironmentVariable(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repositories/{repository_id}/environments/{environment_name}/variables/{name}",
+      path: { repository_id: r, name: e, environment_name: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static actionsDeleteEnvironmentVariable(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repositories/{repository_id}/environments/{environment_name}/variables/{name}",
+      path: { repository_id: r, name: e, environment_name: n },
+    });
+  }
+};
+var ar = class {
+  static activityListPublicEvents(r = 30, e = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/events",
+      query: { per_page: r, page: e },
+      errors: { 304: "Not modified", 403: "Forbidden", 503: "Service unavailable" },
+    });
+  }
+  static activityGetFeeds() {
+    return o(i, { method: "GET", url: "/feeds" });
+  }
+  static activityListPublicEventsForRepoNetwork(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/networks/{owner}/{repo}/events",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+      errors: { 301: "Moved permanently", 304: "Not modified", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static activityListNotificationsForAuthenticatedUser(r = !1, e = !1, n, s, u = 1, _ = 50) {
+    return o(i, {
+      method: "GET",
+      url: "/notifications",
+      query: { all: r, participating: e, since: n, before: s, page: u, per_page: _ },
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static activityMarkNotificationsAsRead(r) {
+    return o(i, {
+      method: "PUT",
+      url: "/notifications",
+      body: r,
+      mediaType: "application/json",
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden" },
+    });
+  }
+  static activityGetThread(r) {
+    return o(i, {
+      method: "GET",
+      url: "/notifications/threads/{thread_id}",
+      path: { thread_id: r },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden" },
+    });
+  }
+  static activityMarkThreadAsRead(r) {
+    return o(i, {
+      method: "PATCH",
+      url: "/notifications/threads/{thread_id}",
+      path: { thread_id: r },
+      errors: { 304: "Not modified", 403: "Forbidden" },
+    });
+  }
+  static activityGetThreadSubscriptionForAuthenticatedUser(r) {
+    return o(i, {
+      method: "GET",
+      url: "/notifications/threads/{thread_id}/subscription",
+      path: { thread_id: r },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden" },
+    });
+  }
+  static activitySetThreadSubscription(r, e) {
+    return o(i, {
+      method: "PUT",
+      url: "/notifications/threads/{thread_id}/subscription",
+      path: { thread_id: r },
+      body: e,
+      mediaType: "application/json",
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden" },
+    });
+  }
+  static activityDeleteThreadSubscription(r) {
+    return o(i, {
+      method: "DELETE",
+      url: "/notifications/threads/{thread_id}/subscription",
+      path: { thread_id: r },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden" },
+    });
+  }
+  static activityListPublicOrgEvents(r, e = 30, n = 1) {
+    return o(i, { method: "GET", url: "/orgs/{org}/events", path: { org: r }, query: { per_page: e, page: n } });
+  }
+  static activityListRepoEvents(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/events",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+    });
+  }
+  static activityListRepoNotificationsForAuthenticatedUser(r, e, n = !1, s = !1, u, _, m = 30, c = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/notifications",
+      path: { owner: r, repo: e },
+      query: { all: n, participating: s, since: u, before: _, per_page: m, page: c },
+    });
+  }
+  static activityMarkRepoNotificationsAsRead(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/notifications",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+    });
+  }
+  static activityListStargazersForRepo(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/stargazers",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static activityListWatchersForRepo(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/subscribers",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+    });
+  }
+  static activityGetRepoSubscription(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/subscription",
+      path: { owner: r, repo: e },
+      errors: { 403: "Forbidden", 404: "Not Found if you don't subscribe to the repository" },
+    });
+  }
+  static activitySetRepoSubscription(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/subscription",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+    });
+  }
+  static activityDeleteRepoSubscription(r, e) {
+    return o(i, { method: "DELETE", url: "/repos/{owner}/{repo}/subscription", path: { owner: r, repo: e } });
+  }
+  static activityListReposStarredByAuthenticatedUser(r = "created", e = "desc", n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/user/starred",
+      query: { sort: r, direction: e, per_page: n, page: s },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden" },
+    });
+  }
+  static activityCheckRepoIsStarredByAuthenticatedUser(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/user/starred/{owner}/{repo}",
+      path: { owner: r, repo: e },
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Not Found if this repository is not starred by you",
+      },
+    });
+  }
+  static activityStarRepoForAuthenticatedUser(r, e) {
+    return o(i, {
+      method: "PUT",
+      url: "/user/starred/{owner}/{repo}",
+      path: { owner: r, repo: e },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static activityUnstarRepoForAuthenticatedUser(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/user/starred/{owner}/{repo}",
+      path: { owner: r, repo: e },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static activityListWatchedReposForAuthenticatedUser(r = 30, e = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/user/subscriptions",
+      query: { per_page: r, page: e },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden" },
+    });
+  }
+  static activityListEventsForAuthenticatedUser(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}/events",
+      path: { username: r },
+      query: { per_page: e, page: n },
+    });
+  }
+  static activityListOrgEventsForAuthenticatedUser(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}/events/orgs/{org}",
+      path: { username: r, org: e },
+      query: { per_page: n, page: s },
+    });
+  }
+  static activityListPublicEventsForUser(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}/events/public",
+      path: { username: r },
+      query: { per_page: e, page: n },
+    });
+  }
+  static activityListReceivedEventsForUser(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}/received_events",
+      path: { username: r },
+      query: { per_page: e, page: n },
+    });
+  }
+  static activityListReceivedPublicEventsForUser(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}/received_events/public",
+      path: { username: r },
+      query: { per_page: e, page: n },
+    });
+  }
+  static activityListReposStarredByUser(r, e = "created", n = "desc", s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}/starred",
+      path: { username: r },
+      query: { sort: e, direction: n, per_page: s, page: u },
+    });
+  }
+  static activityListReposWatchedByUser(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}/subscriptions",
+      path: { username: r },
+      query: { per_page: e, page: n },
+    });
+  }
+};
+var ur = class {
+  static appsGetAuthenticated() {
+    return o(i, { method: "GET", url: "/app" });
+  }
+  static appsCreateFromManifest(r) {
+    return o(i, {
+      method: "POST",
+      url: "/app-manifests/{code}/conversions",
+      path: { code: r },
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static appsGetWebhookConfigForApp() {
+    return o(i, { method: "GET", url: "/app/hook/config" });
+  }
+  static appsUpdateWebhookConfigForApp(r) {
+    return o(i, { method: "PATCH", url: "/app/hook/config", body: r, mediaType: "application/json" });
+  }
+  static appsListWebhookDeliveries(r = 30, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/app/hook/deliveries",
+      query: { per_page: r, cursor: e, redelivery: n },
+      errors: { 400: "Bad Request", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static appsGetWebhookDelivery(r) {
+    return o(i, {
+      method: "GET",
+      url: "/app/hook/deliveries/{delivery_id}",
+      path: { delivery_id: r },
+      errors: { 400: "Bad Request", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static appsRedeliverWebhookDelivery(r) {
+    return o(i, {
+      method: "POST",
+      url: "/app/hook/deliveries/{delivery_id}/attempts",
+      path: { delivery_id: r },
+      errors: { 400: "Bad Request", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static appsListInstallationRequestsForAuthenticatedApp(r = 30, e = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/app/installation-requests",
+      query: { per_page: r, page: e },
+      errors: { 304: "Not modified", 401: "Requires authentication" },
+    });
+  }
+  static appsListInstallations(r = 30, e = 1, n, s) {
+    return o(i, { method: "GET", url: "/app/installations", query: { per_page: r, page: e, since: n, outdated: s } });
+  }
+  static appsGetInstallation(r) {
+    return o(i, {
+      method: "GET",
+      url: "/app/installations/{installation_id}",
+      path: { installation_id: r },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static appsDeleteInstallation(r) {
+    return o(i, {
+      method: "DELETE",
+      url: "/app/installations/{installation_id}",
+      path: { installation_id: r },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static appsCreateInstallationAccessToken(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/app/installations/{installation_id}/access_tokens",
+      path: { installation_id: r },
+      body: e,
+      mediaType: "application/json",
+      errors: {
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static appsSuspendInstallation(r) {
+    return o(i, {
+      method: "PUT",
+      url: "/app/installations/{installation_id}/suspended",
+      path: { installation_id: r },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static appsUnsuspendInstallation(r) {
+    return o(i, {
+      method: "DELETE",
+      url: "/app/installations/{installation_id}/suspended",
+      path: { installation_id: r },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static appsDeleteAuthorization(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/applications/{client_id}/grant",
+      path: { client_id: r },
+      body: e,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static appsCheckToken(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/applications/{client_id}/token",
+      path: { client_id: r },
+      body: e,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static appsResetToken(r, e) {
+    return o(i, {
+      method: "PATCH",
+      url: "/applications/{client_id}/token",
+      path: { client_id: r },
+      body: e,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static appsDeleteToken(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/applications/{client_id}/token",
+      path: { client_id: r },
+      body: e,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static appsScopeToken(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/applications/{client_id}/token/scoped",
+      path: { client_id: r },
+      body: e,
+      mediaType: "application/json",
+      errors: {
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static appsGetBySlug(r) {
+    return o(i, {
+      method: "GET",
+      url: "/apps/{app_slug}",
+      path: { app_slug: r },
+      errors: { 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static appsListReposAccessibleToInstallation(r = 30, e = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/installation/repositories",
+      query: { per_page: r, page: e },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden" },
+    });
+  }
+  static appsRevokeInstallationAccessToken() {
+    return o(i, { method: "DELETE", url: "/installation/token" });
+  }
+  static appsGetSubscriptionPlanForAccount(r) {
+    return o(i, {
+      method: "GET",
+      url: "/marketplace_listing/accounts/{account_id}",
+      path: { account_id: r },
+      errors: { 401: "Requires authentication", 404: "Not Found when the account has not purchased the listing" },
+    });
+  }
+  static appsListPlans(r = 30, e = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/marketplace_listing/plans",
+      query: { per_page: r, page: e },
+      errors: { 401: "Requires authentication", 404: "Resource not found" },
+    });
+  }
+  static appsListAccountsForPlan(r, e = "created", n, s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/marketplace_listing/plans/{plan_id}/accounts",
+      path: { plan_id: r },
+      query: { sort: e, direction: n, per_page: s, page: u },
+      errors: {
+        401: "Requires authentication",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static appsGetSubscriptionPlanForAccountStubbed(r) {
+    return o(i, {
+      method: "GET",
+      url: "/marketplace_listing/stubbed/accounts/{account_id}",
+      path: { account_id: r },
+      errors: { 401: "Requires authentication", 404: "Not Found when the account has not purchased the listing" },
+    });
+  }
+  static appsListPlansStubbed(r = 30, e = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/marketplace_listing/stubbed/plans",
+      query: { per_page: r, page: e },
+      errors: { 401: "Requires authentication" },
+    });
+  }
+  static appsListAccountsForPlanStubbed(r, e = "created", n, s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/marketplace_listing/stubbed/plans/{plan_id}/accounts",
+      path: { plan_id: r },
+      query: { sort: e, direction: n, per_page: s, page: u },
+      errors: { 401: "Requires authentication" },
+    });
+  }
+  static appsGetOrgInstallation(r) {
+    return o(i, { method: "GET", url: "/orgs/{org}/installation", path: { org: r } });
+  }
+  static appsGetRepoInstallation(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/installation",
+      path: { owner: r, repo: e },
+      errors: { 301: "Moved permanently", 404: "Resource not found" },
+    });
+  }
+  static appsListInstallationsForAuthenticatedUser(r = 30, e = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/user/installations",
+      query: { per_page: r, page: e },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden" },
+    });
+  }
+  static appsListInstallationReposForAuthenticatedUser(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/user/installations/{installation_id}/repositories",
+      path: { installation_id: r },
+      query: { per_page: e, page: n },
+      errors: { 304: "Not modified", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static appsAddRepoToInstallationForAuthenticatedUser(r, e) {
+    return o(i, {
+      method: "PUT",
+      url: "/user/installations/{installation_id}/repositories/{repository_id}",
+      path: { installation_id: r, repository_id: e },
+      errors: { 304: "Not modified", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static appsRemoveRepoFromInstallationForAuthenticatedUser(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/user/installations/{installation_id}/repositories/{repository_id}",
+      path: { installation_id: r, repository_id: e },
+      errors: {
+        304: "Not modified",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Returned when the application is installed on `all` repositories in the organization, or if this request would remove the last repository that the application has access to in the organization.",
+      },
+    });
+  }
+  static appsListSubscriptionsForAuthenticatedUser(r = 30, e = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/user/marketplace_purchases",
+      query: { per_page: r, page: e },
+      errors: { 304: "Not modified", 401: "Requires authentication", 404: "Resource not found" },
+    });
+  }
+  static appsListSubscriptionsForAuthenticatedUserStubbed(r = 30, e = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/user/marketplace_purchases/stubbed",
+      query: { per_page: r, page: e },
+      errors: { 304: "Not modified", 401: "Requires authentication" },
+    });
+  }
+  static appsGetUserInstallation(r) {
+    return o(i, { method: "GET", url: "/users/{username}/installation", path: { username: r } });
+  }
+};
+var _r = class {
+  static billingGetGithubActionsBillingOrg(r) {
+    return o(i, { method: "GET", url: "/orgs/{org}/settings/billing/actions", path: { org: r } });
+  }
+  static billingGetGithubPackagesBillingOrg(r) {
+    return o(i, { method: "GET", url: "/orgs/{org}/settings/billing/packages", path: { org: r } });
+  }
+  static billingGetSharedStorageBillingOrg(r) {
+    return o(i, { method: "GET", url: "/orgs/{org}/settings/billing/shared-storage", path: { org: r } });
+  }
+  static billingGetGithubActionsBillingUser(r) {
+    return o(i, { method: "GET", url: "/users/{username}/settings/billing/actions", path: { username: r } });
+  }
+  static billingGetGithubPackagesBillingUser(r) {
+    return o(i, { method: "GET", url: "/users/{username}/settings/billing/packages", path: { username: r } });
+  }
+  static billingGetSharedStorageBillingUser(r) {
+    return o(i, { method: "GET", url: "/users/{username}/settings/billing/shared-storage", path: { username: r } });
+  }
+};
+var gr = class {
+  static checksCreate(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/check-runs",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+    });
+  }
+  static checksGet(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/check-runs/{check_run_id}",
+      path: { owner: r, repo: e, check_run_id: n },
+    });
+  }
+  static checksUpdate(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/check-runs/{check_run_id}",
+      path: { owner: r, repo: e, check_run_id: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static checksListAnnotations(r, e, n, s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/check-runs/{check_run_id}/annotations",
+      path: { owner: r, repo: e, check_run_id: n },
+      query: { per_page: s, page: u },
+    });
+  }
+  static checksRerequestRun(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/check-runs/{check_run_id}/rerequest",
+      path: { owner: r, repo: e, check_run_id: n },
+      errors: {
+        403: "Forbidden if the check run is not rerequestable or doesn't belong to the authenticated GitHub App",
+        404: "Resource not found",
+        422: "Validation error if the check run is not rerequestable",
+      },
+    });
+  }
+  static checksCreateSuite(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/check-suites",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+    });
+  }
+  static checksSetSuitesPreferences(r, e, n) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/check-suites/preferences",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+    });
+  }
+  static checksGetSuite(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/check-suites/{check_suite_id}",
+      path: { owner: r, repo: e, check_suite_id: n },
+    });
+  }
+  static checksListForSuite(r, e, n, s, u, _ = "latest", m = 30, c = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs",
+      path: { owner: r, repo: e, check_suite_id: n },
+      query: { check_name: s, status: u, filter: _, per_page: m, page: c },
+    });
+  }
+  static checksRerequestSuite(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/check-suites/{check_suite_id}/rerequest",
+      path: { owner: r, repo: e, check_suite_id: n },
+    });
+  }
+  static checksListForRef(r, e, n, s, u, _ = "latest", m = 30, c = 1, d) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/commits/{ref}/check-runs",
+      path: { owner: r, repo: e, ref: n },
+      query: { check_name: s, status: u, filter: _, per_page: m, page: c, app_id: d },
+    });
+  }
+  static checksListSuitesForRef(r, e, n, s, u, _ = 30, m = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/commits/{ref}/check-suites",
+      path: { owner: r, repo: e, ref: n },
+      query: { app_id: s, check_name: u, per_page: _, page: m },
+    });
+  }
+};
+var mr = class {
+  static codeScanningListAlertsForOrg(r, e, n, s, u, _ = 1, m = 30, c = "desc", d, v = "created", h) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/code-scanning/alerts",
+      path: { org: r },
+      query: {
+        tool_name: e,
+        tool_guid: n,
+        before: s,
+        after: u,
+        page: _,
+        per_page: m,
+        direction: c,
+        state: d,
+        sort: v,
+        severity: h,
+      },
+      errors: { 404: "Resource not found", 503: "Service unavailable" },
+    });
+  }
+  static codeScanningListAlertsForRepo(r, e, n, s, u = 1, _ = 30, m, c = "desc", d = "created", v, h) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/code-scanning/alerts",
+      path: { owner: r, repo: e },
+      query: { tool_name: n, tool_guid: s, page: u, per_page: _, ref: m, direction: c, sort: d, state: v, severity: h },
+      errors: {
+        304: "Not modified",
+        403: "Response if GitHub Advanced Security is not enabled for this repository",
+        404: "Resource not found",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static codeScanningGetAlert(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/code-scanning/alerts/{alert_number}",
+      path: { owner: r, repo: e, alert_number: n },
+      errors: {
+        304: "Not modified",
+        403: "Response if GitHub Advanced Security is not enabled for this repository",
+        404: "Resource not found",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static codeScanningUpdateAlert(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/code-scanning/alerts/{alert_number}",
+      path: { owner: r, repo: e, alert_number: n },
+      body: s,
+      mediaType: "application/json",
+      errors: {
+        403: "Response if the repository is archived or if GitHub Advanced Security is not enabled for this repository",
+        404: "Resource not found",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static codeScanningListAlertInstances(r, e, n, s = 1, u = 30, _) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/code-scanning/alerts/{alert_number}/instances",
+      path: { owner: r, repo: e, alert_number: n },
+      query: { page: s, per_page: u, ref: _ },
+      errors: {
+        403: "Response if GitHub Advanced Security is not enabled for this repository",
+        404: "Resource not found",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static codeScanningListRecentAnalyses(r, e, n, s, u = 1, _ = 30, m, c, d = "desc", v = "created") {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/code-scanning/analyses",
+      path: { owner: r, repo: e },
+      query: { tool_name: n, tool_guid: s, page: u, per_page: _, ref: m, sarif_id: c, direction: d, sort: v },
+      errors: {
+        403: "Response if GitHub Advanced Security is not enabled for this repository",
+        404: "Resource not found",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static codeScanningGetAnalysis(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/code-scanning/analyses/{analysis_id}",
+      path: { owner: r, repo: e, analysis_id: n },
+      errors: {
+        403: "Response if GitHub Advanced Security is not enabled for this repository",
+        404: "Resource not found",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static codeScanningDeleteAnalysis(r, e, n, s) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/code-scanning/analyses/{analysis_id}",
+      path: { owner: r, repo: e, analysis_id: n },
+      query: { confirm_delete: s },
+      errors: {
+        400: "Bad Request",
+        403: "Response if the repository is archived or if GitHub Advanced Security is not enabled for this repository",
+        404: "Resource not found",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static codeScanningListCodeqlDatabases(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/code-scanning/codeql/databases",
+      path: { owner: r, repo: e },
+      errors: {
+        403: "Response if GitHub Advanced Security is not enabled for this repository",
+        404: "Resource not found",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static codeScanningGetCodeqlDatabase(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/code-scanning/codeql/databases/{language}",
+      path: { owner: r, repo: e, language: n },
+      errors: {
+        302: "Found",
+        403: "Response if GitHub Advanced Security is not enabled for this repository",
+        404: "Resource not found",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static codeScanningGetDefaultSetup(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/code-scanning/default-setup",
+      path: { owner: r, repo: e },
+      errors: {
+        403: "Response if GitHub Advanced Security is not enabled for this repository",
+        404: "Resource not found",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static codeScanningUpdateDefaultSetup(r, e, n) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/code-scanning/default-setup",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        403: "Response if GitHub Advanced Security is not enabled for this repository",
+        404: "Resource not found",
+        409: "Response if there is already a validation run in progress with a different default setup configuration",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static codeScanningUploadSarif(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/code-scanning/sarifs",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        400: "Bad Request if the sarif field is invalid",
+        403: "Response if the repository is archived or if GitHub Advanced Security is not enabled for this repository",
+        404: "Resource not found",
+        413: "Payload Too Large if the sarif field is too large",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static codeScanningGetSarif(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/code-scanning/sarifs/{sarif_id}",
+      path: { owner: r, repo: e, sarif_id: n },
+      errors: {
+        403: "Response if GitHub Advanced Security is not enabled for this repository",
+        404: "Not Found if the sarif id does not match any upload",
+        503: "Service unavailable",
+      },
+    });
+  }
+};
+var pr = class {
+  static codesOfConductGetAllCodesOfConduct() {
+    return o(i, { method: "GET", url: "/codes_of_conduct", errors: { 304: "Not modified" } });
+  }
+  static codesOfConductGetConductCode(r) {
+    return o(i, {
+      method: "GET",
+      url: "/codes_of_conduct/{key}",
+      path: { key: r },
+      errors: { 304: "Not modified", 404: "Resource not found" },
+    });
+  }
+};
+var dr = class {
+  static codespacesListInOrganization(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/codespaces",
+      path: { org: r },
+      query: { per_page: e, page: n },
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        500: "Internal Error",
+      },
+    });
+  }
+  static codespacesSetCodespacesAccess(r, e) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/codespaces/access",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+      errors: {
+        304: "Not modified",
+        400: "Users are neither members nor collaborators of this organization.",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+        500: "Internal Error",
+      },
+    });
+  }
+  static codespacesSetCodespacesAccessUsers(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/codespaces/access/selected_users",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+      errors: {
+        304: "Not modified",
+        400: "Users are neither members nor collaborators of this organization.",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+        500: "Internal Error",
+      },
+    });
+  }
+  static codespacesDeleteCodespacesAccessUsers(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/codespaces/access/selected_users",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+      errors: {
+        304: "Not modified",
+        400: "Users are neither members nor collaborators of this organization.",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+        500: "Internal Error",
+      },
+    });
+  }
+  static codespacesListOrgSecrets(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/codespaces/secrets",
+      path: { org: r },
+      query: { per_page: e, page: n },
+    });
+  }
+  static codespacesGetOrgPublicKey(r) {
+    return o(i, { method: "GET", url: "/orgs/{org}/codespaces/secrets/public-key", path: { org: r } });
+  }
+  static codespacesGetOrgSecret(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/codespaces/secrets/{secret_name}",
+      path: { org: r, secret_name: e },
+    });
+  }
+  static codespacesCreateOrUpdateOrgSecret(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/codespaces/secrets/{secret_name}",
+      path: { org: r, secret_name: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static codespacesDeleteOrgSecret(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/codespaces/secrets/{secret_name}",
+      path: { org: r, secret_name: e },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static codespacesListSelectedReposForOrgSecret(r, e, n = 1, s = 30) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/codespaces/secrets/{secret_name}/repositories",
+      path: { org: r, secret_name: e },
+      query: { page: n, per_page: s },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static codespacesSetSelectedReposForOrgSecret(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/codespaces/secrets/{secret_name}/repositories",
+      path: { org: r, secret_name: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 409: "Conflict when visibility type not set to selected" },
+    });
+  }
+  static codespacesAddSelectedRepoToOrgSecret(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/codespaces/secrets/{secret_name}/repositories/{repository_id}",
+      path: { org: r, secret_name: e, repository_id: n },
+      errors: {
+        404: "Resource not found",
+        409: "Conflict when visibility type is not set to selected",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static codespacesRemoveSelectedRepoFromOrgSecret(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/codespaces/secrets/{secret_name}/repositories/{repository_id}",
+      path: { org: r, secret_name: e, repository_id: n },
+      errors: {
+        404: "Resource not found",
+        409: "Conflict when visibility type not set to selected",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static codespacesGetCodespacesForUserInOrg(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/members/{username}/codespaces",
+      path: { org: r, username: e },
+      query: { per_page: n, page: s },
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        500: "Internal Error",
+      },
+    });
+  }
+  static codespacesDeleteFromOrganization(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/members/{username}/codespaces/{codespace_name}",
+      path: { org: r, username: e, codespace_name: n },
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        500: "Internal Error",
+      },
+    });
+  }
+  static codespacesStopInOrganization(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/members/{username}/codespaces/{codespace_name}/stop",
+      path: { org: r, username: e, codespace_name: n },
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        500: "Internal Error",
+      },
+    });
+  }
+  static codespacesListInRepositoryForAuthenticatedUser(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/codespaces",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found", 500: "Internal Error" },
+    });
+  }
+  static codespacesCreateWithRepoForAuthenticatedUser(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/codespaces",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        400: "Bad Request",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static codespacesListDevcontainersInRepositoryForAuthenticatedUser(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/codespaces/devcontainers",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+      errors: {
+        400: "Bad Request",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        500: "Internal Error",
+      },
+    });
+  }
+  static codespacesRepoMachinesForAuthenticatedUser(r, e, n, s) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/codespaces/machines",
+      path: { owner: r, repo: e },
+      query: { location: n, client_ip: s },
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        500: "Internal Error",
+      },
+    });
+  }
+  static codespacesPreFlightWithRepoForAuthenticatedUser(r, e, n, s) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/codespaces/new",
+      path: { owner: r, repo: e },
+      query: { ref: n, client_ip: s },
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static codespacesListRepoSecrets(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/codespaces/secrets",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+    });
+  }
+  static codespacesGetRepoPublicKey(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/codespaces/secrets/public-key",
+      path: { owner: r, repo: e },
+    });
+  }
+  static codespacesGetRepoSecret(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/codespaces/secrets/{secret_name}",
+      path: { owner: r, repo: e, secret_name: n },
+    });
+  }
+  static codespacesCreateOrUpdateRepoSecret(r, e, n, s) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/codespaces/secrets/{secret_name}",
+      path: { owner: r, repo: e, secret_name: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static codespacesDeleteRepoSecret(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/codespaces/secrets/{secret_name}",
+      path: { owner: r, repo: e, secret_name: n },
+    });
+  }
+  static codespacesCreateWithPrForAuthenticatedUser(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/pulls/{pull_number}/codespaces",
+      path: { owner: r, repo: e, pull_number: n },
+      body: s,
+      mediaType: "application/json",
+      errors: {
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static codespacesListForAuthenticatedUser(r = 30, e = 1, n) {
+    return o(i, {
+      method: "GET",
+      url: "/user/codespaces",
+      query: { per_page: r, page: e, repository_id: n },
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        500: "Internal Error",
+      },
+    });
+  }
+  static codespacesCreateForAuthenticatedUser(r) {
+    return o(i, {
+      method: "POST",
+      url: "/user/codespaces",
+      body: r,
+      mediaType: "application/json",
+      errors: {
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static codespacesListSecretsForAuthenticatedUser(r = 30, e = 1) {
+    return o(i, { method: "GET", url: "/user/codespaces/secrets", query: { per_page: r, page: e } });
+  }
+  static codespacesGetPublicKeyForAuthenticatedUser() {
+    return o(i, { method: "GET", url: "/user/codespaces/secrets/public-key" });
+  }
+  static codespacesGetSecretForAuthenticatedUser(r) {
+    return o(i, { method: "GET", url: "/user/codespaces/secrets/{secret_name}", path: { secret_name: r } });
+  }
+  static codespacesCreateOrUpdateSecretForAuthenticatedUser(r, e) {
+    return o(i, {
+      method: "PUT",
+      url: "/user/codespaces/secrets/{secret_name}",
+      path: { secret_name: r },
+      body: e,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static codespacesDeleteSecretForAuthenticatedUser(r) {
+    return o(i, { method: "DELETE", url: "/user/codespaces/secrets/{secret_name}", path: { secret_name: r } });
+  }
+  static codespacesListRepositoriesForSecretForAuthenticatedUser(r) {
+    return o(i, {
+      method: "GET",
+      url: "/user/codespaces/secrets/{secret_name}/repositories",
+      path: { secret_name: r },
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found", 500: "Internal Error" },
+    });
+  }
+  static codespacesSetRepositoriesForSecretForAuthenticatedUser(r, e) {
+    return o(i, {
+      method: "PUT",
+      url: "/user/codespaces/secrets/{secret_name}/repositories",
+      path: { secret_name: r },
+      body: e,
+      mediaType: "application/json",
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found", 500: "Internal Error" },
+    });
+  }
+  static codespacesAddRepositoryForSecretForAuthenticatedUser(r, e) {
+    return o(i, {
+      method: "PUT",
+      url: "/user/codespaces/secrets/{secret_name}/repositories/{repository_id}",
+      path: { secret_name: r, repository_id: e },
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found", 500: "Internal Error" },
+    });
+  }
+  static codespacesRemoveRepositoryForSecretForAuthenticatedUser(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/user/codespaces/secrets/{secret_name}/repositories/{repository_id}",
+      path: { secret_name: r, repository_id: e },
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found", 500: "Internal Error" },
+    });
+  }
+  static codespacesGetForAuthenticatedUser(r) {
+    return o(i, {
+      method: "GET",
+      url: "/user/codespaces/{codespace_name}",
+      path: { codespace_name: r },
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        500: "Internal Error",
+      },
+    });
+  }
+  static codespacesUpdateForAuthenticatedUser(r, e) {
+    return o(i, {
+      method: "PATCH",
+      url: "/user/codespaces/{codespace_name}",
+      path: { codespace_name: r },
+      body: e,
+      mediaType: "application/json",
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static codespacesDeleteForAuthenticatedUser(r) {
+    return o(i, {
+      method: "DELETE",
+      url: "/user/codespaces/{codespace_name}",
+      path: { codespace_name: r },
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        500: "Internal Error",
+      },
+    });
+  }
+  static codespacesExportForAuthenticatedUser(r) {
+    return o(i, {
+      method: "POST",
+      url: "/user/codespaces/{codespace_name}/exports",
+      path: { codespace_name: r },
+      errors: {
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+        500: "Internal Error",
+      },
+    });
+  }
+  static codespacesGetExportDetailsForAuthenticatedUser(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/user/codespaces/{codespace_name}/exports/{export_id}",
+      path: { codespace_name: r, export_id: e },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static codespacesCodespaceMachinesForAuthenticatedUser(r) {
+    return o(i, {
+      method: "GET",
+      url: "/user/codespaces/{codespace_name}/machines",
+      path: { codespace_name: r },
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        500: "Internal Error",
+      },
+    });
+  }
+  static codespacesPublishForAuthenticatedUser(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/user/codespaces/{codespace_name}/publish",
+      path: { codespace_name: r },
+      body: e,
+      mediaType: "application/json",
+      errors: {
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static codespacesStartForAuthenticatedUser(r) {
+    return o(i, {
+      method: "POST",
+      url: "/user/codespaces/{codespace_name}/start",
+      path: { codespace_name: r },
+      errors: {
+        304: "Not modified",
+        400: "Bad Request",
+        401: "Requires authentication",
+        402: "Payment required",
+        403: "Forbidden",
+        404: "Resource not found",
+        409: "Conflict",
+        500: "Internal Error",
+      },
+    });
+  }
+  static codespacesStopForAuthenticatedUser(r) {
+    return o(i, {
+      method: "POST",
+      url: "/user/codespaces/{codespace_name}/stop",
+      path: { codespace_name: r },
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found", 500: "Internal Error" },
+    });
+  }
+};
+var cr = class {
+  static copilotGetCopilotOrganizationDetails(r) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/copilot/billing",
+      path: { org: r },
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found", 500: "Internal Error" },
+    });
+  }
+  static copilotListCopilotSeats(r, e = 1, n = 50) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/copilot/billing/seats",
+      path: { org: r },
+      query: { page: e, per_page: n },
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found", 500: "Internal Error" },
+    });
+  }
+  static copilotAddCopilotForBusinessSeatsForTeams(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/copilot/billing/selected_teams",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+      errors: {
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Copilot for Business is not enabled for this organization, billing has not been set up for this organization, a public code suggestions policy has not been set for this organization, or the organization's Copilot access setting is set to enable Copilot for all users or is unconfigured.",
+        500: "Internal Error",
+      },
+    });
+  }
+  static copilotCancelCopilotSeatAssignmentForTeams(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/copilot/billing/selected_teams",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+      errors: {
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Copilot for Business is not enabled for this organization, billing has not been set up for this organization, a public code suggestions policy has not been set for this organization, or the organization's Copilot access setting is set to enable Copilot for all users or is unconfigured.",
+        500: "Internal Error",
+      },
+    });
+  }
+  static copilotAddCopilotForBusinessSeatsForUsers(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/copilot/billing/selected_users",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+      errors: {
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Copilot for Business is not enabled for this organization, billing has not been set up for this organization, a public code suggestions policy has not been set for this organization, or the organization's Copilot access setting is set to enable Copilot for all users or is unconfigured.",
+        500: "Internal Error",
+      },
+    });
+  }
+  static copilotCancelCopilotSeatAssignmentForUsers(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/copilot/billing/selected_users",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+      errors: {
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Copilot for Business is not enabled for this organization, billing has not been set up for this organization, a public code suggestions policy has not been set for this organization, the seat management setting is set to enable Copilot for all users or is unconfigured, or a user's seat cannot be cancelled because it was assigned to them via a team.",
+        500: "Internal Error",
+      },
+    });
+  }
+  static copilotGetCopilotSeatAssignmentDetailsForUser(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/members/{username}/copilot",
+      path: { org: r, username: e },
+      errors: {
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Copilot for Business is not enabled for this organization or the user has a pending organization invitation.",
+        500: "Internal Error",
+      },
+    });
+  }
+};
+var br = class {
+  static dependabotListAlertsForEnterprise(r, e, n, s, u, _, m = "created", c = "desc", d, v, h = 30, R, k = 30) {
+    return o(i, {
+      method: "GET",
+      url: "/enterprises/{enterprise}/dependabot/alerts",
+      path: { enterprise: r },
+      query: {
+        state: e,
+        severity: n,
+        ecosystem: s,
+        package: u,
+        scope: _,
+        sort: m,
+        direction: c,
+        before: d,
+        after: v,
+        first: h,
+        last: R,
+        per_page: k,
+      },
+      errors: {
+        304: "Not modified",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static dependabotListAlertsForOrg(r, e, n, s, u, _, m = "created", c = "desc", d, v, h = 30, R, k = 30) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/dependabot/alerts",
+      path: { org: r },
+      query: {
+        state: e,
+        severity: n,
+        ecosystem: s,
+        package: u,
+        scope: _,
+        sort: m,
+        direction: c,
+        before: d,
+        after: v,
+        first: h,
+        last: R,
+        per_page: k,
+      },
+      errors: {
+        304: "Not modified",
+        400: "Bad Request",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static dependabotListOrgSecrets(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/dependabot/secrets",
+      path: { org: r },
+      query: { per_page: e, page: n },
+    });
+  }
+  static dependabotGetOrgPublicKey(r) {
+    return o(i, { method: "GET", url: "/orgs/{org}/dependabot/secrets/public-key", path: { org: r } });
+  }
+  static dependabotGetOrgSecret(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/dependabot/secrets/{secret_name}",
+      path: { org: r, secret_name: e },
+    });
+  }
+  static dependabotCreateOrUpdateOrgSecret(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/dependabot/secrets/{secret_name}",
+      path: { org: r, secret_name: e },
+      body: n,
+      mediaType: "application/json",
+    });
+  }
+  static dependabotDeleteOrgSecret(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/dependabot/secrets/{secret_name}",
+      path: { org: r, secret_name: e },
+    });
+  }
+  static dependabotListSelectedReposForOrgSecret(r, e, n = 1, s = 30) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/dependabot/secrets/{secret_name}/repositories",
+      path: { org: r, secret_name: e },
+      query: { page: n, per_page: s },
+    });
+  }
+  static dependabotSetSelectedReposForOrgSecret(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/dependabot/secrets/{secret_name}/repositories",
+      path: { org: r, secret_name: e },
+      body: n,
+      mediaType: "application/json",
+    });
+  }
+  static dependabotAddSelectedRepoToOrgSecret(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id}",
+      path: { org: r, secret_name: e, repository_id: n },
+      errors: { 409: "Conflict when visibility type is not set to selected" },
+    });
+  }
+  static dependabotRemoveSelectedRepoFromOrgSecret(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id}",
+      path: { org: r, secret_name: e, repository_id: n },
+      errors: { 409: "Conflict when visibility type not set to selected" },
+    });
+  }
+  static dependabotListAlertsForRepo(
+    r,
+    e,
+    n,
+    s,
+    u,
+    _,
+    m,
+    c,
+    d = "created",
+    v = "desc",
+    h = 1,
+    R = 30,
+    k,
+    b,
+    p = 30,
+    f,
+  ) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/dependabot/alerts",
+      path: { owner: r, repo: e },
+      query: {
+        state: n,
+        severity: s,
+        ecosystem: u,
+        package: _,
+        manifest: m,
+        scope: c,
+        sort: d,
+        direction: v,
+        page: h,
+        per_page: R,
+        before: k,
+        after: b,
+        first: p,
+        last: f,
+      },
+      errors: {
+        304: "Not modified",
+        400: "Bad Request",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static dependabotGetAlert(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/dependabot/alerts/{alert_number}",
+      path: { owner: r, repo: e, alert_number: n },
+      errors: { 304: "Not modified", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static dependabotUpdateAlert(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/dependabot/alerts/{alert_number}",
+      path: { owner: r, repo: e, alert_number: n },
+      body: s,
+      mediaType: "application/json",
+      errors: {
+        400: "Bad Request",
+        403: "Forbidden",
+        404: "Resource not found",
+        409: "Conflict",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static dependabotListRepoSecrets(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/dependabot/secrets",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+    });
+  }
+  static dependabotGetRepoPublicKey(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/dependabot/secrets/public-key",
+      path: { owner: r, repo: e },
+    });
+  }
+  static dependabotGetRepoSecret(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/dependabot/secrets/{secret_name}",
+      path: { owner: r, repo: e, secret_name: n },
+    });
+  }
+  static dependabotCreateOrUpdateRepoSecret(r, e, n, s) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/dependabot/secrets/{secret_name}",
+      path: { owner: r, repo: e, secret_name: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static dependabotDeleteRepoSecret(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/dependabot/secrets/{secret_name}",
+      path: { owner: r, repo: e, secret_name: n },
+    });
+  }
+};
+var hr = class {
+  static dependencyGraphDiffRange(r, e, n, s) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/dependency-graph/compare/{basehead}",
+      path: { owner: r, repo: e, basehead: n },
+      query: { name: s },
+      errors: {
+        403: "Response if GitHub Advanced Security is not enabled for this repository",
+        404: "Resource not found",
+      },
+    });
+  }
+  static dependencyGraphExportSbom(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/dependency-graph/sbom",
+      path: { owner: r, repo: e },
+      errors: { 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static dependencyGraphCreateRepositorySnapshot(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/dependency-graph/snapshots",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+    });
+  }
+};
+var yr = class {
+  static emojisGet() {
+    return o(i, { method: "GET", url: "/emojis", errors: { 304: "Not modified" } });
+  }
+};
+var fr = class {
+  static gistsList(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/gists",
+      query: { since: r, per_page: e, page: n },
+      errors: { 304: "Not modified", 403: "Forbidden" },
+    });
+  }
+  static gistsCreate(r) {
+    return o(i, {
+      method: "POST",
+      url: "/gists",
+      body: r,
+      mediaType: "application/json",
+      errors: {
+        304: "Not modified",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static gistsListPublic(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/gists/public",
+      query: { since: r, per_page: e, page: n },
+      errors: { 304: "Not modified", 403: "Forbidden", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static gistsListStarred(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/gists/starred",
+      query: { since: r, per_page: e, page: n },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden" },
+    });
+  }
+  static gistsGet(r) {
+    return o(i, {
+      method: "GET",
+      url: "/gists/{gist_id}",
+      path: { gist_id: r },
+      errors: { 304: "Not modified", 403: "Forbidden Gist", 404: "Resource not found" },
+    });
+  }
+  static gistsUpdate(r, e) {
+    return o(i, {
+      method: "PATCH",
+      url: "/gists/{gist_id}",
+      path: { gist_id: r },
+      body: e,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static gistsDelete(r) {
+    return o(i, {
+      method: "DELETE",
+      url: "/gists/{gist_id}",
+      path: { gist_id: r },
+      errors: { 304: "Not modified", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static gistsListComments(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/gists/{gist_id}/comments",
+      path: { gist_id: r },
+      query: { per_page: e, page: n },
+      errors: { 304: "Not modified", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static gistsCreateComment(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/gists/{gist_id}/comments",
+      path: { gist_id: r },
+      body: e,
+      mediaType: "application/json",
+      errors: { 304: "Not modified", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static gistsGetComment(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/gists/{gist_id}/comments/{comment_id}",
+      path: { gist_id: r, comment_id: e },
+      errors: { 304: "Not modified", 403: "Forbidden Gist", 404: "Resource not found" },
+    });
+  }
+  static gistsUpdateComment(r, e, n) {
+    return o(i, {
+      method: "PATCH",
+      url: "/gists/{gist_id}/comments/{comment_id}",
+      path: { gist_id: r, comment_id: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static gistsDeleteComment(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/gists/{gist_id}/comments/{comment_id}",
+      path: { gist_id: r, comment_id: e },
+      errors: { 304: "Not modified", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static gistsListCommits(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/gists/{gist_id}/commits",
+      path: { gist_id: r },
+      query: { per_page: e, page: n },
+      errors: { 304: "Not modified", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static gistsListForks(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/gists/{gist_id}/forks",
+      path: { gist_id: r },
+      query: { per_page: e, page: n },
+      errors: { 304: "Not modified", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static gistsFork(r) {
+    return o(i, {
+      method: "POST",
+      url: "/gists/{gist_id}/forks",
+      path: { gist_id: r },
+      errors: {
+        304: "Not modified",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static gistsCheckIsStarred(r) {
+    return o(i, {
+      method: "GET",
+      url: "/gists/{gist_id}/star",
+      path: { gist_id: r },
+      errors: { 304: "Not modified", 403: "Forbidden", 404: "Not Found if gist is not starred" },
+    });
+  }
+  static gistsStar(r) {
+    return o(i, {
+      method: "PUT",
+      url: "/gists/{gist_id}/star",
+      path: { gist_id: r },
+      errors: { 304: "Not modified", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static gistsUnstar(r) {
+    return o(i, {
+      method: "DELETE",
+      url: "/gists/{gist_id}/star",
+      path: { gist_id: r },
+      errors: { 304: "Not modified", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static gistsGetRevision(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/gists/{gist_id}/{sha}",
+      path: { gist_id: r, sha: e },
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static gistsListForUser(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}/gists",
+      path: { username: r },
+      query: { since: e, per_page: n, page: s },
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+};
+var wr = class {
+  static gitCreateBlob(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/git/blobs",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        409: "Conflict",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static gitGetBlob(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/git/blobs/{file_sha}",
+      path: { owner: r, repo: e, file_sha: n },
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static gitCreateCommit(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/git/commits",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static gitGetCommit(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/git/commits/{commit_sha}",
+      path: { owner: r, repo: e, commit_sha: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static gitListMatchingRefs(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/git/matching-refs/{ref}",
+      path: { owner: r, repo: e, ref: n },
+    });
+  }
+  static gitGetRef(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/git/ref/{ref}",
+      path: { owner: r, repo: e, ref: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static gitCreateRef(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/git/refs",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static gitUpdateRef(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/git/refs/{ref}",
+      path: { owner: r, repo: e, ref: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static gitDeleteRef(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/git/refs/{ref}",
+      path: { owner: r, repo: e, ref: n },
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static gitCreateTag(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/git/tags",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static gitGetTag(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/git/tags/{tag_sha}",
+      path: { owner: r, repo: e, tag_sha: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static gitCreateTree(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/git/trees",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static gitGetTree(r, e, n, s) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/git/trees/{tree_sha}",
+      path: { owner: r, repo: e, tree_sha: n },
+      query: { recursive: s },
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+};
+var Er = class {
+  static gitignoreGetAllTemplates() {
+    return o(i, { method: "GET", url: "/gitignore/templates", errors: { 304: "Not modified" } });
+  }
+  static gitignoreGetTemplate(r) {
+    return o(i, {
+      method: "GET",
+      url: "/gitignore/templates/{name}",
+      path: { name: r },
+      errors: { 304: "Not modified" },
+    });
+  }
+};
+var vr = class {
+  static interactionsGetRestrictionsForOrg(r) {
+    return o(i, { method: "GET", url: "/orgs/{org}/interaction-limits", path: { org: r } });
+  }
+  static interactionsSetRestrictionsForOrg(r, e) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/interaction-limits",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static interactionsRemoveRestrictionsForOrg(r) {
+    return o(i, { method: "DELETE", url: "/orgs/{org}/interaction-limits", path: { org: r } });
+  }
+  static interactionsGetRestrictionsForRepo(r, e) {
+    return o(i, { method: "GET", url: "/repos/{owner}/{repo}/interaction-limits", path: { owner: r, repo: e } });
+  }
+  static interactionsSetRestrictionsForRepo(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/interaction-limits",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 409: "Response" },
+    });
+  }
+  static interactionsRemoveRestrictionsForRepo(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/interaction-limits",
+      path: { owner: r, repo: e },
+      errors: { 409: "Response" },
+    });
+  }
+  static interactionsGetRestrictionsForAuthenticatedUser() {
+    return o(i, { method: "GET", url: "/user/interaction-limits" });
+  }
+  static interactionsSetRestrictionsForAuthenticatedUser(r) {
+    return o(i, {
+      method: "PUT",
+      url: "/user/interaction-limits",
+      body: r,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static interactionsRemoveRestrictionsForAuthenticatedUser() {
+    return o(i, { method: "DELETE", url: "/user/interaction-limits" });
+  }
+};
+var Rr = class {
+  static issuesList(r = "assigned", e = "open", n, s = "created", u = "desc", _, m, c, d, v, h = 30, R = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/issues",
+      query: {
+        filter: r,
+        state: e,
+        labels: n,
+        sort: s,
+        direction: u,
+        since: _,
+        collab: m,
+        orgs: c,
+        owned: d,
+        pulls: v,
+        per_page: h,
+        page: R,
+      },
+      errors: {
+        304: "Not modified",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static issuesListForOrg(r, e = "assigned", n = "open", s, u = "created", _ = "desc", m, c = 30, d = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/issues",
+      path: { org: r },
+      query: { filter: e, state: n, labels: s, sort: u, direction: _, since: m, per_page: c, page: d },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static issuesListAssignees(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/assignees",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static issuesCheckUserCanBeAssigned(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/assignees/{assignee}",
+      path: { owner: r, repo: e, assignee: n },
+      errors: { 404: "Otherwise a `404` status code is returned." },
+    });
+  }
+  static issuesListForRepo(r, e, n, s = "open", u, _, m, c, d = "created", v = "desc", h, R = 30, k = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/issues",
+      path: { owner: r, repo: e },
+      query: {
+        milestone: n,
+        state: s,
+        assignee: u,
+        creator: _,
+        mentioned: m,
+        labels: c,
+        sort: d,
+        direction: v,
+        since: h,
+        per_page: R,
+        page: k,
+      },
+      errors: {
+        301: "Moved permanently",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static issuesCreate(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/issues",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        400: "Bad Request",
+        403: "Forbidden",
+        404: "Resource not found",
+        410: "Gone",
+        422: "Validation failed, or the endpoint has been spammed.",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static issuesListCommentsForRepo(r, e, n = "created", s, u, _ = 30, m = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/issues/comments",
+      path: { owner: r, repo: e },
+      query: { sort: n, direction: s, since: u, per_page: _, page: m },
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static issuesGetComment(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/issues/comments/{comment_id}",
+      path: { owner: r, repo: e, comment_id: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static issuesUpdateComment(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/issues/comments/{comment_id}",
+      path: { owner: r, repo: e, comment_id: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static issuesDeleteComment(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/issues/comments/{comment_id}",
+      path: { owner: r, repo: e, comment_id: n },
+    });
+  }
+  static issuesListEventsForRepo(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/issues/events",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static issuesGetEvent(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/issues/events/{event_id}",
+      path: { owner: r, repo: e, event_id: n },
+      errors: { 403: "Forbidden", 404: "Resource not found", 410: "Gone" },
+    });
+  }
+  static issuesGet(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/issues/{issue_number}",
+      path: { owner: r, repo: e, issue_number: n },
+      errors: { 301: "Moved permanently", 304: "Not modified", 404: "Resource not found", 410: "Gone" },
+    });
+  }
+  static issuesUpdate(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/issues/{issue_number}",
+      path: { owner: r, repo: e, issue_number: n },
+      body: s,
+      mediaType: "application/json",
+      errors: {
+        301: "Moved permanently",
+        403: "Forbidden",
+        404: "Resource not found",
+        410: "Gone",
+        422: "Validation failed, or the endpoint has been spammed.",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static issuesAddAssignees(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/issues/{issue_number}/assignees",
+      path: { owner: r, repo: e, issue_number: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static issuesRemoveAssignees(r, e, n, s) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/issues/{issue_number}/assignees",
+      path: { owner: r, repo: e, issue_number: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static issuesCheckUserCanBeAssignedToIssue(r, e, n, s) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/issues/{issue_number}/assignees/{assignee}",
+      path: { owner: r, repo: e, issue_number: n, assignee: s },
+      errors: { 404: "Response if `assignee` can not be assigned to `issue_number`" },
+    });
+  }
+  static issuesListComments(r, e, n, s, u = 30, _ = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/issues/{issue_number}/comments",
+      path: { owner: r, repo: e, issue_number: n },
+      query: { since: s, per_page: u, page: _ },
+      errors: { 404: "Resource not found", 410: "Gone" },
+    });
+  }
+  static issuesCreateComment(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/issues/{issue_number}/comments",
+      path: { owner: r, repo: e, issue_number: n },
+      body: s,
+      mediaType: "application/json",
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        410: "Gone",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static issuesListEvents(r, e, n, s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/issues/{issue_number}/events",
+      path: { owner: r, repo: e, issue_number: n },
+      query: { per_page: s, page: u },
+      errors: { 410: "Gone" },
+    });
+  }
+  static issuesListLabelsOnIssue(r, e, n, s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/issues/{issue_number}/labels",
+      path: { owner: r, repo: e, issue_number: n },
+      query: { per_page: s, page: u },
+      errors: { 301: "Moved permanently", 404: "Resource not found", 410: "Gone" },
+    });
+  }
+  static issuesAddLabels(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/issues/{issue_number}/labels",
+      path: { owner: r, repo: e, issue_number: n },
+      body: s,
+      mediaType: "application/json",
+      errors: {
+        301: "Moved permanently",
+        404: "Resource not found",
+        410: "Gone",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static issuesSetLabels(r, e, n, s) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/issues/{issue_number}/labels",
+      path: { owner: r, repo: e, issue_number: n },
+      body: s,
+      mediaType: "application/json",
+      errors: {
+        301: "Moved permanently",
+        404: "Resource not found",
+        410: "Gone",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static issuesRemoveAllLabels(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/issues/{issue_number}/labels",
+      path: { owner: r, repo: e, issue_number: n },
+      errors: { 301: "Moved permanently", 404: "Resource not found", 410: "Gone" },
+    });
+  }
+  static issuesRemoveLabel(r, e, n, s) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/issues/{issue_number}/labels/{name}",
+      path: { owner: r, repo: e, issue_number: n, name: s },
+      errors: { 301: "Moved permanently", 404: "Resource not found", 410: "Gone" },
+    });
+  }
+  static issuesLock(r, e, n, s) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/issues/{issue_number}/lock",
+      path: { owner: r, repo: e, issue_number: n },
+      body: s,
+      mediaType: "application/json",
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        410: "Gone",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static issuesUnlock(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/issues/{issue_number}/lock",
+      path: { owner: r, repo: e, issue_number: n },
+      errors: { 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static issuesListEventsForTimeline(r, e, n, s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/issues/{issue_number}/timeline",
+      path: { owner: r, repo: e, issue_number: n },
+      query: { per_page: s, page: u },
+      errors: { 404: "Resource not found", 410: "Gone" },
+    });
+  }
+  static issuesListLabelsForRepo(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/labels",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static issuesCreateLabel(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/labels",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static issuesGetLabel(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/labels/{name}",
+      path: { owner: r, repo: e, name: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static issuesUpdateLabel(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/labels/{name}",
+      path: { owner: r, repo: e, name: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static issuesDeleteLabel(r, e, n) {
+    return o(i, { method: "DELETE", url: "/repos/{owner}/{repo}/labels/{name}", path: { owner: r, repo: e, name: n } });
+  }
+  static issuesListMilestones(r, e, n = "open", s = "due_on", u = "asc", _ = 30, m = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/milestones",
+      path: { owner: r, repo: e },
+      query: { state: n, sort: s, direction: u, per_page: _, page: m },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static issuesCreateMilestone(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/milestones",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static issuesGetMilestone(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/milestones/{milestone_number}",
+      path: { owner: r, repo: e, milestone_number: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static issuesUpdateMilestone(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/milestones/{milestone_number}",
+      path: { owner: r, repo: e, milestone_number: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static issuesDeleteMilestone(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/milestones/{milestone_number}",
+      path: { owner: r, repo: e, milestone_number: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static issuesListLabelsForMilestone(r, e, n, s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/milestones/{milestone_number}/labels",
+      path: { owner: r, repo: e, milestone_number: n },
+      query: { per_page: s, page: u },
+    });
+  }
+  static issuesListForAuthenticatedUser(r = "assigned", e = "open", n, s = "created", u = "desc", _, m = 30, c = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/user/issues",
+      query: { filter: r, state: e, labels: n, sort: s, direction: u, since: _, per_page: m, page: c },
+      errors: { 304: "Not modified", 404: "Resource not found" },
+    });
+  }
+};
+var Tr = class {
+  static licensesGetAllCommonlyUsed(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/licenses",
+      query: { featured: r, per_page: e, page: n },
+      errors: { 304: "Not modified" },
+    });
+  }
+  static licensesGet(r) {
+    return o(i, {
+      method: "GET",
+      url: "/licenses/{license}",
+      path: { license: r },
+      errors: { 304: "Not modified", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static licensesGetForRepo(r, e) {
+    return o(i, { method: "GET", url: "/repos/{owner}/{repo}/license", path: { owner: r, repo: e } });
+  }
+};
+var Ar = class {
+  static markdownRender(r) {
+    return o(i, {
+      method: "POST",
+      url: "/markdown",
+      body: r,
+      mediaType: "application/json",
+      errors: { 304: "Not modified" },
+    });
+  }
+  static markdownRenderRaw(r) {
+    return o(i, {
+      method: "POST",
+      url: "/markdown/raw",
+      body: r,
+      mediaType: "text/plain",
+      errors: { 304: "Not modified" },
+    });
+  }
+};
+var kr = class {
+  static metaRoot() {
+    return o(i, { method: "GET", url: "/" });
+  }
+  static metaGet() {
+    return o(i, { method: "GET", url: "/meta", errors: { 304: "Not modified" } });
+  }
+  static metaGetOctocat(r) {
+    return o(i, { method: "GET", url: "/octocat", query: { s: r } });
+  }
+  static metaGetAllVersions() {
+    return o(i, { method: "GET", url: "/versions", errors: { 404: "Resource not found" } });
+  }
+  static metaGetZen() {
+    return o(i, { method: "GET", url: "/zen" });
+  }
+};
+var xr = class {
+  static migrationsListForOrg(r, e = 30, n = 1, s) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/migrations",
+      path: { org: r },
+      query: { per_page: e, page: n, exclude: s },
+    });
+  }
+  static migrationsStartForOrg(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/migrations",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static migrationsGetStatusForOrg(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/migrations/{migration_id}",
+      path: { org: r, migration_id: e },
+      query: { exclude: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static migrationsDownloadArchiveForOrg(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/migrations/{migration_id}/archive",
+      path: { org: r, migration_id: e },
+      errors: { 302: "Response", 404: "Resource not found" },
+    });
+  }
+  static migrationsDeleteArchiveForOrg(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/migrations/{migration_id}/archive",
+      path: { org: r, migration_id: e },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static migrationsUnlockRepoForOrg(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/migrations/{migration_id}/repos/{repo_name}/lock",
+      path: { org: r, migration_id: e, repo_name: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static migrationsListReposForOrg(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/migrations/{migration_id}/repositories",
+      path: { org: r, migration_id: e },
+      query: { per_page: n, page: s },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static migrationsGetImportStatus(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/import",
+      path: { owner: r, repo: e },
+      errors: { 404: "Resource not found", 503: "Unavailable due to service under maintenance." },
+    });
+  }
+  static migrationsStartImport(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/import",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+        503: "Unavailable due to service under maintenance.",
+      },
+    });
+  }
+  static migrationsUpdateImport(r, e, n) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/import",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 503: "Unavailable due to service under maintenance." },
+    });
+  }
+  static migrationsCancelImport(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/import",
+      path: { owner: r, repo: e },
+      errors: { 503: "Unavailable due to service under maintenance." },
+    });
+  }
+  static migrationsGetCommitAuthors(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/import/authors",
+      path: { owner: r, repo: e },
+      query: { since: n },
+      errors: { 404: "Resource not found", 503: "Unavailable due to service under maintenance." },
+    });
+  }
+  static migrationsMapCommitAuthor(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/import/authors/{author_id}",
+      path: { owner: r, repo: e, author_id: n },
+      body: s,
+      mediaType: "application/json",
+      errors: {
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+        503: "Unavailable due to service under maintenance.",
+      },
+    });
+  }
+  static migrationsGetLargeFiles(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/import/large_files",
+      path: { owner: r, repo: e },
+      errors: { 503: "Unavailable due to service under maintenance." },
+    });
+  }
+  static migrationsSetLfsPreference(r, e, n) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/import/lfs",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        422: "Validation failed, or the endpoint has been spammed.",
+        503: "Unavailable due to service under maintenance.",
+      },
+    });
+  }
+  static migrationsListForAuthenticatedUser(r = 30, e = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/user/migrations",
+      query: { per_page: r, page: e },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden" },
+    });
+  }
+  static migrationsStartForAuthenticatedUser(r) {
+    return o(i, {
+      method: "POST",
+      url: "/user/migrations",
+      body: r,
+      mediaType: "application/json",
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static migrationsGetStatusForAuthenticatedUser(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/user/migrations/{migration_id}",
+      path: { migration_id: r },
+      query: { exclude: e },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static migrationsGetArchiveForAuthenticatedUser(r) {
+    return o(i, {
+      method: "GET",
+      url: "/user/migrations/{migration_id}/archive",
+      path: { migration_id: r },
+      errors: { 302: "Response", 304: "Not modified", 401: "Requires authentication", 403: "Forbidden" },
+    });
+  }
+  static migrationsDeleteArchiveForAuthenticatedUser(r) {
+    return o(i, {
+      method: "DELETE",
+      url: "/user/migrations/{migration_id}/archive",
+      path: { migration_id: r },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static migrationsUnlockRepoForAuthenticatedUser(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/user/migrations/{migration_id}/repos/{repo_name}/lock",
+      path: { migration_id: r, repo_name: e },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static migrationsListReposForAuthenticatedUser(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/user/migrations/{migration_id}/repositories",
+      path: { migration_id: r },
+      query: { per_page: e, page: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+};
+var Ir = class {
+  static oidcGetOidcCustomSubTemplateForOrg(r) {
+    return o(i, { method: "GET", url: "/orgs/{org}/actions/oidc/customization/sub", path: { org: r } });
+  }
+  static oidcUpdateOidcCustomSubTemplateForOrg(r, e) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/actions/oidc/customization/sub",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+      errors: { 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+};
+var Or = class {
+  static orgsList(r, e = 30) {
+    return o(i, {
+      method: "GET",
+      url: "/organizations",
+      query: { since: r, per_page: e },
+      errors: { 304: "Not modified" },
+    });
+  }
+  static orgsGet(r) {
+    return o(i, { method: "GET", url: "/orgs/{org}", path: { org: r }, errors: { 404: "Resource not found" } });
+  }
+  static orgsUpdate(r, e) {
+    return o(i, {
+      method: "PATCH",
+      url: "/orgs/{org}",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+      errors: { 409: "Conflict", 422: "Validation failed" },
+    });
+  }
+  static orgsDelete(r) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}",
+      path: { org: r },
+      errors: { 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static orgsListBlockedUsers(r, e = 30, n = 1) {
+    return o(i, { method: "GET", url: "/orgs/{org}/blocks", path: { org: r }, query: { per_page: e, page: n } });
+  }
+  static orgsCheckBlockedUser(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/blocks/{username}",
+      path: { org: r, username: e },
+      errors: { 404: "If the user is not blocked" },
+    });
+  }
+  static orgsBlockUser(r, e) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/blocks/{username}",
+      path: { org: r, username: e },
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static orgsUnblockUser(r, e) {
+    return o(i, { method: "DELETE", url: "/orgs/{org}/blocks/{username}", path: { org: r, username: e } });
+  }
+  static orgsListFailedInvitations(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/failed_invitations",
+      path: { org: r },
+      query: { per_page: e, page: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static orgsListWebhooks(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/hooks",
+      path: { org: r },
+      query: { per_page: e, page: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static orgsCreateWebhook(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/hooks",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static orgsGetWebhook(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/hooks/{hook_id}",
+      path: { org: r, hook_id: e },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static orgsUpdateWebhook(r, e, n) {
+    return o(i, {
+      method: "PATCH",
+      url: "/orgs/{org}/hooks/{hook_id}",
+      path: { org: r, hook_id: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static orgsDeleteWebhook(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/hooks/{hook_id}",
+      path: { org: r, hook_id: e },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static orgsGetWebhookConfigForOrg(r, e) {
+    return o(i, { method: "GET", url: "/orgs/{org}/hooks/{hook_id}/config", path: { org: r, hook_id: e } });
+  }
+  static orgsUpdateWebhookConfigForOrg(r, e, n) {
+    return o(i, {
+      method: "PATCH",
+      url: "/orgs/{org}/hooks/{hook_id}/config",
+      path: { org: r, hook_id: e },
+      body: n,
+      mediaType: "application/json",
+    });
+  }
+  static orgsListWebhookDeliveries(r, e, n = 30, s, u) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/hooks/{hook_id}/deliveries",
+      path: { org: r, hook_id: e },
+      query: { per_page: n, cursor: s, redelivery: u },
+      errors: { 400: "Bad Request", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static orgsGetWebhookDelivery(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/hooks/{hook_id}/deliveries/{delivery_id}",
+      path: { org: r, hook_id: e, delivery_id: n },
+      errors: { 400: "Bad Request", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static orgsRedeliverWebhookDelivery(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/hooks/{hook_id}/deliveries/{delivery_id}/attempts",
+      path: { org: r, hook_id: e, delivery_id: n },
+      errors: { 400: "Bad Request", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static orgsPingWebhook(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/hooks/{hook_id}/pings",
+      path: { org: r, hook_id: e },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static orgsListAppInstallations(r, e = 30, n = 1) {
+    return o(i, { method: "GET", url: "/orgs/{org}/installations", path: { org: r }, query: { per_page: e, page: n } });
+  }
+  static orgsListPendingInvitations(r, e = 30, n = 1, s = "all", u = "all") {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/invitations",
+      path: { org: r },
+      query: { per_page: e, page: n, role: s, invitation_source: u },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static orgsCreateInvitation(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/invitations",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static orgsCancelInvitation(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/invitations/{invitation_id}",
+      path: { org: r, invitation_id: e },
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static orgsListInvitationTeams(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/invitations/{invitation_id}/teams",
+      path: { org: r, invitation_id: e },
+      query: { per_page: n, page: s },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static orgsListMembers(r, e = "all", n = "all", s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/members",
+      path: { org: r },
+      query: { filter: e, role: n, per_page: s, page: u },
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static orgsCheckMembershipForUser(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/members/{username}",
+      path: { org: r, username: e },
+      errors: {
+        302: "Response if requester is not an organization member",
+        404: "Not Found if requester is an organization member and user is not a member",
+      },
+    });
+  }
+  static orgsRemoveMember(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/members/{username}",
+      path: { org: r, username: e },
+      errors: { 403: "Forbidden" },
+    });
+  }
+  static orgsGetMembershipForUser(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/memberships/{username}",
+      path: { org: r, username: e },
+      errors: { 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static orgsSetMembershipForUser(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/memberships/{username}",
+      path: { org: r, username: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 403: "Forbidden", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static orgsRemoveMembershipForUser(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/memberships/{username}",
+      path: { org: r, username: e },
+      errors: { 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static orgsListOutsideCollaborators(r, e = "all", n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/outside_collaborators",
+      path: { org: r },
+      query: { filter: e, per_page: n, page: s },
+    });
+  }
+  static orgsConvertMemberToOutsideCollaborator(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/outside_collaborators/{username}",
+      path: { org: r, username: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        403: 'Forbidden if user is the last owner of the organization, not a member of the organization, or if the enterprise enforces a policy for inviting outside collaborators. For more information, see "[Enforcing repository management policies in your enterprise](https://docs.github.com/admin/policies/enforcing-policies-for-your-enterprise/enforcing-repository-management-policies-in-your-enterprise#enforcing-a-policy-for-inviting-outside-collaborators-to-repositories)."',
+        404: "Resource not found",
+      },
+    });
+  }
+  static orgsRemoveOutsideCollaborator(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/outside_collaborators/{username}",
+      path: { org: r, username: e },
+      errors: { 422: "Unprocessable Entity if user is a member of the organization" },
+    });
+  }
+  static orgsListPatGrantRequests(r, e = 30, n = 1, s = "created_at", u = "desc", _, m, c, d, v) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/personal-access-token-requests",
+      path: { org: r },
+      query: {
+        per_page: e,
+        page: n,
+        sort: s,
+        direction: u,
+        owner: _,
+        repository: m,
+        permission: c,
+        last_used_before: d,
+        last_used_after: v,
+      },
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+        500: "Internal Error",
+      },
+    });
+  }
+  static orgsReviewPatGrantRequestsInBulk(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/personal-access-token-requests",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+        500: "Internal Error",
+      },
+    });
+  }
+  static orgsReviewPatGrantRequest(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/personal-access-token-requests/{pat_request_id}",
+      path: { org: r, pat_request_id: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+        500: "Internal Error",
+      },
+    });
+  }
+  static orgsListPatGrantRequestRepositories(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/personal-access-token-requests/{pat_request_id}/repositories",
+      path: { org: r, pat_request_id: e },
+      query: { per_page: n, page: s },
+      errors: { 403: "Forbidden", 404: "Resource not found", 500: "Internal Error" },
+    });
+  }
+  static orgsListPatGrants(r, e = 30, n = 1, s = "created_at", u = "desc", _, m, c, d, v) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/personal-access-tokens",
+      path: { org: r },
+      query: {
+        per_page: e,
+        page: n,
+        sort: s,
+        direction: u,
+        owner: _,
+        repository: m,
+        permission: c,
+        last_used_before: d,
+        last_used_after: v,
+      },
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+        500: "Internal Error",
+      },
+    });
+  }
+  static orgsUpdatePatAccesses(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/personal-access-tokens",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+        500: "Internal Error",
+      },
+    });
+  }
+  static orgsUpdatePatAccess(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/personal-access-tokens/{pat_id}",
+      path: { org: r, pat_id: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+        500: "Internal Error",
+      },
+    });
+  }
+  static orgsListPatGrantRepositories(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/personal-access-tokens/{pat_id}/repositories",
+      path: { org: r, pat_id: e },
+      query: { per_page: n, page: s },
+      errors: { 403: "Forbidden", 404: "Resource not found", 500: "Internal Error" },
+    });
+  }
+  static orgsListPublicMembers(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/public_members",
+      path: { org: r },
+      query: { per_page: e, page: n },
+    });
+  }
+  static orgsCheckPublicMembershipForUser(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/public_members/{username}",
+      path: { org: r, username: e },
+      errors: { 404: "Not Found if user is not a public member" },
+    });
+  }
+  static orgsSetPublicMembershipForAuthenticatedUser(r, e) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/public_members/{username}",
+      path: { org: r, username: e },
+      errors: { 403: "Forbidden" },
+    });
+  }
+  static orgsRemovePublicMembershipForAuthenticatedUser(r, e) {
+    return o(i, { method: "DELETE", url: "/orgs/{org}/public_members/{username}", path: { org: r, username: e } });
+  }
+  static orgsListSecurityManagerTeams(r) {
+    return o(i, { method: "GET", url: "/orgs/{org}/security-managers", path: { org: r } });
+  }
+  static orgsAddSecurityManagerTeam(r, e) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/security-managers/teams/{team_slug}",
+      path: { org: r, team_slug: e },
+      errors: { 409: "The organization has reached the maximum number of security manager teams." },
+    });
+  }
+  static orgsRemoveSecurityManagerTeam(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/security-managers/teams/{team_slug}",
+      path: { org: r, team_slug: e },
+    });
+  }
+  static orgsEnableOrDisableSecurityProductOnAllOrgRepos(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/{security_product}/{enablement}",
+      path: { org: r, security_product: e, enablement: n },
+      body: s,
+      mediaType: "application/json",
+      errors: {
+        422: "The action could not be taken due to an in progress enablement, or a policy is preventing enablement",
+      },
+    });
+  }
+  static orgsListMembershipsForAuthenticatedUser(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/user/memberships/orgs",
+      query: { state: r, per_page: e, page: n },
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static orgsGetMembershipForAuthenticatedUser(r) {
+    return o(i, {
+      method: "GET",
+      url: "/user/memberships/orgs/{org}",
+      path: { org: r },
+      errors: { 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static orgsUpdateMembershipForAuthenticatedUser(r, e) {
+    return o(i, {
+      method: "PATCH",
+      url: "/user/memberships/orgs/{org}",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static orgsListForAuthenticatedUser(r = 30, e = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/user/orgs",
+      query: { per_page: r, page: e },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden" },
+    });
+  }
+  static orgsListForUser(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}/orgs",
+      path: { username: r },
+      query: { per_page: e, page: n },
+    });
+  }
+};
+var Nr = class {
+  static packagesListDockerMigrationConflictingPackagesForOrganization(r) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/docker/conflicts",
+      path: { org: r },
+      errors: { 401: "Requires authentication", 403: "Forbidden" },
+    });
+  }
+  static packagesListPackagesForOrganization(r, e, n, s = 1, u = 30) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/packages",
+      path: { org: e },
+      query: { package_type: r, visibility: n, page: s, per_page: u },
+      errors: {
+        400: "The value of `per_page` multiplied by `page` cannot be greater than 10000.",
+        401: "Requires authentication",
+        403: "Forbidden",
+      },
+    });
+  }
+  static packagesGetPackageForOrganization(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/packages/{package_type}/{package_name}",
+      path: { package_type: r, package_name: e, org: n },
+    });
+  }
+  static packagesDeletePackageForOrg(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/packages/{package_type}/{package_name}",
+      path: { package_type: r, package_name: e, org: n },
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static packagesRestorePackageForOrg(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/packages/{package_type}/{package_name}/restore",
+      path: { package_type: r, package_name: e, org: n },
+      query: { token: s },
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static packagesGetAllPackageVersionsForPackageOwnedByOrg(r, e, n, s = 1, u = 30, _ = "active") {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/packages/{package_type}/{package_name}/versions",
+      path: { package_type: r, package_name: e, org: n },
+      query: { page: s, per_page: u, state: _ },
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static packagesGetPackageVersionForOrganization(r, e, n, s) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}",
+      path: { package_type: r, package_name: e, org: n, package_version_id: s },
+    });
+  }
+  static packagesDeletePackageVersionForOrg(r, e, n, s) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}",
+      path: { package_type: r, package_name: e, org: n, package_version_id: s },
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static packagesRestorePackageVersionForOrg(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}/restore",
+      path: { package_type: r, package_name: e, org: n, package_version_id: s },
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static packagesListDockerMigrationConflictingPackagesForAuthenticatedUser() {
+    return o(i, { method: "GET", url: "/user/docker/conflicts" });
+  }
+  static packagesListPackagesForAuthenticatedUser(r, e, n = 1, s = 30) {
+    return o(i, {
+      method: "GET",
+      url: "/user/packages",
+      query: { package_type: r, visibility: e, page: n, per_page: s },
+      errors: { 400: "The value of `per_page` multiplied by `page` cannot be greater than 10000." },
+    });
+  }
+  static packagesGetPackageForAuthenticatedUser(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/user/packages/{package_type}/{package_name}",
+      path: { package_type: r, package_name: e },
+    });
+  }
+  static packagesDeletePackageForAuthenticatedUser(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/user/packages/{package_type}/{package_name}",
+      path: { package_type: r, package_name: e },
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static packagesRestorePackageForAuthenticatedUser(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/user/packages/{package_type}/{package_name}/restore",
+      path: { package_type: r, package_name: e },
+      query: { token: n },
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static packagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUser(r, e, n = 1, s = 30, u = "active") {
+    return o(i, {
+      method: "GET",
+      url: "/user/packages/{package_type}/{package_name}/versions",
+      path: { package_type: r, package_name: e },
+      query: { page: n, per_page: s, state: u },
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static packagesGetPackageVersionForAuthenticatedUser(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/user/packages/{package_type}/{package_name}/versions/{package_version_id}",
+      path: { package_type: r, package_name: e, package_version_id: n },
+    });
+  }
+  static packagesDeletePackageVersionForAuthenticatedUser(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/user/packages/{package_type}/{package_name}/versions/{package_version_id}",
+      path: { package_type: r, package_name: e, package_version_id: n },
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static packagesRestorePackageVersionForAuthenticatedUser(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/user/packages/{package_type}/{package_name}/versions/{package_version_id}/restore",
+      path: { package_type: r, package_name: e, package_version_id: n },
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static packagesListDockerMigrationConflictingPackagesForUser(r) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}/docker/conflicts",
+      path: { username: r },
+      errors: { 401: "Requires authentication", 403: "Forbidden" },
+    });
+  }
+  static packagesListPackagesForUser(r, e, n, s = 1, u = 30) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}/packages",
+      path: { username: e },
+      query: { package_type: r, visibility: n, page: s, per_page: u },
+      errors: {
+        400: "The value of `per_page` multiplied by `page` cannot be greater than 10000.",
+        401: "Requires authentication",
+        403: "Forbidden",
+      },
+    });
+  }
+  static packagesGetPackageForUser(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}/packages/{package_type}/{package_name}",
+      path: { package_type: r, package_name: e, username: n },
+    });
+  }
+  static packagesDeletePackageForUser(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/users/{username}/packages/{package_type}/{package_name}",
+      path: { package_type: r, package_name: e, username: n },
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static packagesRestorePackageForUser(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/users/{username}/packages/{package_type}/{package_name}/restore",
+      path: { package_type: r, package_name: e, username: n },
+      query: { token: s },
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static packagesGetAllPackageVersionsForPackageOwnedByUser(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}/packages/{package_type}/{package_name}/versions",
+      path: { package_type: r, package_name: e, username: n },
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static packagesGetPackageVersionForUser(r, e, n, s) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}/packages/{package_type}/{package_name}/versions/{package_version_id}",
+      path: { package_type: r, package_name: e, package_version_id: n, username: s },
+    });
+  }
+  static packagesDeletePackageVersionForUser(r, e, n, s) {
+    return o(i, {
+      method: "DELETE",
+      url: "/users/{username}/packages/{package_type}/{package_name}/versions/{package_version_id}",
+      path: { package_type: r, package_name: e, username: n, package_version_id: s },
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static packagesRestorePackageVersionForUser(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/users/{username}/packages/{package_type}/{package_name}/versions/{package_version_id}/restore",
+      path: { package_type: r, package_name: e, username: n, package_version_id: s },
+      errors: { 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+};
+var zr = class {
+  static projectsListForOrg(r, e = "open", n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/projects",
+      path: { org: r },
+      query: { state: e, per_page: n, page: s },
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static projectsCreateForOrg(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/projects",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+      errors: {
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        410: "Gone",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static projectsGetCard(r) {
+    return o(i, {
+      method: "GET",
+      url: "/projects/columns/cards/{card_id}",
+      path: { card_id: r },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static projectsUpdateCard(r, e) {
+    return o(i, {
+      method: "PATCH",
+      url: "/projects/columns/cards/{card_id}",
+      path: { card_id: r },
+      body: e,
+      mediaType: "application/json",
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static projectsDeleteCard(r) {
+    return o(i, {
+      method: "DELETE",
+      url: "/projects/columns/cards/{card_id}",
+      path: { card_id: r },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static projectsMoveCard(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/projects/columns/cards/{card_id}/moves",
+      path: { card_id: r },
+      body: e,
+      mediaType: "application/json",
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        422: "Validation failed, or the endpoint has been spammed.",
+        503: "Response",
+      },
+    });
+  }
+  static projectsGetColumn(r) {
+    return o(i, {
+      method: "GET",
+      url: "/projects/columns/{column_id}",
+      path: { column_id: r },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static projectsUpdateColumn(r, e) {
+    return o(i, {
+      method: "PATCH",
+      url: "/projects/columns/{column_id}",
+      path: { column_id: r },
+      body: e,
+      mediaType: "application/json",
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden" },
+    });
+  }
+  static projectsDeleteColumn(r) {
+    return o(i, {
+      method: "DELETE",
+      url: "/projects/columns/{column_id}",
+      path: { column_id: r },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden" },
+    });
+  }
+  static projectsListCards(r, e = "not_archived", n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/projects/columns/{column_id}/cards",
+      path: { column_id: r },
+      query: { archived_state: e, per_page: n, page: s },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden" },
+    });
+  }
+  static projectsCreateCard(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/projects/columns/{column_id}/cards",
+      path: { column_id: r },
+      body: e,
+      mediaType: "application/json",
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        422: "Validation failed",
+        503: "Response",
+      },
+    });
+  }
+  static projectsMoveColumn(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/projects/columns/{column_id}/moves",
+      path: { column_id: r },
+      body: e,
+      mediaType: "application/json",
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static projectsGet(r) {
+    return o(i, {
+      method: "GET",
+      url: "/projects/{project_id}",
+      path: { project_id: r },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden" },
+    });
+  }
+  static projectsUpdate(r, e) {
+    return o(i, {
+      method: "PATCH",
+      url: "/projects/{project_id}",
+      path: { project_id: r },
+      body: e,
+      mediaType: "application/json",
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Not Found if the authenticated user does not have access to the project",
+        410: "Gone",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static projectsDelete(r) {
+    return o(i, {
+      method: "DELETE",
+      url: "/projects/{project_id}",
+      path: { project_id: r },
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        410: "Gone",
+      },
+    });
+  }
+  static projectsListCollaborators(r, e = "all", n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/projects/{project_id}/collaborators",
+      path: { project_id: r },
+      query: { affiliation: e, per_page: n, page: s },
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static projectsAddCollaborator(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/projects/{project_id}/collaborators/{username}",
+      path: { project_id: r, username: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static projectsRemoveCollaborator(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/projects/{project_id}/collaborators/{username}",
+      path: { project_id: r, username: e },
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static projectsGetPermissionForUser(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/projects/{project_id}/collaborators/{username}/permission",
+      path: { project_id: r, username: e },
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static projectsListColumns(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/projects/{project_id}/columns",
+      path: { project_id: r },
+      query: { per_page: e, page: n },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden" },
+    });
+  }
+  static projectsCreateColumn(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/projects/{project_id}/columns",
+      path: { project_id: r },
+      body: e,
+      mediaType: "application/json",
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static projectsListForRepo(r, e, n = "open", s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/projects",
+      path: { owner: r, repo: e },
+      query: { state: n, per_page: s, page: u },
+      errors: {
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        410: "Gone",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static projectsCreateForRepo(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/projects",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        410: "Gone",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static projectsCreateForAuthenticatedUser(r) {
+    return o(i, {
+      method: "POST",
+      url: "/user/projects",
+      body: r,
+      mediaType: "application/json",
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static projectsListForUser(r, e = "open", n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}/projects",
+      path: { username: r },
+      query: { state: e, per_page: n, page: s },
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+};
+var Pr = class {
+  static pullsList(r, e, n = "open", s, u, _ = "created", m, c = 30, d = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/pulls",
+      path: { owner: r, repo: e },
+      query: { state: n, head: s, base: u, sort: _, direction: m, per_page: c, page: d },
+      errors: { 304: "Not modified", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static pullsCreate(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/pulls",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 403: "Forbidden", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static pullsListReviewCommentsForRepo(r, e, n, s, u, _ = 30, m = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/pulls/comments",
+      path: { owner: r, repo: e },
+      query: { sort: n, direction: s, since: u, per_page: _, page: m },
+    });
+  }
+  static pullsGetReviewComment(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/pulls/comments/{comment_id}",
+      path: { owner: r, repo: e, comment_id: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static pullsUpdateReviewComment(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/pulls/comments/{comment_id}",
+      path: { owner: r, repo: e, comment_id: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static pullsDeleteReviewComment(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/pulls/comments/{comment_id}",
+      path: { owner: r, repo: e, comment_id: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static pullsGet(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/pulls/{pull_number}",
+      path: { owner: r, repo: e, pull_number: n },
+      errors: { 304: "Not modified", 404: "Resource not found", 500: "Internal Error", 503: "Service unavailable" },
+    });
+  }
+  static pullsUpdate(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/pulls/{pull_number}",
+      path: { owner: r, repo: e, pull_number: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 403: "Forbidden", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static pullsListReviewComments(r, e, n, s = "created", u, _, m = 30, c = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/pulls/{pull_number}/comments",
+      path: { owner: r, repo: e, pull_number: n },
+      query: { sort: s, direction: u, since: _, per_page: m, page: c },
+    });
+  }
+  static pullsCreateReviewComment(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/pulls/{pull_number}/comments",
+      path: { owner: r, repo: e, pull_number: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 403: "Forbidden", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static pullsCreateReplyForReviewComment(r, e, n, s, u) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies",
+      path: { owner: r, repo: e, pull_number: n, comment_id: s },
+      body: u,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static pullsListCommits(r, e, n, s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/pulls/{pull_number}/commits",
+      path: { owner: r, repo: e, pull_number: n },
+      query: { per_page: s, page: u },
+    });
+  }
+  static pullsListFiles(r, e, n, s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/pulls/{pull_number}/files",
+      path: { owner: r, repo: e, pull_number: n },
+      query: { per_page: s, page: u },
+      errors: {
+        422: "Validation failed, or the endpoint has been spammed.",
+        500: "Internal Error",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static pullsCheckIfMerged(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/pulls/{pull_number}/merge",
+      path: { owner: r, repo: e, pull_number: n },
+      errors: { 404: "Not Found if pull request has not been merged" },
+    });
+  }
+  static pullsMerge(r, e, n, s) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/pulls/{pull_number}/merge",
+      path: { owner: r, repo: e, pull_number: n },
+      body: s,
+      mediaType: "application/json",
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        405: "Method Not Allowed if merge cannot be performed",
+        409: "Conflict if sha was provided and pull request head did not match",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static pullsListRequestedReviewers(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers",
+      path: { owner: r, repo: e, pull_number: n },
+    });
+  }
+  static pullsRequestReviewers(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers",
+      path: { owner: r, repo: e, pull_number: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 403: "Forbidden", 422: "Unprocessable Entity if user is not a collaborator" },
+    });
+  }
+  static pullsRemoveRequestedReviewers(r, e, n, s) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers",
+      path: { owner: r, repo: e, pull_number: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static pullsListReviews(r, e, n, s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/pulls/{pull_number}/reviews",
+      path: { owner: r, repo: e, pull_number: n },
+      query: { per_page: s, page: u },
+    });
+  }
+  static pullsCreateReview(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/pulls/{pull_number}/reviews",
+      path: { owner: r, repo: e, pull_number: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 403: "Forbidden", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static pullsGetReview(r, e, n, s) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}",
+      path: { owner: r, repo: e, pull_number: n, review_id: s },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static pullsUpdateReview(r, e, n, s, u) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}",
+      path: { owner: r, repo: e, pull_number: n, review_id: s },
+      body: u,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static pullsDeletePendingReview(r, e, n, s) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}",
+      path: { owner: r, repo: e, pull_number: n, review_id: s },
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static pullsListCommentsForReview(r, e, n, s, u = 30, _ = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments",
+      path: { owner: r, repo: e, pull_number: n, review_id: s },
+      query: { per_page: u, page: _ },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static pullsDismissReview(r, e, n, s, u) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals",
+      path: { owner: r, repo: e, pull_number: n, review_id: s },
+      body: u,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static pullsSubmitReview(r, e, n, s, u) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events",
+      path: { owner: r, repo: e, pull_number: n, review_id: s },
+      body: u,
+      mediaType: "application/json",
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static pullsUpdateBranch(r, e, n, s) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/pulls/{pull_number}/update-branch",
+      path: { owner: r, repo: e, pull_number: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 403: "Forbidden", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+};
+var Cr = class {
+  static rateLimitGet() {
+    return o(i, { method: "GET", url: "/rate_limit", errors: { 304: "Not modified", 404: "Resource not found" } });
+  }
+};
+var Dr = class {
+  static reactionsListForTeamDiscussionCommentInOrg(r, e, n, s, u, _ = 30, m = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions",
+      path: { org: r, team_slug: e, discussion_number: n, comment_number: s },
+      query: { content: u, per_page: _, page: m },
+    });
+  }
+  static reactionsCreateForTeamDiscussionCommentInOrg(r, e, n, s, u) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions",
+      path: { org: r, team_slug: e, discussion_number: n, comment_number: s },
+      body: u,
+      mediaType: "application/json",
+    });
+  }
+  static reactionsDeleteForTeamDiscussionComment(r, e, n, s, u) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions/{reaction_id}",
+      path: { org: r, team_slug: e, discussion_number: n, comment_number: s, reaction_id: u },
+    });
+  }
+  static reactionsListForTeamDiscussionInOrg(r, e, n, s, u = 30, _ = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions",
+      path: { org: r, team_slug: e, discussion_number: n },
+      query: { content: s, per_page: u, page: _ },
+    });
+  }
+  static reactionsCreateForTeamDiscussionInOrg(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions",
+      path: { org: r, team_slug: e, discussion_number: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static reactionsDeleteForTeamDiscussion(r, e, n, s) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions/{reaction_id}",
+      path: { org: r, team_slug: e, discussion_number: n, reaction_id: s },
+    });
+  }
+  static reactionsListForCommitComment(r, e, n, s, u = 30, _ = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/comments/{comment_id}/reactions",
+      path: { owner: r, repo: e, comment_id: n },
+      query: { content: s, per_page: u, page: _ },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reactionsCreateForCommitComment(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/comments/{comment_id}/reactions",
+      path: { owner: r, repo: e, comment_id: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reactionsDeleteForCommitComment(r, e, n, s) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}",
+      path: { owner: r, repo: e, comment_id: n, reaction_id: s },
+    });
+  }
+  static reactionsListForIssueComment(r, e, n, s, u = 30, _ = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/issues/comments/{comment_id}/reactions",
+      path: { owner: r, repo: e, comment_id: n },
+      query: { content: s, per_page: u, page: _ },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reactionsCreateForIssueComment(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/issues/comments/{comment_id}/reactions",
+      path: { owner: r, repo: e, comment_id: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reactionsDeleteForIssueComment(r, e, n, s) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}",
+      path: { owner: r, repo: e, comment_id: n, reaction_id: s },
+    });
+  }
+  static reactionsListForIssue(r, e, n, s, u = 30, _ = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/issues/{issue_number}/reactions",
+      path: { owner: r, repo: e, issue_number: n },
+      query: { content: s, per_page: u, page: _ },
+      errors: { 404: "Resource not found", 410: "Gone" },
+    });
+  }
+  static reactionsCreateForIssue(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/issues/{issue_number}/reactions",
+      path: { owner: r, repo: e, issue_number: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reactionsDeleteForIssue(r, e, n, s) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}",
+      path: { owner: r, repo: e, issue_number: n, reaction_id: s },
+    });
+  }
+  static reactionsListForPullRequestReviewComment(r, e, n, s, u = 30, _ = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",
+      path: { owner: r, repo: e, comment_id: n },
+      query: { content: s, per_page: u, page: _ },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reactionsCreateForPullRequestReviewComment(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",
+      path: { owner: r, repo: e, comment_id: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reactionsDeleteForPullRequestComment(r, e, n, s) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}",
+      path: { owner: r, repo: e, comment_id: n, reaction_id: s },
+    });
+  }
+  static reactionsListForRelease(r, e, n, s, u = 30, _ = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/releases/{release_id}/reactions",
+      path: { owner: r, repo: e, release_id: n },
+      query: { content: s, per_page: u, page: _ },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reactionsCreateForRelease(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/releases/{release_id}/reactions",
+      path: { owner: r, repo: e, release_id: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reactionsDeleteForRelease(r, e, n, s) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/releases/{release_id}/reactions/{reaction_id}",
+      path: { owner: r, repo: e, release_id: n, reaction_id: s },
+    });
+  }
+  static reactionsListForTeamDiscussionCommentLegacy(r, e, n, s, u = 30, _ = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}/reactions",
+      path: { team_id: r, discussion_number: e, comment_number: n },
+      query: { content: s, per_page: u, page: _ },
+    });
+  }
+  static reactionsCreateForTeamDiscussionCommentLegacy(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}/reactions",
+      path: { team_id: r, discussion_number: e, comment_number: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static reactionsListForTeamDiscussionLegacy(r, e, n, s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/teams/{team_id}/discussions/{discussion_number}/reactions",
+      path: { team_id: r, discussion_number: e },
+      query: { content: n, per_page: s, page: u },
+    });
+  }
+  static reactionsCreateForTeamDiscussionLegacy(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/teams/{team_id}/discussions/{discussion_number}/reactions",
+      path: { team_id: r, discussion_number: e },
+      body: n,
+      mediaType: "application/json",
+    });
+  }
+};
+var qr = class {
+  static reposListForOrg(r, e = "all", n = "created", s, u = 30, _ = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/repos",
+      path: { org: r },
+      query: { type: e, sort: n, direction: s, per_page: u, page: _ },
+    });
+  }
+  static reposCreateInOrg(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/repos",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+      errors: { 403: "Forbidden", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposGetOrgRulesets(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/rulesets",
+      path: { org: r },
+      query: { per_page: e, page: n },
+      errors: { 404: "Resource not found", 500: "Internal Error" },
+    });
+  }
+  static reposCreateOrgRuleset(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/rulesets",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 500: "Internal Error" },
+    });
+  }
+  static reposGetOrgRuleset(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/rulesets/{ruleset_id}",
+      path: { org: r, ruleset_id: e },
+      errors: { 404: "Resource not found", 500: "Internal Error" },
+    });
+  }
+  static reposUpdateOrgRuleset(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/rulesets/{ruleset_id}",
+      path: { org: r, ruleset_id: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 500: "Internal Error" },
+    });
+  }
+  static reposDeleteOrgRuleset(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/rulesets/{ruleset_id}",
+      path: { org: r, ruleset_id: e },
+      errors: { 404: "Resource not found", 500: "Internal Error" },
+    });
+  }
+  static reposGet(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}",
+      path: { owner: r, repo: e },
+      errors: { 301: "Moved permanently", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static reposUpdate(r, e, n) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        307: "Temporary Redirect",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static reposDelete(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}",
+      path: { owner: r, repo: e },
+      errors: {
+        307: "Temporary Redirect",
+        403: "If an organization owner has configured the organization to prevent members from deleting organization-owned repositories, a member will get this response:",
+        404: "Resource not found",
+      },
+    });
+  }
+  static reposListActivities(r, e, n = "desc", s = 30, u, _, m, c, d, v) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/activity",
+      path: { owner: r, repo: e },
+      query: { direction: n, per_page: s, before: u, after: _, ref: m, actor: c, time_period: d, activity_type: v },
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposListAutolinks(r, e, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/autolinks",
+      path: { owner: r, repo: e },
+      query: { page: n },
+    });
+  }
+  static reposCreateAutolink(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/autolinks",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposGetAutolink(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/autolinks/{autolink_id}",
+      path: { owner: r, repo: e, autolink_id: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposDeleteAutolink(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/autolinks/{autolink_id}",
+      path: { owner: r, repo: e, autolink_id: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposCheckAutomatedSecurityFixes(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/automated-security-fixes",
+      path: { owner: r, repo: e },
+      errors: { 404: "Not Found if dependabot is not enabled for the repository" },
+    });
+  }
+  static reposEnableAutomatedSecurityFixes(r, e) {
+    return o(i, { method: "PUT", url: "/repos/{owner}/{repo}/automated-security-fixes", path: { owner: r, repo: e } });
+  }
+  static reposDisableAutomatedSecurityFixes(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/automated-security-fixes",
+      path: { owner: r, repo: e },
+    });
+  }
+  static reposListBranches(r, e, n, s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/branches",
+      path: { owner: r, repo: e },
+      query: { protected: n, per_page: s, page: u },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposGetBranch(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/branches/{branch}",
+      path: { owner: r, repo: e, branch: n },
+      errors: { 301: "Moved permanently", 404: "Resource not found" },
+    });
+  }
+  static reposGetBranchProtection(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection",
+      path: { owner: r, repo: e, branch: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposUpdateBranchProtection(r, e, n, s) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection",
+      path: { owner: r, repo: e, branch: n },
+      body: s,
+      mediaType: "application/json",
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static reposDeleteBranchProtection(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection",
+      path: { owner: r, repo: e, branch: n },
+      errors: { 403: "Forbidden" },
+    });
+  }
+  static reposGetAdminBranchProtection(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins",
+      path: { owner: r, repo: e, branch: n },
+    });
+  }
+  static reposSetAdminBranchProtection(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins",
+      path: { owner: r, repo: e, branch: n },
+    });
+  }
+  static reposDeleteAdminBranchProtection(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins",
+      path: { owner: r, repo: e, branch: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposGetPullRequestReviewProtection(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews",
+      path: { owner: r, repo: e, branch: n },
+    });
+  }
+  static reposUpdatePullRequestReviewProtection(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews",
+      path: { owner: r, repo: e, branch: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposDeletePullRequestReviewProtection(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews",
+      path: { owner: r, repo: e, branch: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposGetCommitSignatureProtection(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/required_signatures",
+      path: { owner: r, repo: e, branch: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposCreateCommitSignatureProtection(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/required_signatures",
+      path: { owner: r, repo: e, branch: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposDeleteCommitSignatureProtection(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/required_signatures",
+      path: { owner: r, repo: e, branch: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposGetStatusChecksProtection(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks",
+      path: { owner: r, repo: e, branch: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposUpdateStatusCheckProtection(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks",
+      path: { owner: r, repo: e, branch: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposRemoveStatusCheckProtection(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks",
+      path: { owner: r, repo: e, branch: n },
+    });
+  }
+  static reposGetAllStatusCheckContexts(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts",
+      path: { owner: r, repo: e, branch: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposAddStatusCheckContexts(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts",
+      path: { owner: r, repo: e, branch: n },
+      body: s,
+      mediaType: "application/json",
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static reposSetStatusCheckContexts(r, e, n, s) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts",
+      path: { owner: r, repo: e, branch: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposRemoveStatusCheckContexts(r, e, n, s) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts",
+      path: { owner: r, repo: e, branch: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposGetAccessRestrictions(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions",
+      path: { owner: r, repo: e, branch: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposDeleteAccessRestrictions(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions",
+      path: { owner: r, repo: e, branch: n },
+    });
+  }
+  static reposGetAppsWithAccessToProtectedBranch(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps",
+      path: { owner: r, repo: e, branch: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposAddAppAccessRestrictions(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps",
+      path: { owner: r, repo: e, branch: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposSetAppAccessRestrictions(r, e, n, s) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps",
+      path: { owner: r, repo: e, branch: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposRemoveAppAccessRestrictions(r, e, n, s) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps",
+      path: { owner: r, repo: e, branch: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposGetTeamsWithAccessToProtectedBranch(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams",
+      path: { owner: r, repo: e, branch: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposAddTeamAccessRestrictions(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams",
+      path: { owner: r, repo: e, branch: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposSetTeamAccessRestrictions(r, e, n, s) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams",
+      path: { owner: r, repo: e, branch: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposRemoveTeamAccessRestrictions(r, e, n, s) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams",
+      path: { owner: r, repo: e, branch: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposGetUsersWithAccessToProtectedBranch(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users",
+      path: { owner: r, repo: e, branch: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposAddUserAccessRestrictions(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users",
+      path: { owner: r, repo: e, branch: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposSetUserAccessRestrictions(r, e, n, s) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users",
+      path: { owner: r, repo: e, branch: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposRemoveUserAccessRestrictions(r, e, n, s) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users",
+      path: { owner: r, repo: e, branch: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposRenameBranch(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/branches/{branch}/rename",
+      path: { owner: r, repo: e, branch: n },
+      body: s,
+      mediaType: "application/json",
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static reposCodeownersErrors(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/codeowners/errors",
+      path: { owner: r, repo: e },
+      query: { ref: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposListCollaborators(r, e, n = "all", s, u = 30, _ = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/collaborators",
+      path: { owner: r, repo: e },
+      query: { affiliation: n, permission: s, per_page: u, page: _ },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposCheckCollaborator(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/collaborators/{username}",
+      path: { owner: r, repo: e, username: n },
+      errors: { 404: "Not Found if user is not a collaborator" },
+    });
+  }
+  static reposAddCollaborator(r, e, n, s) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/collaborators/{username}",
+      path: { owner: r, repo: e, username: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 403: "Forbidden", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposRemoveCollaborator(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/collaborators/{username}",
+      path: { owner: r, repo: e, username: n },
+      errors: { 403: "Forbidden", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposGetCollaboratorPermissionLevel(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/collaborators/{username}/permission",
+      path: { owner: r, repo: e, username: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposListCommitCommentsForRepo(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/comments",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+    });
+  }
+  static reposGetCommitComment(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/comments/{comment_id}",
+      path: { owner: r, repo: e, comment_id: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposUpdateCommitComment(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/comments/{comment_id}",
+      path: { owner: r, repo: e, comment_id: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposDeleteCommitComment(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/comments/{comment_id}",
+      path: { owner: r, repo: e, comment_id: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposListCommits(r, e, n, s, u, _, m, c, d = 30, v = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/commits",
+      path: { owner: r, repo: e },
+      query: { sha: n, path: s, author: u, committer: _, since: m, until: c, per_page: d, page: v },
+      errors: { 400: "Bad Request", 404: "Resource not found", 409: "Conflict", 500: "Internal Error" },
+    });
+  }
+  static reposListBranchesForHeadCommit(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head",
+      path: { owner: r, repo: e, commit_sha: n },
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposListCommentsForCommit(r, e, n, s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/commits/{commit_sha}/comments",
+      path: { owner: r, repo: e, commit_sha: n },
+      query: { per_page: s, page: u },
+    });
+  }
+  static reposCreateCommitComment(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/commits/{commit_sha}/comments",
+      path: { owner: r, repo: e, commit_sha: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 403: "Forbidden", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposListPullRequestsAssociatedWithCommit(r, e, n, s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/commits/{commit_sha}/pulls",
+      path: { owner: r, repo: e, commit_sha: n },
+      query: { per_page: s, page: u },
+    });
+  }
+  static reposGetCommit(r, e, n, s = 1, u = 30) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/commits/{ref}",
+      path: { owner: r, repo: e, ref: n },
+      query: { page: s, per_page: u },
+      errors: {
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+        500: "Internal Error",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static reposGetCombinedStatusForRef(r, e, n, s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/commits/{ref}/status",
+      path: { owner: r, repo: e, ref: n },
+      query: { per_page: s, page: u },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposListCommitStatusesForRef(r, e, n, s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/commits/{ref}/statuses",
+      path: { owner: r, repo: e, ref: n },
+      query: { per_page: s, page: u },
+      errors: { 301: "Moved permanently" },
+    });
+  }
+  static reposGetCommunityProfileMetrics(r, e) {
+    return o(i, { method: "GET", url: "/repos/{owner}/{repo}/community/profile", path: { owner: r, repo: e } });
+  }
+  static reposCompareCommits(r, e, n, s = 1, u = 30) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/compare/{basehead}",
+      path: { owner: r, repo: e, basehead: n },
+      query: { page: s, per_page: u },
+      errors: { 404: "Resource not found", 500: "Internal Error", 503: "Service unavailable" },
+    });
+  }
+  static reposGetContent(r, e, n, s) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/contents/{path}",
+      path: { owner: r, repo: e, path: n },
+      query: { ref: s },
+      errors: { 302: "Found", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static reposCreateOrUpdateFileContents(r, e, n, s) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/contents/{path}",
+      path: { owner: r, repo: e, path: n },
+      body: s,
+      mediaType: "application/json",
+      errors: {
+        404: "Resource not found",
+        409: "Conflict",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static reposDeleteFile(r, e, n, s) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/contents/{path}",
+      path: { owner: r, repo: e, path: n },
+      body: s,
+      mediaType: "application/json",
+      errors: {
+        404: "Resource not found",
+        409: "Conflict",
+        422: "Validation failed, or the endpoint has been spammed.",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static reposListContributors(r, e, n, s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/contributors",
+      path: { owner: r, repo: e },
+      query: { anon: n, per_page: s, page: u },
+      errors: { 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static reposListDeployments(r, e, n = "none", s = "none", u = "none", _ = "none", m = 30, c = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/deployments",
+      path: { owner: r, repo: e },
+      query: { sha: n, ref: s, task: u, environment: _, per_page: m, page: c },
+    });
+  }
+  static reposCreateDeployment(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/deployments",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        409: "Conflict when there is a merge conflict or the commit's status checks failed",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static reposGetDeployment(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/deployments/{deployment_id}",
+      path: { owner: r, repo: e, deployment_id: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposDeleteDeployment(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/deployments/{deployment_id}",
+      path: { owner: r, repo: e, deployment_id: n },
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposListDeploymentStatuses(r, e, n, s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/deployments/{deployment_id}/statuses",
+      path: { owner: r, repo: e, deployment_id: n },
+      query: { per_page: s, page: u },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposCreateDeploymentStatus(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/deployments/{deployment_id}/statuses",
+      path: { owner: r, repo: e, deployment_id: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposGetDeploymentStatus(r, e, n, s) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/deployments/{deployment_id}/statuses/{status_id}",
+      path: { owner: r, repo: e, deployment_id: n, status_id: s },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposCreateDispatchEvent(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/dispatches",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposGetAllEnvironments(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/environments",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+    });
+  }
+  static reposGetEnvironment(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/environments/{environment_name}",
+      path: { owner: r, repo: e, environment_name: n },
+    });
+  }
+  static reposCreateOrUpdateEnvironment(r, e, n, s) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/environments/{environment_name}",
+      path: { owner: r, repo: e, environment_name: n },
+      body: s,
+      mediaType: "application/json",
+      errors: {
+        422: "Validation error when the environment name is invalid or when `protected_branches` and `custom_branch_policies` in `deployment_branch_policy` are set to the same value",
+      },
+    });
+  }
+  static reposDeleteAnEnvironment(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/environments/{environment_name}",
+      path: { owner: r, repo: e, environment_name: n },
+    });
+  }
+  static reposListDeploymentBranchPolicies(r, e, n, s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/environments/{environment_name}/deployment-branch-policies",
+      path: { owner: r, repo: e, environment_name: n },
+      query: { per_page: s, page: u },
+    });
+  }
+  static reposCreateDeploymentBranchPolicy(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/environments/{environment_name}/deployment-branch-policies",
+      path: { owner: r, repo: e, environment_name: n },
+      body: s,
+      mediaType: "application/json",
+      errors: {
+        303: "Response if the same branch name pattern already exists",
+        404: "Not Found or `deployment_branch_policy.custom_branch_policies` property for the environment is set to false",
+      },
+    });
+  }
+  static reposGetDeploymentBranchPolicy(r, e, n, s) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/environments/{environment_name}/deployment-branch-policies/{branch_policy_id}",
+      path: { owner: r, repo: e, environment_name: n, branch_policy_id: s },
+    });
+  }
+  static reposUpdateDeploymentBranchPolicy(r, e, n, s, u) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/environments/{environment_name}/deployment-branch-policies/{branch_policy_id}",
+      path: { owner: r, repo: e, environment_name: n, branch_policy_id: s },
+      body: u,
+      mediaType: "application/json",
+    });
+  }
+  static reposDeleteDeploymentBranchPolicy(r, e, n, s) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/environments/{environment_name}/deployment-branch-policies/{branch_policy_id}",
+      path: { owner: r, repo: e, environment_name: n, branch_policy_id: s },
+    });
+  }
+  static reposGetAllDeploymentProtectionRules(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/environments/{environment_name}/deployment_protection_rules",
+      path: { environment_name: r, repo: e, owner: n },
+    });
+  }
+  static reposCreateDeploymentProtectionRule(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/environments/{environment_name}/deployment_protection_rules",
+      path: { environment_name: r, repo: e, owner: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static reposListCustomDeploymentRuleIntegrations(r, e, n, s = 1, u = 30) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/environments/{environment_name}/deployment_protection_rules/apps",
+      path: { environment_name: r, repo: e, owner: n },
+      query: { page: s, per_page: u },
+    });
+  }
+  static reposGetCustomDeploymentProtectionRule(r, e, n, s) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/environments/{environment_name}/deployment_protection_rules/{protection_rule_id}",
+      path: { owner: r, repo: e, environment_name: n, protection_rule_id: s },
+    });
+  }
+  static reposDisableDeploymentProtectionRule(r, e, n, s) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/environments/{environment_name}/deployment_protection_rules/{protection_rule_id}",
+      path: { environment_name: r, repo: e, owner: n, protection_rule_id: s },
+    });
+  }
+  static reposListForks(r, e, n = "newest", s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/forks",
+      path: { owner: r, repo: e },
+      query: { sort: n, per_page: s, page: u },
+      errors: { 400: "Bad Request" },
+    });
+  }
+  static reposCreateFork(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/forks",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        400: "Bad Request",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static reposListWebhooks(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/hooks",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposCreateWebhook(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/hooks",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static reposGetWebhook(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/hooks/{hook_id}",
+      path: { owner: r, repo: e, hook_id: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposUpdateWebhook(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/hooks/{hook_id}",
+      path: { owner: r, repo: e, hook_id: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposDeleteWebhook(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/hooks/{hook_id}",
+      path: { owner: r, repo: e, hook_id: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposGetWebhookConfigForRepo(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/hooks/{hook_id}/config",
+      path: { owner: r, repo: e, hook_id: n },
+    });
+  }
+  static reposUpdateWebhookConfigForRepo(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/hooks/{hook_id}/config",
+      path: { owner: r, repo: e, hook_id: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static reposListWebhookDeliveries(r, e, n, s = 30, u, _) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/hooks/{hook_id}/deliveries",
+      path: { owner: r, repo: e, hook_id: n },
+      query: { per_page: s, cursor: u, redelivery: _ },
+      errors: { 400: "Bad Request", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposGetWebhookDelivery(r, e, n, s) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/hooks/{hook_id}/deliveries/{delivery_id}",
+      path: { owner: r, repo: e, hook_id: n, delivery_id: s },
+      errors: { 400: "Bad Request", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposRedeliverWebhookDelivery(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/hooks/{hook_id}/deliveries/{delivery_id}/attempts",
+      path: { owner: r, repo: e, hook_id: n, delivery_id: s },
+      errors: { 400: "Bad Request", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposPingWebhook(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/hooks/{hook_id}/pings",
+      path: { owner: r, repo: e, hook_id: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposTestPushWebhook(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/hooks/{hook_id}/tests",
+      path: { owner: r, repo: e, hook_id: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposListInvitations(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/invitations",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+    });
+  }
+  static reposUpdateInvitation(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/invitations/{invitation_id}",
+      path: { owner: r, repo: e, invitation_id: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static reposDeleteInvitation(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/invitations/{invitation_id}",
+      path: { owner: r, repo: e, invitation_id: n },
+    });
+  }
+  static reposListDeployKeys(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/keys",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+    });
+  }
+  static reposCreateDeployKey(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/keys",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposGetDeployKey(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/keys/{key_id}",
+      path: { owner: r, repo: e, key_id: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposDeleteDeployKey(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/keys/{key_id}",
+      path: { owner: r, repo: e, key_id: n },
+    });
+  }
+  static reposListLanguages(r, e) {
+    return o(i, { method: "GET", url: "/repos/{owner}/{repo}/languages", path: { owner: r, repo: e } });
+  }
+  static reposEnableLfsForRepo(r, e) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/lfs",
+      path: { owner: r, repo: e },
+      errors: {
+        403: `We will return a 403 with one of the following messages:
 
                 - Git LFS support not enabled because Git LFS is globally disabled.
                 - Git LFS support not enabled because Git LFS is disabled for the root repository in the network.
-                - Git LFS support not enabled because Git LFS is disabled for <owner>.`}})}static reposDisableLfsForRepo(r,e){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/lfs",path:{owner:r,repo:e}})}static reposMergeUpstream(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/merge-upstream",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{409:"The branch could not be synced because of a merge conflict",422:"The branch could not be synced for some other reason"}})}static reposMerge(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/merges",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{403:"Forbidden",404:"Not Found when the base or head does not exist",409:"Conflict when there is a merge conflict",422:"Validation failed, or the endpoint has been spammed."}})}static reposGetPages(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/pages",path:{owner:r,repo:e},errors:{404:"Resource not found"}})}static reposCreatePagesSite(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/pages",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{409:"Conflict",422:"Validation failed, or the endpoint has been spammed."}})}static reposUpdateInformationAboutPagesSite(r,e,n){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/pages",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{400:"Bad Request",409:"Conflict",422:"Validation failed, or the endpoint has been spammed."}})}static reposDeletePagesSite(r,e){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/pages",path:{owner:r,repo:e},errors:{404:"Resource not found",409:"Conflict",422:"Validation failed, or the endpoint has been spammed."}})}static reposListPagesBuilds(r,e,n=30,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/pages/builds",path:{owner:r,repo:e},query:{per_page:n,page:s}})}static reposRequestPagesBuild(r,e){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/pages/builds",path:{owner:r,repo:e}})}static reposGetLatestPagesBuild(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/pages/builds/latest",path:{owner:r,repo:e}})}static reposGetPagesBuild(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/pages/builds/{build_id}",path:{owner:r,repo:e,build_id:n}})}static reposCreatePagesDeployment(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/pages/deployment",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{400:"Bad Request",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static reposGetPagesHealthCheck(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/pages/health",path:{owner:r,repo:e},errors:{400:"Custom domains are not available for GitHub Pages",404:"Resource not found",422:"There isn't a CNAME for this page"}})}static reposGetReadme(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/readme",path:{owner:r,repo:e},query:{ref:n},errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static reposGetReadmeInDirectory(r,e,n,s){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/readme/{dir}",path:{owner:r,repo:e,dir:n},query:{ref:s},errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static reposListReleases(r,e,n=30,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/releases",path:{owner:r,repo:e},query:{per_page:n,page:s},errors:{404:"Resource not found"}})}static reposCreateRelease(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/releases",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{404:"Not Found if the discussion category name is invalid",422:"Validation failed, or the endpoint has been spammed."}})}static reposGetReleaseAsset(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/releases/assets/{asset_id}",path:{owner:r,repo:e,asset_id:n},errors:{302:"Found",404:"Resource not found"}})}static reposUpdateReleaseAsset(r,e,n,s){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/releases/assets/{asset_id}",path:{owner:r,repo:e,asset_id:n},body:s,mediaType:"application/json"})}static reposDeleteReleaseAsset(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/releases/assets/{asset_id}",path:{owner:r,repo:e,asset_id:n}})}static reposGenerateReleaseNotes(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/releases/generate-notes",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{404:"Resource not found"}})}static reposGetLatestRelease(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/releases/latest",path:{owner:r,repo:e}})}static reposGetReleaseByTag(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/releases/tags/{tag}",path:{owner:r,repo:e,tag:n},errors:{404:"Resource not found"}})}static reposGetRelease(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/releases/{release_id}",path:{owner:r,repo:e,release_id:n},errors:{401:"Unauthorized"}})}static reposUpdateRelease(r,e,n,s){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/releases/{release_id}",path:{owner:r,repo:e,release_id:n},body:s,mediaType:"application/json",errors:{404:"Not Found if the discussion category name is invalid"}})}static reposDeleteRelease(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/releases/{release_id}",path:{owner:r,repo:e,release_id:n}})}static reposListReleaseAssets(r,e,n,s=30,u=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/releases/{release_id}/assets",path:{owner:r,repo:e,release_id:n},query:{per_page:s,page:u}})}static reposUploadReleaseAsset(r,e,n,s,u,_){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/releases/{release_id}/assets",path:{owner:r,repo:e,release_id:n},query:{name:s,label:u},body:_,mediaType:"application/octet-stream",errors:{422:"Response if you upload an asset with the same filename as another uploaded asset"}})}static reposGetBranchRules(r,e,n,s=30,u=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/rules/branches/{branch}",path:{owner:r,repo:e,branch:n},query:{per_page:s,page:u}})}static reposGetRepoRulesets(r,e,n=30,s=1,u=!0){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/rulesets",path:{owner:r,repo:e},query:{per_page:n,page:s,includes_parents:u},errors:{404:"Resource not found",500:"Internal Error"}})}static reposCreateRepoRuleset(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/rulesets",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{404:"Resource not found",500:"Internal Error"}})}static reposGetRepoRuleset(r,e,n,s=!0){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/rulesets/{ruleset_id}",path:{owner:r,repo:e,ruleset_id:n},query:{includes_parents:s},errors:{404:"Resource not found",500:"Internal Error"}})}static reposUpdateRepoRuleset(r,e,n,s){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/rulesets/{ruleset_id}",path:{owner:r,repo:e,ruleset_id:n},body:s,mediaType:"application/json",errors:{404:"Resource not found",500:"Internal Error"}})}static reposDeleteRepoRuleset(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/rulesets/{ruleset_id}",path:{owner:r,repo:e,ruleset_id:n},errors:{404:"Resource not found",500:"Internal Error"}})}static reposGetCodeFrequencyStats(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/stats/code_frequency",path:{owner:r,repo:e}})}static reposGetCommitActivityStats(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/stats/commit_activity",path:{owner:r,repo:e}})}static reposGetContributorsStats(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/stats/contributors",path:{owner:r,repo:e}})}static reposGetParticipationStats(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/stats/participation",path:{owner:r,repo:e},errors:{404:"Resource not found"}})}static reposGetPunchCardStats(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/stats/punch_card",path:{owner:r,repo:e}})}static reposCreateCommitStatus(r,e,n,s){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/statuses/{sha}",path:{owner:r,repo:e,sha:n},body:s,mediaType:"application/json"})}static reposListTags(r,e,n=30,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/tags",path:{owner:r,repo:e},query:{per_page:n,page:s}})}static reposListTagProtection(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/tags/protection",path:{owner:r,repo:e},errors:{403:"Forbidden",404:"Resource not found"}})}static reposCreateTagProtection(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/tags/protection",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{403:"Forbidden",404:"Resource not found"}})}static reposDeleteTagProtection(r,e,n){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/tags/protection/{tag_protection_id}",path:{owner:r,repo:e,tag_protection_id:n},errors:{403:"Forbidden",404:"Resource not found"}})}static reposDownloadTarballArchive(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/tarball/{ref}",path:{owner:r,repo:e,ref:n},errors:{302:"Response"}})}static reposListTeams(r,e,n=30,s=1){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/teams",path:{owner:r,repo:e},query:{per_page:n,page:s},errors:{404:"Resource not found"}})}static reposGetAllTopics(r,e,n=1,s=30){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/topics",path:{owner:r,repo:e},query:{page:n,per_page:s},errors:{404:"Resource not found"}})}static reposReplaceAllTopics(r,e,n){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/topics",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static reposGetClones(r,e,n="day"){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/traffic/clones",path:{owner:r,repo:e},query:{per:n},errors:{403:"Forbidden"}})}static reposGetTopPaths(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/traffic/popular/paths",path:{owner:r,repo:e},errors:{403:"Forbidden"}})}static reposGetTopReferrers(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/traffic/popular/referrers",path:{owner:r,repo:e},errors:{403:"Forbidden"}})}static reposGetViews(r,e,n="day"){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/traffic/views",path:{owner:r,repo:e},query:{per:n},errors:{403:"Forbidden"}})}static reposTransfer(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/transfer",path:{owner:r,repo:e},body:n,mediaType:"application/json"})}static reposCheckVulnerabilityAlerts(r,e){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/vulnerability-alerts",path:{owner:r,repo:e},errors:{404:"Not Found if repository is not enabled with vulnerability alerts"}})}static reposEnableVulnerabilityAlerts(r,e){return o(i,{method:"PUT",url:"/repos/{owner}/{repo}/vulnerability-alerts",path:{owner:r,repo:e}})}static reposDisableVulnerabilityAlerts(r,e){return o(i,{method:"DELETE",url:"/repos/{owner}/{repo}/vulnerability-alerts",path:{owner:r,repo:e}})}static reposDownloadZipballArchive(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/zipball/{ref}",path:{owner:r,repo:e,ref:n},errors:{302:"Response"}})}static reposCreateUsingTemplate(r,e,n){return o(i,{method:"POST",url:"/repos/{template_owner}/{template_repo}/generate",path:{template_owner:r,template_repo:e},body:n,mediaType:"application/json"})}static reposListPublic(r){return o(i,{method:"GET",url:"/repositories",query:{since:r},errors:{304:"Not modified",422:"Validation failed, or the endpoint has been spammed."}})}static reposListForAuthenticatedUser(r="all",e="owner,collaborator,organization_member",n="all",s="full_name",u,_=30,m=1,c,d){return o(i,{method:"GET",url:"/user/repos",query:{visibility:r,affiliation:e,type:n,sort:s,direction:u,per_page:_,page:m,since:c,before:d},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",422:"Validation failed, or the endpoint has been spammed."}})}static reposCreateForAuthenticatedUser(r){return o(i,{method:"POST",url:"/user/repos",body:r,mediaType:"application/json",errors:{304:"Not modified",400:"Bad Request",401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static reposListInvitationsForAuthenticatedUser(r=30,e=1){return o(i,{method:"GET",url:"/user/repository_invitations",query:{per_page:r,page:e},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static reposAcceptInvitationForAuthenticatedUser(r){return o(i,{method:"PATCH",url:"/user/repository_invitations/{invitation_id}",path:{invitation_id:r},errors:{304:"Not modified",403:"Forbidden",404:"Resource not found",409:"Conflict"}})}static reposDeclineInvitationForAuthenticatedUser(r){return o(i,{method:"DELETE",url:"/user/repository_invitations/{invitation_id}",path:{invitation_id:r},errors:{304:"Not modified",403:"Forbidden",404:"Resource not found",409:"Conflict"}})}static reposListForUser(r,e="owner",n="full_name",s,u=30,_=1){return o(i,{method:"GET",url:"/users/{username}/repos",path:{username:r},query:{type:e,sort:n,direction:s,per_page:u,page:_}})}};var Sr=class{static searchCode(r,e,n="desc",s=30,u=1){return o(i,{method:"GET",url:"/search/code",query:{q:r,sort:e,order:n,per_page:s,page:u},errors:{304:"Not modified",403:"Forbidden",422:"Validation failed, or the endpoint has been spammed.",503:"Service unavailable"}})}static searchCommits(r,e,n="desc",s=30,u=1){return o(i,{method:"GET",url:"/search/commits",query:{q:r,sort:e,order:n,per_page:s,page:u},errors:{304:"Not modified"}})}static searchIssuesAndPullRequests(r,e,n="desc",s=30,u=1){return o(i,{method:"GET",url:"/search/issues",query:{q:r,sort:e,order:n,per_page:s,page:u},errors:{304:"Not modified",403:"Forbidden",422:"Validation failed, or the endpoint has been spammed.",503:"Service unavailable"}})}static searchLabels(r,e,n,s="desc",u=30,_=1){return o(i,{method:"GET",url:"/search/labels",query:{repository_id:r,q:e,sort:n,order:s,per_page:u,page:_},errors:{304:"Not modified",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static searchRepos(r,e,n="desc",s=30,u=1){return o(i,{method:"GET",url:"/search/repositories",query:{q:r,sort:e,order:n,per_page:s,page:u},errors:{304:"Not modified",422:"Validation failed, or the endpoint has been spammed.",503:"Service unavailable"}})}static searchTopics(r,e=30,n=1){return o(i,{method:"GET",url:"/search/topics",query:{q:r,per_page:e,page:n},errors:{304:"Not modified"}})}static searchUsers(r,e,n="desc",s=30,u=1){return o(i,{method:"GET",url:"/search/users",query:{q:r,sort:e,order:n,per_page:s,page:u},errors:{304:"Not modified",422:"Validation failed, or the endpoint has been spammed.",503:"Service unavailable"}})}};var Lr=class{static secretScanningListAlertsForEnterprise(r,e,n,s,u="created",_="desc",m=30,c,d){return o(i,{method:"GET",url:"/enterprises/{enterprise}/secret-scanning/alerts",path:{enterprise:r},query:{state:e,secret_type:n,resolution:s,sort:u,direction:_,per_page:m,before:c,after:d},errors:{404:"Resource not found",503:"Service unavailable"}})}static secretScanningListAlertsForOrg(r,e,n,s,u="created",_="desc",m=1,c=30,d,v){return o(i,{method:"GET",url:"/orgs/{org}/secret-scanning/alerts",path:{org:r},query:{state:e,secret_type:n,resolution:s,sort:u,direction:_,page:m,per_page:c,before:d,after:v},errors:{404:"Resource not found",503:"Service unavailable"}})}static secretScanningListAlertsForRepo(r,e,n,s,u,_="created",m="desc",c=1,d=30,v,h){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/secret-scanning/alerts",path:{owner:r,repo:e},query:{state:n,secret_type:s,resolution:u,sort:_,direction:m,page:c,per_page:d,before:v,after:h},errors:{404:"Repository is public or secret scanning is disabled for the repository",503:"Service unavailable"}})}static secretScanningGetAlert(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}",path:{owner:r,repo:e,alert_number:n},errors:{304:"Not modified",404:"Repository is public, or secret scanning is disabled for the repository, or the resource is not found",503:"Service unavailable"}})}static secretScanningUpdateAlert(r,e,n,s){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}",path:{owner:r,repo:e,alert_number:n},body:s,mediaType:"application/json",errors:{400:"Bad request, resolution comment is invalid or the resolution was not changed.",404:"Repository is public, or secret scanning is disabled for the repository, or the resource is not found",422:"State does not match the resolution or resolution comment",503:"Service unavailable"}})}static secretScanningListLocationsForAlert(r,e,n,s=1,u=30){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations",path:{owner:r,repo:e,alert_number:n},query:{page:s,per_page:u},errors:{404:"Repository is public, or secret scanning is disabled for the repository, or the resource is not found",503:"Service unavailable"}})}};var Ur=class{static securityAdvisoriesListGlobalAdvisories(r,e="reviewed",n,s,u,_,m,c,d,v,h,R,k,b="desc",p=30,f="published"){return o(i,{method:"GET",url:"/advisories",query:{ghsa_id:r,type:e,cve_id:n,ecosystem:s,severity:u,cwes:_,is_withdrawn:m,affects:c,published:d,updated:v,modified:h,before:R,after:k,direction:b,per_page:p,sort:f},errors:{422:"Validation failed, or the endpoint has been spammed.",429:"Too many requests"}})}static securityAdvisoriesGetGlobalAdvisory(r){return o(i,{method:"GET",url:"/advisories/{ghsa_id}",path:{ghsa_id:r},errors:{404:"Resource not found"}})}static securityAdvisoriesListRepositoryAdvisories(r,e,n="desc",s="created",u,_,m=30,c){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/security-advisories",path:{owner:r,repo:e},query:{direction:n,sort:s,before:u,after:_,per_page:m,state:c},errors:{400:"Bad Request",404:"Resource not found"}})}static securityAdvisoriesCreateRepositoryAdvisory(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/security-advisories",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static securityAdvisoriesCreatePrivateVulnerabilityReport(r,e,n){return o(i,{method:"POST",url:"/repos/{owner}/{repo}/security-advisories/reports",path:{owner:r,repo:e},body:n,mediaType:"application/json",errors:{403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static securityAdvisoriesGetRepositoryAdvisory(r,e,n){return o(i,{method:"GET",url:"/repos/{owner}/{repo}/security-advisories/{ghsa_id}",path:{owner:r,repo:e,ghsa_id:n},errors:{403:"Forbidden",404:"Resource not found"}})}static securityAdvisoriesUpdateRepositoryAdvisory(r,e,n,s){return o(i,{method:"PATCH",url:"/repos/{owner}/{repo}/security-advisories/{ghsa_id}",path:{owner:r,repo:e,ghsa_id:n},body:s,mediaType:"application/json",errors:{403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}};var Mr=class{static teamsList(r,e=30,n=1){return o(i,{method:"GET",url:"/orgs/{org}/teams",path:{org:r},query:{per_page:e,page:n},errors:{403:"Forbidden"}})}static teamsCreate(r,e){return o(i,{method:"POST",url:"/orgs/{org}/teams",path:{org:r},body:e,mediaType:"application/json",errors:{403:"Forbidden",422:"Validation failed, or the endpoint has been spammed."}})}static teamsGetByName(r,e){return o(i,{method:"GET",url:"/orgs/{org}/teams/{team_slug}",path:{org:r,team_slug:e},errors:{404:"Resource not found"}})}static teamsUpdateInOrg(r,e,n){return o(i,{method:"PATCH",url:"/orgs/{org}/teams/{team_slug}",path:{org:r,team_slug:e},body:n,mediaType:"application/json",errors:{403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static teamsDeleteInOrg(r,e){return o(i,{method:"DELETE",url:"/orgs/{org}/teams/{team_slug}",path:{org:r,team_slug:e}})}static teamsListDiscussionsInOrg(r,e,n="desc",s=30,u=1,_){return o(i,{method:"GET",url:"/orgs/{org}/teams/{team_slug}/discussions",path:{org:r,team_slug:e},query:{direction:n,per_page:s,page:u,pinned:_}})}static teamsCreateDiscussionInOrg(r,e,n){return o(i,{method:"POST",url:"/orgs/{org}/teams/{team_slug}/discussions",path:{org:r,team_slug:e},body:n,mediaType:"application/json"})}static teamsGetDiscussionInOrg(r,e,n){return o(i,{method:"GET",url:"/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}",path:{org:r,team_slug:e,discussion_number:n}})}static teamsUpdateDiscussionInOrg(r,e,n,s){return o(i,{method:"PATCH",url:"/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}",path:{org:r,team_slug:e,discussion_number:n},body:s,mediaType:"application/json"})}static teamsDeleteDiscussionInOrg(r,e,n){return o(i,{method:"DELETE",url:"/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}",path:{org:r,team_slug:e,discussion_number:n}})}static teamsListDiscussionCommentsInOrg(r,e,n,s="desc",u=30,_=1){return o(i,{method:"GET",url:"/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments",path:{org:r,team_slug:e,discussion_number:n},query:{direction:s,per_page:u,page:_}})}static teamsCreateDiscussionCommentInOrg(r,e,n,s){return o(i,{method:"POST",url:"/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments",path:{org:r,team_slug:e,discussion_number:n},body:s,mediaType:"application/json"})}static teamsGetDiscussionCommentInOrg(r,e,n,s){return o(i,{method:"GET",url:"/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}",path:{org:r,team_slug:e,discussion_number:n,comment_number:s}})}static teamsUpdateDiscussionCommentInOrg(r,e,n,s,u){return o(i,{method:"PATCH",url:"/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}",path:{org:r,team_slug:e,discussion_number:n,comment_number:s},body:u,mediaType:"application/json"})}static teamsDeleteDiscussionCommentInOrg(r,e,n,s){return o(i,{method:"DELETE",url:"/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}",path:{org:r,team_slug:e,discussion_number:n,comment_number:s}})}static teamsListPendingInvitationsInOrg(r,e,n=30,s=1){return o(i,{method:"GET",url:"/orgs/{org}/teams/{team_slug}/invitations",path:{org:r,team_slug:e},query:{per_page:n,page:s}})}static teamsListMembersInOrg(r,e,n="all",s=30,u=1){return o(i,{method:"GET",url:"/orgs/{org}/teams/{team_slug}/members",path:{org:r,team_slug:e},query:{role:n,per_page:s,page:u}})}static teamsGetMembershipForUserInOrg(r,e,n){return o(i,{method:"GET",url:"/orgs/{org}/teams/{team_slug}/memberships/{username}",path:{org:r,team_slug:e,username:n},errors:{404:"if user has no team membership"}})}static teamsAddOrUpdateMembershipForUserInOrg(r,e,n,s){return o(i,{method:"PUT",url:"/orgs/{org}/teams/{team_slug}/memberships/{username}",path:{org:r,team_slug:e,username:n},body:s,mediaType:"application/json",errors:{403:"Forbidden if team synchronization is set up",422:"Unprocessable Entity if you attempt to add an organization to a team"}})}static teamsRemoveMembershipForUserInOrg(r,e,n){return o(i,{method:"DELETE",url:"/orgs/{org}/teams/{team_slug}/memberships/{username}",path:{org:r,team_slug:e,username:n},errors:{403:"Forbidden if team synchronization is set up"}})}static teamsListProjectsInOrg(r,e,n=30,s=1){return o(i,{method:"GET",url:"/orgs/{org}/teams/{team_slug}/projects",path:{org:r,team_slug:e},query:{per_page:n,page:s}})}static teamsCheckPermissionsForProjectInOrg(r,e,n){return o(i,{method:"GET",url:"/orgs/{org}/teams/{team_slug}/projects/{project_id}",path:{org:r,team_slug:e,project_id:n},errors:{404:"Not Found if project is not managed by this team"}})}static teamsAddOrUpdateProjectPermissionsInOrg(r,e,n,s){return o(i,{method:"PUT",url:"/orgs/{org}/teams/{team_slug}/projects/{project_id}",path:{org:r,team_slug:e,project_id:n},body:s,mediaType:"application/json",errors:{403:"Forbidden if the project is not owned by the organization"}})}static teamsRemoveProjectInOrg(r,e,n){return o(i,{method:"DELETE",url:"/orgs/{org}/teams/{team_slug}/projects/{project_id}",path:{org:r,team_slug:e,project_id:n}})}static teamsListReposInOrg(r,e,n=30,s=1){return o(i,{method:"GET",url:"/orgs/{org}/teams/{team_slug}/repos",path:{org:r,team_slug:e},query:{per_page:n,page:s}})}static teamsCheckPermissionsForRepoInOrg(r,e,n,s){return o(i,{method:"GET",url:"/orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}",path:{org:r,team_slug:e,owner:n,repo:s},errors:{404:"Not Found if team does not have permission for the repository"}})}static teamsAddOrUpdateRepoPermissionsInOrg(r,e,n,s,u){return o(i,{method:"PUT",url:"/orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}",path:{org:r,team_slug:e,owner:n,repo:s},body:u,mediaType:"application/json"})}static teamsRemoveRepoInOrg(r,e,n,s){return o(i,{method:"DELETE",url:"/orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}",path:{org:r,team_slug:e,owner:n,repo:s}})}static teamsListChildInOrg(r,e,n=30,s=1){return o(i,{method:"GET",url:"/orgs/{org}/teams/{team_slug}/teams",path:{org:r,team_slug:e},query:{per_page:n,page:s}})}static teamsGetLegacy(r){return o(i,{method:"GET",url:"/teams/{team_id}",path:{team_id:r},errors:{404:"Resource not found"}})}static teamsUpdateLegacy(r,e){return o(i,{method:"PATCH",url:"/teams/{team_id}",path:{team_id:r},body:e,mediaType:"application/json",errors:{403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static teamsDeleteLegacy(r){return o(i,{method:"DELETE",url:"/teams/{team_id}",path:{team_id:r},errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static teamsListDiscussionsLegacy(r,e="desc",n=30,s=1){return o(i,{method:"GET",url:"/teams/{team_id}/discussions",path:{team_id:r},query:{direction:e,per_page:n,page:s}})}static teamsCreateDiscussionLegacy(r,e){return o(i,{method:"POST",url:"/teams/{team_id}/discussions",path:{team_id:r},body:e,mediaType:"application/json"})}static teamsGetDiscussionLegacy(r,e){return o(i,{method:"GET",url:"/teams/{team_id}/discussions/{discussion_number}",path:{team_id:r,discussion_number:e}})}static teamsUpdateDiscussionLegacy(r,e,n){return o(i,{method:"PATCH",url:"/teams/{team_id}/discussions/{discussion_number}",path:{team_id:r,discussion_number:e},body:n,mediaType:"application/json"})}static teamsDeleteDiscussionLegacy(r,e){return o(i,{method:"DELETE",url:"/teams/{team_id}/discussions/{discussion_number}",path:{team_id:r,discussion_number:e}})}static teamsListDiscussionCommentsLegacy(r,e,n="desc",s=30,u=1){return o(i,{method:"GET",url:"/teams/{team_id}/discussions/{discussion_number}/comments",path:{team_id:r,discussion_number:e},query:{direction:n,per_page:s,page:u}})}static teamsCreateDiscussionCommentLegacy(r,e,n){return o(i,{method:"POST",url:"/teams/{team_id}/discussions/{discussion_number}/comments",path:{team_id:r,discussion_number:e},body:n,mediaType:"application/json"})}static teamsGetDiscussionCommentLegacy(r,e,n){return o(i,{method:"GET",url:"/teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}",path:{team_id:r,discussion_number:e,comment_number:n}})}static teamsUpdateDiscussionCommentLegacy(r,e,n,s){return o(i,{method:"PATCH",url:"/teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}",path:{team_id:r,discussion_number:e,comment_number:n},body:s,mediaType:"application/json"})}static teamsDeleteDiscussionCommentLegacy(r,e,n){return o(i,{method:"DELETE",url:"/teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}",path:{team_id:r,discussion_number:e,comment_number:n}})}static teamsListPendingInvitationsLegacy(r,e=30,n=1){return o(i,{method:"GET",url:"/teams/{team_id}/invitations",path:{team_id:r},query:{per_page:e,page:n}})}static teamsListMembersLegacy(r,e="all",n=30,s=1){return o(i,{method:"GET",url:"/teams/{team_id}/members",path:{team_id:r},query:{role:e,per_page:n,page:s},errors:{404:"Resource not found"}})}static teamsGetMemberLegacy(r,e){return o(i,{method:"GET",url:"/teams/{team_id}/members/{username}",path:{team_id:r,username:e},errors:{404:"if user is not a member"}})}static teamsAddMemberLegacy(r,e){return o(i,{method:"PUT",url:"/teams/{team_id}/members/{username}",path:{team_id:r,username:e},errors:{403:"Forbidden",404:"Not Found if team synchronization is set up",422:"Unprocessable Entity if you attempt to add an organization to a team or you attempt to add a user to a team when they are not a member of at least one other team in the same organization"}})}static teamsRemoveMemberLegacy(r,e){return o(i,{method:"DELETE",url:"/teams/{team_id}/members/{username}",path:{team_id:r,username:e},errors:{404:"Not Found if team synchronization is setup"}})}static teamsGetMembershipForUserLegacy(r,e){return o(i,{method:"GET",url:"/teams/{team_id}/memberships/{username}",path:{team_id:r,username:e},errors:{404:"Resource not found"}})}static teamsAddOrUpdateMembershipForUserLegacy(r,e,n){return o(i,{method:"PUT",url:"/teams/{team_id}/memberships/{username}",path:{team_id:r,username:e},body:n,mediaType:"application/json",errors:{403:"Forbidden if team synchronization is set up",404:"Resource not found",422:"Unprocessable Entity if you attempt to add an organization to a team"}})}static teamsRemoveMembershipForUserLegacy(r,e){return o(i,{method:"DELETE",url:"/teams/{team_id}/memberships/{username}",path:{team_id:r,username:e},errors:{403:"if team synchronization is set up"}})}static teamsListProjectsLegacy(r,e=30,n=1){return o(i,{method:"GET",url:"/teams/{team_id}/projects",path:{team_id:r},query:{per_page:e,page:n},errors:{404:"Resource not found"}})}static teamsCheckPermissionsForProjectLegacy(r,e){return o(i,{method:"GET",url:"/teams/{team_id}/projects/{project_id}",path:{team_id:r,project_id:e},errors:{404:"Not Found if project is not managed by this team"}})}static teamsAddOrUpdateProjectPermissionsLegacy(r,e,n){return o(i,{method:"PUT",url:"/teams/{team_id}/projects/{project_id}",path:{team_id:r,project_id:e},body:n,mediaType:"application/json",errors:{403:"Forbidden if the project is not owned by the organization",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static teamsRemoveProjectLegacy(r,e){return o(i,{method:"DELETE",url:"/teams/{team_id}/projects/{project_id}",path:{team_id:r,project_id:e},errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static teamsListReposLegacy(r,e=30,n=1){return o(i,{method:"GET",url:"/teams/{team_id}/repos",path:{team_id:r},query:{per_page:e,page:n},errors:{404:"Resource not found"}})}static teamsCheckPermissionsForRepoLegacy(r,e,n){return o(i,{method:"GET",url:"/teams/{team_id}/repos/{owner}/{repo}",path:{team_id:r,owner:e,repo:n},errors:{404:"Not Found if repository is not managed by this team"}})}static teamsAddOrUpdateRepoPermissionsLegacy(r,e,n,s){return o(i,{method:"PUT",url:"/teams/{team_id}/repos/{owner}/{repo}",path:{team_id:r,owner:e,repo:n},body:s,mediaType:"application/json",errors:{403:"Forbidden",422:"Validation failed, or the endpoint has been spammed."}})}static teamsRemoveRepoLegacy(r,e,n){return o(i,{method:"DELETE",url:"/teams/{team_id}/repos/{owner}/{repo}",path:{team_id:r,owner:e,repo:n}})}static teamsListChildLegacy(r,e=30,n=1){return o(i,{method:"GET",url:"/teams/{team_id}/teams",path:{team_id:r},query:{per_page:e,page:n},errors:{403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static teamsListForAuthenticatedUser(r=30,e=1){return o(i,{method:"GET",url:"/user/teams",query:{per_page:r,page:e},errors:{304:"Not modified",403:"Forbidden",404:"Resource not found"}})}};var Gr=class{static usersGetAuthenticated(){return o(i,{method:"GET",url:"/user",errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden"}})}static usersUpdateAuthenticated(r){return o(i,{method:"PATCH",url:"/user",body:r,mediaType:"application/json",errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static usersListBlockedByAuthenticatedUser(r=30,e=1){return o(i,{method:"GET",url:"/user/blocks",query:{per_page:r,page:e},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static usersCheckBlocked(r){return o(i,{method:"GET",url:"/user/blocks/{username}",path:{username:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"If the user is not blocked"}})}static usersBlock(r){return o(i,{method:"PUT",url:"/user/blocks/{username}",path:{username:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static usersUnblock(r){return o(i,{method:"DELETE",url:"/user/blocks/{username}",path:{username:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static usersSetPrimaryEmailVisibilityForAuthenticatedUser(r){return o(i,{method:"PATCH",url:"/user/email/visibility",body:r,mediaType:"application/json",errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static usersListEmailsForAuthenticatedUser(r=30,e=1){return o(i,{method:"GET",url:"/user/emails",query:{per_page:r,page:e},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static usersAddEmailForAuthenticatedUser(r){return o(i,{method:"POST",url:"/user/emails",body:r,mediaType:"application/json",errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static usersDeleteEmailForAuthenticatedUser(r){return o(i,{method:"DELETE",url:"/user/emails",body:r,mediaType:"application/json",errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static usersListFollowersForAuthenticatedUser(r=30,e=1){return o(i,{method:"GET",url:"/user/followers",query:{per_page:r,page:e},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden"}})}static usersListFollowedByAuthenticatedUser(r=30,e=1){return o(i,{method:"GET",url:"/user/following",query:{per_page:r,page:e},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden"}})}static usersCheckPersonIsFollowedByAuthenticated(r){return o(i,{method:"GET",url:"/user/following/{username}",path:{username:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"if the person is not followed by the authenticated user"}})}static usersFollow(r){return o(i,{method:"PUT",url:"/user/following/{username}",path:{username:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static usersUnfollow(r){return o(i,{method:"DELETE",url:"/user/following/{username}",path:{username:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static usersListGpgKeysForAuthenticatedUser(r=30,e=1){return o(i,{method:"GET",url:"/user/gpg_keys",query:{per_page:r,page:e},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static usersCreateGpgKeyForAuthenticatedUser(r){return o(i,{method:"POST",url:"/user/gpg_keys",body:r,mediaType:"application/json",errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static usersGetGpgKeyForAuthenticatedUser(r){return o(i,{method:"GET",url:"/user/gpg_keys/{gpg_key_id}",path:{gpg_key_id:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static usersDeleteGpgKeyForAuthenticatedUser(r){return o(i,{method:"DELETE",url:"/user/gpg_keys/{gpg_key_id}",path:{gpg_key_id:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static usersListPublicSshKeysForAuthenticatedUser(r=30,e=1){return o(i,{method:"GET",url:"/user/keys",query:{per_page:r,page:e},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static usersCreatePublicSshKeyForAuthenticatedUser(r){return o(i,{method:"POST",url:"/user/keys",body:r,mediaType:"application/json",errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static usersGetPublicSshKeyForAuthenticatedUser(r){return o(i,{method:"GET",url:"/user/keys/{key_id}",path:{key_id:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static usersDeletePublicSshKeyForAuthenticatedUser(r){return o(i,{method:"DELETE",url:"/user/keys/{key_id}",path:{key_id:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static usersListPublicEmailsForAuthenticatedUser(r=30,e=1){return o(i,{method:"GET",url:"/user/public_emails",query:{per_page:r,page:e},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static usersListSocialAccountsForAuthenticatedUser(r=30,e=1){return o(i,{method:"GET",url:"/user/social_accounts",query:{per_page:r,page:e},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static usersAddSocialAccountForAuthenticatedUser(r){return o(i,{method:"POST",url:"/user/social_accounts",body:r,mediaType:"application/json",errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static usersDeleteSocialAccountForAuthenticatedUser(r){return o(i,{method:"DELETE",url:"/user/social_accounts",body:r,mediaType:"application/json",errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static usersListSshSigningKeysForAuthenticatedUser(r=30,e=1){return o(i,{method:"GET",url:"/user/ssh_signing_keys",query:{per_page:r,page:e},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static usersCreateSshSigningKeyForAuthenticatedUser(r){return o(i,{method:"POST",url:"/user/ssh_signing_keys",body:r,mediaType:"application/json",errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static usersGetSshSigningKeyForAuthenticatedUser(r){return o(i,{method:"GET",url:"/user/ssh_signing_keys/{ssh_signing_key_id}",path:{ssh_signing_key_id:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static usersDeleteSshSigningKeyForAuthenticatedUser(r){return o(i,{method:"DELETE",url:"/user/ssh_signing_keys/{ssh_signing_key_id}",path:{ssh_signing_key_id:r},errors:{304:"Not modified",401:"Requires authentication",403:"Forbidden",404:"Resource not found"}})}static usersList(r,e=30){return o(i,{method:"GET",url:"/users",query:{since:r,per_page:e},errors:{304:"Not modified"}})}static usersGetByUsername(r){return o(i,{method:"GET",url:"/users/{username}",path:{username:r},errors:{404:"Resource not found"}})}static usersListFollowersForUser(r,e=30,n=1){return o(i,{method:"GET",url:"/users/{username}/followers",path:{username:r},query:{per_page:e,page:n}})}static usersListFollowingForUser(r,e=30,n=1){return o(i,{method:"GET",url:"/users/{username}/following",path:{username:r},query:{per_page:e,page:n}})}static usersCheckFollowingForUser(r,e){return o(i,{method:"GET",url:"/users/{username}/following/{target_user}",path:{username:r,target_user:e},errors:{404:"if the user does not follow the target user"}})}static usersListGpgKeysForUser(r,e=30,n=1){return o(i,{method:"GET",url:"/users/{username}/gpg_keys",path:{username:r},query:{per_page:e,page:n}})}static usersGetContextForUser(r,e,n){return o(i,{method:"GET",url:"/users/{username}/hovercard",path:{username:r},query:{subject_type:e,subject_id:n},errors:{404:"Resource not found",422:"Validation failed, or the endpoint has been spammed."}})}static usersListPublicKeysForUser(r,e=30,n=1){return o(i,{method:"GET",url:"/users/{username}/keys",path:{username:r},query:{per_page:e,page:n}})}static usersListSocialAccountsForUser(r,e=30,n=1){return o(i,{method:"GET",url:"/users/{username}/social_accounts",path:{username:r},query:{per_page:e,page:n}})}static usersListSshSigningKeysForUser(r,e=30,n=1){return o(i,{method:"GET",url:"/users/{username}/ssh_signing_keys",path:{username:r},query:{per_page:e,page:n}})}};export{lr as ActionsService,ar as ActivityService,J as ApiError,ur as AppsService,_r as BillingService,tr as CancelError,rr as CancelablePromise,gr as ChecksService,mr as CodeScanningService,pr as CodesOfConductService,dr as CodespacesService,cr as CopilotService,br as DependabotService,hr as DependencyGraphService,yr as EmojisService,fr as GistsService,wr as GitService,Er as GitignoreService,vr as InteractionsService,Rr as IssuesService,Tr as LicensesService,Ar as MarkdownService,kr as MetaService,xr as MigrationsService,Ir as OidcService,i as OpenAPI,Or as OrgsService,Nr as PackagesService,zr as ProjectsService,Pr as PullsService,Cr as RateLimitService,Dr as ReactionsService,qr as ReposService,Sr as SearchService,Lr as SecretScanningService,Ur as SecurityAdvisoriesService,Mr as TeamsService,Gr as UsersService,Br as _import,Wr as _package,Fr as actions_cache_list_sort,jr as actions_default_workflow_permissions,Vr as actions_workflow_access_to_repository,Hr as activity,Qr as allowed_actions,Kr as app_permissions,Yr as authentication_token,Zr as author_association,Xr as auto_merge,$r as check_run,Jr as check_run_with_simple_check_suite,re as check_suite,ee as code_scanning_alert_classification,te as code_scanning_alert_dismissed_reason,ne as code_scanning_alert_rule,se as code_scanning_alert_rule_summary,ie as code_scanning_alert_set_state,oe as code_scanning_alert_severity,le as code_scanning_alert_state,ae as code_scanning_alert_state_query,ue as code_scanning_default_setup,_e as code_scanning_default_setup_update,ge as code_scanning_sarifs_status,me as codespace,pe as codespace_machine,de as codespace_with_full_repository,ce as codespaces_org_secret,be as codespaces_secret,he as commit_comparison,ye as content_file,fe as content_submodule,we as content_symlink,Ee as dependabot_alert,ve as dependabot_alert_scope,Re as dependabot_alert_security_advisory,Te as dependabot_alert_security_vulnerability,Ae as dependabot_alert_sort,ke as dependabot_alert_with_repository,xe as dependency,Ie as deployment_reviewer_type,Oe as deployment_status,Ne as diff_entry,ze as direction,Pe as discussion,Ce as enabled_repositories,De as environment_approvals,qe as full_repository,Se as global_advisory,Le as installation,Ue as installation_token,Me as interaction_expiry,Ge as interaction_group,Be as issue,We as job,Fe as marketplace_listing_plan,je as merged_upstream,Ve as milestone,He as nullable_codespace_machine,Qe as nullable_issue,Ke as nullable_milestone,Ye as nullable_repository,Ze as nullable_scoped_installation,Xe as order,$e as org_membership,Je as org_security_product_enablement,rt as organization_actions_secret,et as organization_actions_variable,tt as organization_dependabot_secret,nt as organization_programmatic_access_grant,st as organization_programmatic_access_grant_request,it as package_type,ot as package_version,lt as package_visibility,at as pages_https_certificate,ut as per,_t as personal_access_token_request,gt as personal_access_token_sort,mt as private_vulnerability_report_create,pt as project,dt as projects_v2_item_content_type,ct as pull_request,bt as pull_request_review_comment,ht as reaction,yt as release_asset,ft as repository,wt as repository_advisory,Et as repository_advisory_create,vt as repository_advisory_credit,Rt as repository_advisory_update,Tt as repository_invitation,At as repository_rule_branch_name_pattern,kt as repository_rule_commit_author_email_pattern,xt as repository_rule_commit_message_pattern,It as repository_rule_committer_email_pattern,Ot as repository_rule_creation,Nt as repository_rule_deletion,zt as repository_rule_enforcement,Pt as repository_rule_non_fast_forward,Ct as repository_rule_pull_request,Dt as repository_rule_required_deployments,qt as repository_rule_required_linear_history,St as repository_rule_required_signatures,Lt as repository_rule_required_status_checks,Ut as repository_rule_tag_name_pattern,Mt as repository_rule_update,Gt as repository_ruleset,Bt as repository_ruleset_bypass_actor,Wt as review_comment,Ft as review_custom_gates_state_required,jt as runner_label,Vt as secret_scanning_alert_resolution_webhook,Ht as secret_scanning_alert_sort,Qt as secret_scanning_alert_state,Kt as secret_scanning_location,Yt as security_advisory_credit_types,Zt as security_advisory_ecosystems,Xt as security_and_analysis,$t as security_product,Jt as simple_check_suite,rn as sort,en as sort_starred,tn as status,nn as team_full,sn as team_membership,on as webhook_branch_protection_rule_created,ln as webhook_branch_protection_rule_deleted,an as webhook_branch_protection_rule_edited,un as webhook_check_run_completed,_n as webhook_check_run_created,gn as webhook_check_run_requested_action,mn as webhook_check_run_rerequested,pn as webhook_check_suite_completed,dn as webhook_check_suite_requested,cn as webhook_check_suite_rerequested,bn as webhook_code_scanning_alert_appeared_in_branch,hn as webhook_code_scanning_alert_closed_by_user,yn as webhook_code_scanning_alert_created,fn as webhook_code_scanning_alert_fixed,wn as webhook_code_scanning_alert_reopened,En as webhook_code_scanning_alert_reopened_by_user,vn as webhook_commit_comment_created,Rn as webhook_create,Tn as webhook_delete,An as webhook_dependabot_alert_auto_dismissed,kn as webhook_dependabot_alert_auto_reopened,xn as webhook_dependabot_alert_created,In as webhook_dependabot_alert_dismissed,On as webhook_dependabot_alert_fixed,Nn as webhook_dependabot_alert_reintroduced,zn as webhook_dependabot_alert_reopened,Pn as webhook_deploy_key_created,Cn as webhook_deploy_key_deleted,Dn as webhook_deployment_created,qn as webhook_deployment_protection_rule_requested,Sn as webhook_deployment_status_created,Ln as webhook_discussion_answered,Un as webhook_discussion_category_changed,Mn as webhook_discussion_closed,Gn as webhook_discussion_comment_created,Bn as webhook_discussion_comment_deleted,Wn as webhook_discussion_comment_edited,Fn as webhook_discussion_created,jn as webhook_discussion_deleted,Vn as webhook_discussion_edited,Hn as webhook_discussion_labeled,Qn as webhook_discussion_locked,Kn as webhook_discussion_pinned,Yn as webhook_discussion_reopened,Zn as webhook_discussion_transferred,Xn as webhook_discussion_unanswered,$n as webhook_discussion_unlabeled,Jn as webhook_discussion_unlocked,rs as webhook_discussion_unpinned,es as webhook_fork,ts as webhook_github_app_authorization_revoked,ns as webhook_installation_created,ss as webhook_installation_deleted,is as webhook_installation_new_permissions_accepted,os as webhook_installation_repositories_added,ls as webhook_installation_repositories_removed,as as webhook_installation_suspend,us as webhook_installation_unsuspend,_s as webhook_issue_comment_created,gs as webhook_issue_comment_deleted,ms as webhook_issue_comment_edited,ps as webhook_issues_assigned,ds as webhook_issues_closed,cs as webhook_issues_deleted,bs as webhook_issues_demilestoned,hs as webhook_issues_edited,ys as webhook_issues_labeled,fs as webhook_issues_locked,ws as webhook_issues_milestoned,Es as webhook_issues_opened,vs as webhook_issues_pinned,Rs as webhook_issues_reopened,Ts as webhook_issues_transferred,As as webhook_issues_unassigned,ks as webhook_issues_unlabeled,xs as webhook_issues_unlocked,Is as webhook_issues_unpinned,Os as webhook_label_created,Ns as webhook_label_deleted,zs as webhook_label_edited,Ps as webhook_marketplace_purchase_cancelled,Cs as webhook_marketplace_purchase_changed,Ds as webhook_marketplace_purchase_pending_change,qs as webhook_marketplace_purchase_pending_change_cancelled,Ss as webhook_marketplace_purchase_purchased,Ls as webhook_member_added,Us as webhook_member_edited,Ms as webhook_member_removed,Gs as webhook_membership_added,Bs as webhook_membership_removed,Ws as webhook_merge_group_checks_requested,Fs as webhook_merge_group_destroyed,js as webhook_meta_deleted,Vs as webhook_milestone_closed,Hs as webhook_milestone_created,Qs as webhook_milestone_deleted,Ks as webhook_milestone_edited,Ys as webhook_milestone_opened,Zs as webhook_org_block_blocked,Xs as webhook_org_block_unblocked,$s as webhook_organization_deleted,Js as webhook_organization_member_added,ri as webhook_organization_member_invited,ei as webhook_organization_member_removed,ti as webhook_organization_renamed,ni as webhook_package_published,si as webhook_package_updated,ii as webhook_page_build,oi as webhook_personal_access_token_request_approved,li as webhook_personal_access_token_request_cancelled,ai as webhook_personal_access_token_request_created,ui as webhook_personal_access_token_request_denied,_i as webhook_ping,gi as webhook_project_card_converted,mi as webhook_project_card_created,pi as webhook_project_card_deleted,di as webhook_project_card_edited,ci as webhook_project_card_moved,bi as webhook_project_closed,hi as webhook_project_column_created,yi as webhook_project_column_deleted,fi as webhook_project_column_edited,wi as webhook_project_column_moved,Ei as webhook_project_created,vi as webhook_project_deleted,Ri as webhook_project_edited,Ti as webhook_project_reopened,Ai as webhook_projects_v2_item_archived,ki as webhook_projects_v2_item_converted,xi as webhook_projects_v2_item_created,Ii as webhook_projects_v2_item_deleted,Oi as webhook_projects_v2_item_edited,Ni as webhook_projects_v2_item_reordered,zi as webhook_projects_v2_item_restored,Pi as webhook_projects_v2_project_closed,Ci as webhook_projects_v2_project_created,Di as webhook_projects_v2_project_deleted,qi as webhook_projects_v2_project_edited,Si as webhook_projects_v2_project_reopened,Li as webhook_pull_request_assigned,Ui as webhook_pull_request_auto_merge_disabled,Mi as webhook_pull_request_auto_merge_enabled,Gi as webhook_pull_request_closed,Bi as webhook_pull_request_converted_to_draft,Wi as webhook_pull_request_demilestoned,Fi as webhook_pull_request_dequeued,ji as webhook_pull_request_edited,Vi as webhook_pull_request_enqueued,Hi as webhook_pull_request_labeled,Qi as webhook_pull_request_locked,Ki as webhook_pull_request_milestoned,Yi as webhook_pull_request_opened,Zi as webhook_pull_request_ready_for_review,Xi as webhook_pull_request_reopened,$i as webhook_pull_request_review_comment_created,Ji as webhook_pull_request_review_comment_deleted,ro as webhook_pull_request_review_comment_edited,eo as webhook_pull_request_review_dismissed,to as webhook_pull_request_review_edited,no as webhook_pull_request_review_request_removed,so as webhook_pull_request_review_requested,io as webhook_pull_request_review_submitted,oo as webhook_pull_request_review_thread_resolved,lo as webhook_pull_request_review_thread_unresolved,ao as webhook_pull_request_synchronize,uo as webhook_pull_request_unassigned,_o as webhook_pull_request_unlabeled,go as webhook_pull_request_unlocked,mo as webhook_push,po as webhook_registry_package_published,co as webhook_release_created,bo as webhook_release_deleted,ho as webhook_release_edited,yo as webhook_release_prereleased,fo as webhook_release_published,wo as webhook_release_released,Eo as webhook_release_unpublished,vo as webhook_repository_advisory_published,Ro as webhook_repository_advisory_reported,To as webhook_repository_archived,Ao as webhook_repository_created,ko as webhook_repository_deleted,xo as webhook_repository_edited,Io as webhook_repository_import,Oo as webhook_repository_privatized,No as webhook_repository_publicized,zo as webhook_repository_renamed,Po as webhook_repository_transferred,Co as webhook_repository_unarchived,Do as webhook_repository_vulnerability_alert_create,qo as webhook_repository_vulnerability_alert_dismiss,So as webhook_repository_vulnerability_alert_reopen,Lo as webhook_repository_vulnerability_alert_resolve,Uo as webhook_secret_scanning_alert_created,Mo as webhook_secret_scanning_alert_location_created,Go as webhook_secret_scanning_alert_reopened,Bo as webhook_secret_scanning_alert_resolved,Wo as webhook_secret_scanning_alert_revoked,Fo as webhook_security_advisory_published,jo as webhook_security_advisory_updated,Vo as webhook_security_advisory_withdrawn,Ho as webhook_sponsorship_cancelled,Qo as webhook_sponsorship_created,Ko as webhook_sponsorship_edited,Yo as webhook_sponsorship_pending_cancellation,Zo as webhook_sponsorship_pending_tier_change,Xo as webhook_sponsorship_tier_changed,$o as webhook_star_created,Jo as webhook_star_deleted,rl as webhook_status,el as webhook_team_add,tl as webhook_team_added_to_repository,nl as webhook_team_created,sl as webhook_team_deleted,il as webhook_team_edited,ol as webhook_team_removed_from_repository,ll as webhook_watch_started,al as webhook_workflow_job_completed,ul as webhook_workflow_job_in_progress,_l as webhook_workflow_job_queued,gl as webhook_workflow_job_waiting,ml as webhook_workflow_run_completed,pl as webhook_workflow_run_in_progress,dl as webhook_workflow_run_requested,cl as workflow,bl as workflow_run_status};
+                - Git LFS support not enabled because Git LFS is disabled for <owner>.`,
+      },
+    });
+  }
+  static reposDisableLfsForRepo(r, e) {
+    return o(i, { method: "DELETE", url: "/repos/{owner}/{repo}/lfs", path: { owner: r, repo: e } });
+  }
+  static reposMergeUpstream(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/merge-upstream",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        409: "The branch could not be synced because of a merge conflict",
+        422: "The branch could not be synced for some other reason",
+      },
+    });
+  }
+  static reposMerge(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/merges",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        403: "Forbidden",
+        404: "Not Found when the base or head does not exist",
+        409: "Conflict when there is a merge conflict",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static reposGetPages(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/pages",
+      path: { owner: r, repo: e },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposCreatePagesSite(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/pages",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 409: "Conflict", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposUpdateInformationAboutPagesSite(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/pages",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 400: "Bad Request", 409: "Conflict", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposDeletePagesSite(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/pages",
+      path: { owner: r, repo: e },
+      errors: {
+        404: "Resource not found",
+        409: "Conflict",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static reposListPagesBuilds(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/pages/builds",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+    });
+  }
+  static reposRequestPagesBuild(r, e) {
+    return o(i, { method: "POST", url: "/repos/{owner}/{repo}/pages/builds", path: { owner: r, repo: e } });
+  }
+  static reposGetLatestPagesBuild(r, e) {
+    return o(i, { method: "GET", url: "/repos/{owner}/{repo}/pages/builds/latest", path: { owner: r, repo: e } });
+  }
+  static reposGetPagesBuild(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/pages/builds/{build_id}",
+      path: { owner: r, repo: e, build_id: n },
+    });
+  }
+  static reposCreatePagesDeployment(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/pages/deployment",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        400: "Bad Request",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static reposGetPagesHealthCheck(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/pages/health",
+      path: { owner: r, repo: e },
+      errors: {
+        400: "Custom domains are not available for GitHub Pages",
+        404: "Resource not found",
+        422: "There isn't a CNAME for this page",
+      },
+    });
+  }
+  static reposGetReadme(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/readme",
+      path: { owner: r, repo: e },
+      query: { ref: n },
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposGetReadmeInDirectory(r, e, n, s) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/readme/{dir}",
+      path: { owner: r, repo: e, dir: n },
+      query: { ref: s },
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposListReleases(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/releases",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposCreateRelease(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/releases",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        404: "Not Found if the discussion category name is invalid",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static reposGetReleaseAsset(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/releases/assets/{asset_id}",
+      path: { owner: r, repo: e, asset_id: n },
+      errors: { 302: "Found", 404: "Resource not found" },
+    });
+  }
+  static reposUpdateReleaseAsset(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/releases/assets/{asset_id}",
+      path: { owner: r, repo: e, asset_id: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static reposDeleteReleaseAsset(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/releases/assets/{asset_id}",
+      path: { owner: r, repo: e, asset_id: n },
+    });
+  }
+  static reposGenerateReleaseNotes(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/releases/generate-notes",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposGetLatestRelease(r, e) {
+    return o(i, { method: "GET", url: "/repos/{owner}/{repo}/releases/latest", path: { owner: r, repo: e } });
+  }
+  static reposGetReleaseByTag(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/releases/tags/{tag}",
+      path: { owner: r, repo: e, tag: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposGetRelease(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/releases/{release_id}",
+      path: { owner: r, repo: e, release_id: n },
+      errors: { 401: "Unauthorized" },
+    });
+  }
+  static reposUpdateRelease(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/releases/{release_id}",
+      path: { owner: r, repo: e, release_id: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 404: "Not Found if the discussion category name is invalid" },
+    });
+  }
+  static reposDeleteRelease(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/releases/{release_id}",
+      path: { owner: r, repo: e, release_id: n },
+    });
+  }
+  static reposListReleaseAssets(r, e, n, s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/releases/{release_id}/assets",
+      path: { owner: r, repo: e, release_id: n },
+      query: { per_page: s, page: u },
+    });
+  }
+  static reposUploadReleaseAsset(r, e, n, s, u, _) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/releases/{release_id}/assets",
+      path: { owner: r, repo: e, release_id: n },
+      query: { name: s, label: u },
+      body: _,
+      mediaType: "application/octet-stream",
+      errors: { 422: "Response if you upload an asset with the same filename as another uploaded asset" },
+    });
+  }
+  static reposGetBranchRules(r, e, n, s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/rules/branches/{branch}",
+      path: { owner: r, repo: e, branch: n },
+      query: { per_page: s, page: u },
+    });
+  }
+  static reposGetRepoRulesets(r, e, n = 30, s = 1, u = !0) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/rulesets",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s, includes_parents: u },
+      errors: { 404: "Resource not found", 500: "Internal Error" },
+    });
+  }
+  static reposCreateRepoRuleset(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/rulesets",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 500: "Internal Error" },
+    });
+  }
+  static reposGetRepoRuleset(r, e, n, s = !0) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/rulesets/{ruleset_id}",
+      path: { owner: r, repo: e, ruleset_id: n },
+      query: { includes_parents: s },
+      errors: { 404: "Resource not found", 500: "Internal Error" },
+    });
+  }
+  static reposUpdateRepoRuleset(r, e, n, s) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/rulesets/{ruleset_id}",
+      path: { owner: r, repo: e, ruleset_id: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 500: "Internal Error" },
+    });
+  }
+  static reposDeleteRepoRuleset(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/rulesets/{ruleset_id}",
+      path: { owner: r, repo: e, ruleset_id: n },
+      errors: { 404: "Resource not found", 500: "Internal Error" },
+    });
+  }
+  static reposGetCodeFrequencyStats(r, e) {
+    return o(i, { method: "GET", url: "/repos/{owner}/{repo}/stats/code_frequency", path: { owner: r, repo: e } });
+  }
+  static reposGetCommitActivityStats(r, e) {
+    return o(i, { method: "GET", url: "/repos/{owner}/{repo}/stats/commit_activity", path: { owner: r, repo: e } });
+  }
+  static reposGetContributorsStats(r, e) {
+    return o(i, { method: "GET", url: "/repos/{owner}/{repo}/stats/contributors", path: { owner: r, repo: e } });
+  }
+  static reposGetParticipationStats(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/stats/participation",
+      path: { owner: r, repo: e },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposGetPunchCardStats(r, e) {
+    return o(i, { method: "GET", url: "/repos/{owner}/{repo}/stats/punch_card", path: { owner: r, repo: e } });
+  }
+  static reposCreateCommitStatus(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/statuses/{sha}",
+      path: { owner: r, repo: e, sha: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static reposListTags(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/tags",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+    });
+  }
+  static reposListTagProtection(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/tags/protection",
+      path: { owner: r, repo: e },
+      errors: { 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static reposCreateTagProtection(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/tags/protection",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static reposDeleteTagProtection(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/repos/{owner}/{repo}/tags/protection/{tag_protection_id}",
+      path: { owner: r, repo: e, tag_protection_id: n },
+      errors: { 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static reposDownloadTarballArchive(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/tarball/{ref}",
+      path: { owner: r, repo: e, ref: n },
+      errors: { 302: "Response" },
+    });
+  }
+  static reposListTeams(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/teams",
+      path: { owner: r, repo: e },
+      query: { per_page: n, page: s },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposGetAllTopics(r, e, n = 1, s = 30) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/topics",
+      path: { owner: r, repo: e },
+      query: { page: n, per_page: s },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static reposReplaceAllTopics(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/repos/{owner}/{repo}/topics",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposGetClones(r, e, n = "day") {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/traffic/clones",
+      path: { owner: r, repo: e },
+      query: { per: n },
+      errors: { 403: "Forbidden" },
+    });
+  }
+  static reposGetTopPaths(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/traffic/popular/paths",
+      path: { owner: r, repo: e },
+      errors: { 403: "Forbidden" },
+    });
+  }
+  static reposGetTopReferrers(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/traffic/popular/referrers",
+      path: { owner: r, repo: e },
+      errors: { 403: "Forbidden" },
+    });
+  }
+  static reposGetViews(r, e, n = "day") {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/traffic/views",
+      path: { owner: r, repo: e },
+      query: { per: n },
+      errors: { 403: "Forbidden" },
+    });
+  }
+  static reposTransfer(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/transfer",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+    });
+  }
+  static reposCheckVulnerabilityAlerts(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/vulnerability-alerts",
+      path: { owner: r, repo: e },
+      errors: { 404: "Not Found if repository is not enabled with vulnerability alerts" },
+    });
+  }
+  static reposEnableVulnerabilityAlerts(r, e) {
+    return o(i, { method: "PUT", url: "/repos/{owner}/{repo}/vulnerability-alerts", path: { owner: r, repo: e } });
+  }
+  static reposDisableVulnerabilityAlerts(r, e) {
+    return o(i, { method: "DELETE", url: "/repos/{owner}/{repo}/vulnerability-alerts", path: { owner: r, repo: e } });
+  }
+  static reposDownloadZipballArchive(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/zipball/{ref}",
+      path: { owner: r, repo: e, ref: n },
+      errors: { 302: "Response" },
+    });
+  }
+  static reposCreateUsingTemplate(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{template_owner}/{template_repo}/generate",
+      path: { template_owner: r, template_repo: e },
+      body: n,
+      mediaType: "application/json",
+    });
+  }
+  static reposListPublic(r) {
+    return o(i, {
+      method: "GET",
+      url: "/repositories",
+      query: { since: r },
+      errors: { 304: "Not modified", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static reposListForAuthenticatedUser(
+    r = "all",
+    e = "owner,collaborator,organization_member",
+    n = "all",
+    s = "full_name",
+    u,
+    _ = 30,
+    m = 1,
+    c,
+    d,
+  ) {
+    return o(i, {
+      method: "GET",
+      url: "/user/repos",
+      query: {
+        visibility: r,
+        affiliation: e,
+        type: n,
+        sort: s,
+        direction: u,
+        per_page: _,
+        page: m,
+        since: c,
+        before: d,
+      },
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static reposCreateForAuthenticatedUser(r) {
+    return o(i, {
+      method: "POST",
+      url: "/user/repos",
+      body: r,
+      mediaType: "application/json",
+      errors: {
+        304: "Not modified",
+        400: "Bad Request",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static reposListInvitationsForAuthenticatedUser(r = 30, e = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/user/repository_invitations",
+      query: { per_page: r, page: e },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static reposAcceptInvitationForAuthenticatedUser(r) {
+    return o(i, {
+      method: "PATCH",
+      url: "/user/repository_invitations/{invitation_id}",
+      path: { invitation_id: r },
+      errors: { 304: "Not modified", 403: "Forbidden", 404: "Resource not found", 409: "Conflict" },
+    });
+  }
+  static reposDeclineInvitationForAuthenticatedUser(r) {
+    return o(i, {
+      method: "DELETE",
+      url: "/user/repository_invitations/{invitation_id}",
+      path: { invitation_id: r },
+      errors: { 304: "Not modified", 403: "Forbidden", 404: "Resource not found", 409: "Conflict" },
+    });
+  }
+  static reposListForUser(r, e = "owner", n = "full_name", s, u = 30, _ = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}/repos",
+      path: { username: r },
+      query: { type: e, sort: n, direction: s, per_page: u, page: _ },
+    });
+  }
+};
+var Sr = class {
+  static searchCode(r, e, n = "desc", s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/search/code",
+      query: { q: r, sort: e, order: n, per_page: s, page: u },
+      errors: {
+        304: "Not modified",
+        403: "Forbidden",
+        422: "Validation failed, or the endpoint has been spammed.",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static searchCommits(r, e, n = "desc", s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/search/commits",
+      query: { q: r, sort: e, order: n, per_page: s, page: u },
+      errors: { 304: "Not modified" },
+    });
+  }
+  static searchIssuesAndPullRequests(r, e, n = "desc", s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/search/issues",
+      query: { q: r, sort: e, order: n, per_page: s, page: u },
+      errors: {
+        304: "Not modified",
+        403: "Forbidden",
+        422: "Validation failed, or the endpoint has been spammed.",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static searchLabels(r, e, n, s = "desc", u = 30, _ = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/search/labels",
+      query: { repository_id: r, q: e, sort: n, order: s, per_page: u, page: _ },
+      errors: {
+        304: "Not modified",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static searchRepos(r, e, n = "desc", s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/search/repositories",
+      query: { q: r, sort: e, order: n, per_page: s, page: u },
+      errors: {
+        304: "Not modified",
+        422: "Validation failed, or the endpoint has been spammed.",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static searchTopics(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/search/topics",
+      query: { q: r, per_page: e, page: n },
+      errors: { 304: "Not modified" },
+    });
+  }
+  static searchUsers(r, e, n = "desc", s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/search/users",
+      query: { q: r, sort: e, order: n, per_page: s, page: u },
+      errors: {
+        304: "Not modified",
+        422: "Validation failed, or the endpoint has been spammed.",
+        503: "Service unavailable",
+      },
+    });
+  }
+};
+var Lr = class {
+  static secretScanningListAlertsForEnterprise(r, e, n, s, u = "created", _ = "desc", m = 30, c, d) {
+    return o(i, {
+      method: "GET",
+      url: "/enterprises/{enterprise}/secret-scanning/alerts",
+      path: { enterprise: r },
+      query: { state: e, secret_type: n, resolution: s, sort: u, direction: _, per_page: m, before: c, after: d },
+      errors: { 404: "Resource not found", 503: "Service unavailable" },
+    });
+  }
+  static secretScanningListAlertsForOrg(r, e, n, s, u = "created", _ = "desc", m = 1, c = 30, d, v) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/secret-scanning/alerts",
+      path: { org: r },
+      query: {
+        state: e,
+        secret_type: n,
+        resolution: s,
+        sort: u,
+        direction: _,
+        page: m,
+        per_page: c,
+        before: d,
+        after: v,
+      },
+      errors: { 404: "Resource not found", 503: "Service unavailable" },
+    });
+  }
+  static secretScanningListAlertsForRepo(r, e, n, s, u, _ = "created", m = "desc", c = 1, d = 30, v, h) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/secret-scanning/alerts",
+      path: { owner: r, repo: e },
+      query: {
+        state: n,
+        secret_type: s,
+        resolution: u,
+        sort: _,
+        direction: m,
+        page: c,
+        per_page: d,
+        before: v,
+        after: h,
+      },
+      errors: {
+        404: "Repository is public or secret scanning is disabled for the repository",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static secretScanningGetAlert(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}",
+      path: { owner: r, repo: e, alert_number: n },
+      errors: {
+        304: "Not modified",
+        404: "Repository is public, or secret scanning is disabled for the repository, or the resource is not found",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static secretScanningUpdateAlert(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}",
+      path: { owner: r, repo: e, alert_number: n },
+      body: s,
+      mediaType: "application/json",
+      errors: {
+        400: "Bad request, resolution comment is invalid or the resolution was not changed.",
+        404: "Repository is public, or secret scanning is disabled for the repository, or the resource is not found",
+        422: "State does not match the resolution or resolution comment",
+        503: "Service unavailable",
+      },
+    });
+  }
+  static secretScanningListLocationsForAlert(r, e, n, s = 1, u = 30) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations",
+      path: { owner: r, repo: e, alert_number: n },
+      query: { page: s, per_page: u },
+      errors: {
+        404: "Repository is public, or secret scanning is disabled for the repository, or the resource is not found",
+        503: "Service unavailable",
+      },
+    });
+  }
+};
+var Ur = class {
+  static securityAdvisoriesListGlobalAdvisories(
+    r,
+    e = "reviewed",
+    n,
+    s,
+    u,
+    _,
+    m,
+    c,
+    d,
+    v,
+    h,
+    R,
+    k,
+    b = "desc",
+    p = 30,
+    f = "published",
+  ) {
+    return o(i, {
+      method: "GET",
+      url: "/advisories",
+      query: {
+        ghsa_id: r,
+        type: e,
+        cve_id: n,
+        ecosystem: s,
+        severity: u,
+        cwes: _,
+        is_withdrawn: m,
+        affects: c,
+        published: d,
+        updated: v,
+        modified: h,
+        before: R,
+        after: k,
+        direction: b,
+        per_page: p,
+        sort: f,
+      },
+      errors: { 422: "Validation failed, or the endpoint has been spammed.", 429: "Too many requests" },
+    });
+  }
+  static securityAdvisoriesGetGlobalAdvisory(r) {
+    return o(i, {
+      method: "GET",
+      url: "/advisories/{ghsa_id}",
+      path: { ghsa_id: r },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static securityAdvisoriesListRepositoryAdvisories(r, e, n = "desc", s = "created", u, _, m = 30, c) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/security-advisories",
+      path: { owner: r, repo: e },
+      query: { direction: n, sort: s, before: u, after: _, per_page: m, state: c },
+      errors: { 400: "Bad Request", 404: "Resource not found" },
+    });
+  }
+  static securityAdvisoriesCreateRepositoryAdvisory(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/security-advisories",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static securityAdvisoriesCreatePrivateVulnerabilityReport(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/repos/{owner}/{repo}/security-advisories/reports",
+      path: { owner: r, repo: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static securityAdvisoriesGetRepositoryAdvisory(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/repos/{owner}/{repo}/security-advisories/{ghsa_id}",
+      path: { owner: r, repo: e, ghsa_id: n },
+      errors: { 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static securityAdvisoriesUpdateRepositoryAdvisory(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/repos/{owner}/{repo}/security-advisories/{ghsa_id}",
+      path: { owner: r, repo: e, ghsa_id: n },
+      body: s,
+      mediaType: "application/json",
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+};
+var Mr = class {
+  static teamsList(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/teams",
+      path: { org: r },
+      query: { per_page: e, page: n },
+      errors: { 403: "Forbidden" },
+    });
+  }
+  static teamsCreate(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/teams",
+      path: { org: r },
+      body: e,
+      mediaType: "application/json",
+      errors: { 403: "Forbidden", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static teamsGetByName(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/teams/{team_slug}",
+      path: { org: r, team_slug: e },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static teamsUpdateInOrg(r, e, n) {
+    return o(i, {
+      method: "PATCH",
+      url: "/orgs/{org}/teams/{team_slug}",
+      path: { org: r, team_slug: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static teamsDeleteInOrg(r, e) {
+    return o(i, { method: "DELETE", url: "/orgs/{org}/teams/{team_slug}", path: { org: r, team_slug: e } });
+  }
+  static teamsListDiscussionsInOrg(r, e, n = "desc", s = 30, u = 1, _) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/teams/{team_slug}/discussions",
+      path: { org: r, team_slug: e },
+      query: { direction: n, per_page: s, page: u, pinned: _ },
+    });
+  }
+  static teamsCreateDiscussionInOrg(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/teams/{team_slug}/discussions",
+      path: { org: r, team_slug: e },
+      body: n,
+      mediaType: "application/json",
+    });
+  }
+  static teamsGetDiscussionInOrg(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}",
+      path: { org: r, team_slug: e, discussion_number: n },
+    });
+  }
+  static teamsUpdateDiscussionInOrg(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}",
+      path: { org: r, team_slug: e, discussion_number: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static teamsDeleteDiscussionInOrg(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}",
+      path: { org: r, team_slug: e, discussion_number: n },
+    });
+  }
+  static teamsListDiscussionCommentsInOrg(r, e, n, s = "desc", u = 30, _ = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments",
+      path: { org: r, team_slug: e, discussion_number: n },
+      query: { direction: s, per_page: u, page: _ },
+    });
+  }
+  static teamsCreateDiscussionCommentInOrg(r, e, n, s) {
+    return o(i, {
+      method: "POST",
+      url: "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments",
+      path: { org: r, team_slug: e, discussion_number: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static teamsGetDiscussionCommentInOrg(r, e, n, s) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}",
+      path: { org: r, team_slug: e, discussion_number: n, comment_number: s },
+    });
+  }
+  static teamsUpdateDiscussionCommentInOrg(r, e, n, s, u) {
+    return o(i, {
+      method: "PATCH",
+      url: "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}",
+      path: { org: r, team_slug: e, discussion_number: n, comment_number: s },
+      body: u,
+      mediaType: "application/json",
+    });
+  }
+  static teamsDeleteDiscussionCommentInOrg(r, e, n, s) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}",
+      path: { org: r, team_slug: e, discussion_number: n, comment_number: s },
+    });
+  }
+  static teamsListPendingInvitationsInOrg(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/teams/{team_slug}/invitations",
+      path: { org: r, team_slug: e },
+      query: { per_page: n, page: s },
+    });
+  }
+  static teamsListMembersInOrg(r, e, n = "all", s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/teams/{team_slug}/members",
+      path: { org: r, team_slug: e },
+      query: { role: n, per_page: s, page: u },
+    });
+  }
+  static teamsGetMembershipForUserInOrg(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/teams/{team_slug}/memberships/{username}",
+      path: { org: r, team_slug: e, username: n },
+      errors: { 404: "if user has no team membership" },
+    });
+  }
+  static teamsAddOrUpdateMembershipForUserInOrg(r, e, n, s) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/teams/{team_slug}/memberships/{username}",
+      path: { org: r, team_slug: e, username: n },
+      body: s,
+      mediaType: "application/json",
+      errors: {
+        403: "Forbidden if team synchronization is set up",
+        422: "Unprocessable Entity if you attempt to add an organization to a team",
+      },
+    });
+  }
+  static teamsRemoveMembershipForUserInOrg(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/teams/{team_slug}/memberships/{username}",
+      path: { org: r, team_slug: e, username: n },
+      errors: { 403: "Forbidden if team synchronization is set up" },
+    });
+  }
+  static teamsListProjectsInOrg(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/teams/{team_slug}/projects",
+      path: { org: r, team_slug: e },
+      query: { per_page: n, page: s },
+    });
+  }
+  static teamsCheckPermissionsForProjectInOrg(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/teams/{team_slug}/projects/{project_id}",
+      path: { org: r, team_slug: e, project_id: n },
+      errors: { 404: "Not Found if project is not managed by this team" },
+    });
+  }
+  static teamsAddOrUpdateProjectPermissionsInOrg(r, e, n, s) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/teams/{team_slug}/projects/{project_id}",
+      path: { org: r, team_slug: e, project_id: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 403: "Forbidden if the project is not owned by the organization" },
+    });
+  }
+  static teamsRemoveProjectInOrg(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/teams/{team_slug}/projects/{project_id}",
+      path: { org: r, team_slug: e, project_id: n },
+    });
+  }
+  static teamsListReposInOrg(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/teams/{team_slug}/repos",
+      path: { org: r, team_slug: e },
+      query: { per_page: n, page: s },
+    });
+  }
+  static teamsCheckPermissionsForRepoInOrg(r, e, n, s) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}",
+      path: { org: r, team_slug: e, owner: n, repo: s },
+      errors: { 404: "Not Found if team does not have permission for the repository" },
+    });
+  }
+  static teamsAddOrUpdateRepoPermissionsInOrg(r, e, n, s, u) {
+    return o(i, {
+      method: "PUT",
+      url: "/orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}",
+      path: { org: r, team_slug: e, owner: n, repo: s },
+      body: u,
+      mediaType: "application/json",
+    });
+  }
+  static teamsRemoveRepoInOrg(r, e, n, s) {
+    return o(i, {
+      method: "DELETE",
+      url: "/orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}",
+      path: { org: r, team_slug: e, owner: n, repo: s },
+    });
+  }
+  static teamsListChildInOrg(r, e, n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/orgs/{org}/teams/{team_slug}/teams",
+      path: { org: r, team_slug: e },
+      query: { per_page: n, page: s },
+    });
+  }
+  static teamsGetLegacy(r) {
+    return o(i, {
+      method: "GET",
+      url: "/teams/{team_id}",
+      path: { team_id: r },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static teamsUpdateLegacy(r, e) {
+    return o(i, {
+      method: "PATCH",
+      url: "/teams/{team_id}",
+      path: { team_id: r },
+      body: e,
+      mediaType: "application/json",
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static teamsDeleteLegacy(r) {
+    return o(i, {
+      method: "DELETE",
+      url: "/teams/{team_id}",
+      path: { team_id: r },
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static teamsListDiscussionsLegacy(r, e = "desc", n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/teams/{team_id}/discussions",
+      path: { team_id: r },
+      query: { direction: e, per_page: n, page: s },
+    });
+  }
+  static teamsCreateDiscussionLegacy(r, e) {
+    return o(i, {
+      method: "POST",
+      url: "/teams/{team_id}/discussions",
+      path: { team_id: r },
+      body: e,
+      mediaType: "application/json",
+    });
+  }
+  static teamsGetDiscussionLegacy(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/teams/{team_id}/discussions/{discussion_number}",
+      path: { team_id: r, discussion_number: e },
+    });
+  }
+  static teamsUpdateDiscussionLegacy(r, e, n) {
+    return o(i, {
+      method: "PATCH",
+      url: "/teams/{team_id}/discussions/{discussion_number}",
+      path: { team_id: r, discussion_number: e },
+      body: n,
+      mediaType: "application/json",
+    });
+  }
+  static teamsDeleteDiscussionLegacy(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/teams/{team_id}/discussions/{discussion_number}",
+      path: { team_id: r, discussion_number: e },
+    });
+  }
+  static teamsListDiscussionCommentsLegacy(r, e, n = "desc", s = 30, u = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/teams/{team_id}/discussions/{discussion_number}/comments",
+      path: { team_id: r, discussion_number: e },
+      query: { direction: n, per_page: s, page: u },
+    });
+  }
+  static teamsCreateDiscussionCommentLegacy(r, e, n) {
+    return o(i, {
+      method: "POST",
+      url: "/teams/{team_id}/discussions/{discussion_number}/comments",
+      path: { team_id: r, discussion_number: e },
+      body: n,
+      mediaType: "application/json",
+    });
+  }
+  static teamsGetDiscussionCommentLegacy(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}",
+      path: { team_id: r, discussion_number: e, comment_number: n },
+    });
+  }
+  static teamsUpdateDiscussionCommentLegacy(r, e, n, s) {
+    return o(i, {
+      method: "PATCH",
+      url: "/teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}",
+      path: { team_id: r, discussion_number: e, comment_number: n },
+      body: s,
+      mediaType: "application/json",
+    });
+  }
+  static teamsDeleteDiscussionCommentLegacy(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}",
+      path: { team_id: r, discussion_number: e, comment_number: n },
+    });
+  }
+  static teamsListPendingInvitationsLegacy(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/teams/{team_id}/invitations",
+      path: { team_id: r },
+      query: { per_page: e, page: n },
+    });
+  }
+  static teamsListMembersLegacy(r, e = "all", n = 30, s = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/teams/{team_id}/members",
+      path: { team_id: r },
+      query: { role: e, per_page: n, page: s },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static teamsGetMemberLegacy(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/teams/{team_id}/members/{username}",
+      path: { team_id: r, username: e },
+      errors: { 404: "if user is not a member" },
+    });
+  }
+  static teamsAddMemberLegacy(r, e) {
+    return o(i, {
+      method: "PUT",
+      url: "/teams/{team_id}/members/{username}",
+      path: { team_id: r, username: e },
+      errors: {
+        403: "Forbidden",
+        404: "Not Found if team synchronization is set up",
+        422: "Unprocessable Entity if you attempt to add an organization to a team or you attempt to add a user to a team when they are not a member of at least one other team in the same organization",
+      },
+    });
+  }
+  static teamsRemoveMemberLegacy(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/teams/{team_id}/members/{username}",
+      path: { team_id: r, username: e },
+      errors: { 404: "Not Found if team synchronization is setup" },
+    });
+  }
+  static teamsGetMembershipForUserLegacy(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/teams/{team_id}/memberships/{username}",
+      path: { team_id: r, username: e },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static teamsAddOrUpdateMembershipForUserLegacy(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/teams/{team_id}/memberships/{username}",
+      path: { team_id: r, username: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        403: "Forbidden if team synchronization is set up",
+        404: "Resource not found",
+        422: "Unprocessable Entity if you attempt to add an organization to a team",
+      },
+    });
+  }
+  static teamsRemoveMembershipForUserLegacy(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/teams/{team_id}/memberships/{username}",
+      path: { team_id: r, username: e },
+      errors: { 403: "if team synchronization is set up" },
+    });
+  }
+  static teamsListProjectsLegacy(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/teams/{team_id}/projects",
+      path: { team_id: r },
+      query: { per_page: e, page: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static teamsCheckPermissionsForProjectLegacy(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/teams/{team_id}/projects/{project_id}",
+      path: { team_id: r, project_id: e },
+      errors: { 404: "Not Found if project is not managed by this team" },
+    });
+  }
+  static teamsAddOrUpdateProjectPermissionsLegacy(r, e, n) {
+    return o(i, {
+      method: "PUT",
+      url: "/teams/{team_id}/projects/{project_id}",
+      path: { team_id: r, project_id: e },
+      body: n,
+      mediaType: "application/json",
+      errors: {
+        403: "Forbidden if the project is not owned by the organization",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static teamsRemoveProjectLegacy(r, e) {
+    return o(i, {
+      method: "DELETE",
+      url: "/teams/{team_id}/projects/{project_id}",
+      path: { team_id: r, project_id: e },
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static teamsListReposLegacy(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/teams/{team_id}/repos",
+      path: { team_id: r },
+      query: { per_page: e, page: n },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static teamsCheckPermissionsForRepoLegacy(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/teams/{team_id}/repos/{owner}/{repo}",
+      path: { team_id: r, owner: e, repo: n },
+      errors: { 404: "Not Found if repository is not managed by this team" },
+    });
+  }
+  static teamsAddOrUpdateRepoPermissionsLegacy(r, e, n, s) {
+    return o(i, {
+      method: "PUT",
+      url: "/teams/{team_id}/repos/{owner}/{repo}",
+      path: { team_id: r, owner: e, repo: n },
+      body: s,
+      mediaType: "application/json",
+      errors: { 403: "Forbidden", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static teamsRemoveRepoLegacy(r, e, n) {
+    return o(i, {
+      method: "DELETE",
+      url: "/teams/{team_id}/repos/{owner}/{repo}",
+      path: { team_id: r, owner: e, repo: n },
+    });
+  }
+  static teamsListChildLegacy(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/teams/{team_id}/teams",
+      path: { team_id: r },
+      query: { per_page: e, page: n },
+      errors: {
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static teamsListForAuthenticatedUser(r = 30, e = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/user/teams",
+      query: { per_page: r, page: e },
+      errors: { 304: "Not modified", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+};
+var Gr = class {
+  static usersGetAuthenticated() {
+    return o(i, {
+      method: "GET",
+      url: "/user",
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden" },
+    });
+  }
+  static usersUpdateAuthenticated(r) {
+    return o(i, {
+      method: "PATCH",
+      url: "/user",
+      body: r,
+      mediaType: "application/json",
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static usersListBlockedByAuthenticatedUser(r = 30, e = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/user/blocks",
+      query: { per_page: r, page: e },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static usersCheckBlocked(r) {
+    return o(i, {
+      method: "GET",
+      url: "/user/blocks/{username}",
+      path: { username: r },
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "If the user is not blocked",
+      },
+    });
+  }
+  static usersBlock(r) {
+    return o(i, {
+      method: "PUT",
+      url: "/user/blocks/{username}",
+      path: { username: r },
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static usersUnblock(r) {
+    return o(i, {
+      method: "DELETE",
+      url: "/user/blocks/{username}",
+      path: { username: r },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static usersSetPrimaryEmailVisibilityForAuthenticatedUser(r) {
+    return o(i, {
+      method: "PATCH",
+      url: "/user/email/visibility",
+      body: r,
+      mediaType: "application/json",
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static usersListEmailsForAuthenticatedUser(r = 30, e = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/user/emails",
+      query: { per_page: r, page: e },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static usersAddEmailForAuthenticatedUser(r) {
+    return o(i, {
+      method: "POST",
+      url: "/user/emails",
+      body: r,
+      mediaType: "application/json",
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static usersDeleteEmailForAuthenticatedUser(r) {
+    return o(i, {
+      method: "DELETE",
+      url: "/user/emails",
+      body: r,
+      mediaType: "application/json",
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static usersListFollowersForAuthenticatedUser(r = 30, e = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/user/followers",
+      query: { per_page: r, page: e },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden" },
+    });
+  }
+  static usersListFollowedByAuthenticatedUser(r = 30, e = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/user/following",
+      query: { per_page: r, page: e },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden" },
+    });
+  }
+  static usersCheckPersonIsFollowedByAuthenticated(r) {
+    return o(i, {
+      method: "GET",
+      url: "/user/following/{username}",
+      path: { username: r },
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "if the person is not followed by the authenticated user",
+      },
+    });
+  }
+  static usersFollow(r) {
+    return o(i, {
+      method: "PUT",
+      url: "/user/following/{username}",
+      path: { username: r },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static usersUnfollow(r) {
+    return o(i, {
+      method: "DELETE",
+      url: "/user/following/{username}",
+      path: { username: r },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static usersListGpgKeysForAuthenticatedUser(r = 30, e = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/user/gpg_keys",
+      query: { per_page: r, page: e },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static usersCreateGpgKeyForAuthenticatedUser(r) {
+    return o(i, {
+      method: "POST",
+      url: "/user/gpg_keys",
+      body: r,
+      mediaType: "application/json",
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static usersGetGpgKeyForAuthenticatedUser(r) {
+    return o(i, {
+      method: "GET",
+      url: "/user/gpg_keys/{gpg_key_id}",
+      path: { gpg_key_id: r },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static usersDeleteGpgKeyForAuthenticatedUser(r) {
+    return o(i, {
+      method: "DELETE",
+      url: "/user/gpg_keys/{gpg_key_id}",
+      path: { gpg_key_id: r },
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static usersListPublicSshKeysForAuthenticatedUser(r = 30, e = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/user/keys",
+      query: { per_page: r, page: e },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static usersCreatePublicSshKeyForAuthenticatedUser(r) {
+    return o(i, {
+      method: "POST",
+      url: "/user/keys",
+      body: r,
+      mediaType: "application/json",
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static usersGetPublicSshKeyForAuthenticatedUser(r) {
+    return o(i, {
+      method: "GET",
+      url: "/user/keys/{key_id}",
+      path: { key_id: r },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static usersDeletePublicSshKeyForAuthenticatedUser(r) {
+    return o(i, {
+      method: "DELETE",
+      url: "/user/keys/{key_id}",
+      path: { key_id: r },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static usersListPublicEmailsForAuthenticatedUser(r = 30, e = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/user/public_emails",
+      query: { per_page: r, page: e },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static usersListSocialAccountsForAuthenticatedUser(r = 30, e = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/user/social_accounts",
+      query: { per_page: r, page: e },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static usersAddSocialAccountForAuthenticatedUser(r) {
+    return o(i, {
+      method: "POST",
+      url: "/user/social_accounts",
+      body: r,
+      mediaType: "application/json",
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static usersDeleteSocialAccountForAuthenticatedUser(r) {
+    return o(i, {
+      method: "DELETE",
+      url: "/user/social_accounts",
+      body: r,
+      mediaType: "application/json",
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static usersListSshSigningKeysForAuthenticatedUser(r = 30, e = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/user/ssh_signing_keys",
+      query: { per_page: r, page: e },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static usersCreateSshSigningKeyForAuthenticatedUser(r) {
+    return o(i, {
+      method: "POST",
+      url: "/user/ssh_signing_keys",
+      body: r,
+      mediaType: "application/json",
+      errors: {
+        304: "Not modified",
+        401: "Requires authentication",
+        403: "Forbidden",
+        404: "Resource not found",
+        422: "Validation failed, or the endpoint has been spammed.",
+      },
+    });
+  }
+  static usersGetSshSigningKeyForAuthenticatedUser(r) {
+    return o(i, {
+      method: "GET",
+      url: "/user/ssh_signing_keys/{ssh_signing_key_id}",
+      path: { ssh_signing_key_id: r },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static usersDeleteSshSigningKeyForAuthenticatedUser(r) {
+    return o(i, {
+      method: "DELETE",
+      url: "/user/ssh_signing_keys/{ssh_signing_key_id}",
+      path: { ssh_signing_key_id: r },
+      errors: { 304: "Not modified", 401: "Requires authentication", 403: "Forbidden", 404: "Resource not found" },
+    });
+  }
+  static usersList(r, e = 30) {
+    return o(i, { method: "GET", url: "/users", query: { since: r, per_page: e }, errors: { 304: "Not modified" } });
+  }
+  static usersGetByUsername(r) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}",
+      path: { username: r },
+      errors: { 404: "Resource not found" },
+    });
+  }
+  static usersListFollowersForUser(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}/followers",
+      path: { username: r },
+      query: { per_page: e, page: n },
+    });
+  }
+  static usersListFollowingForUser(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}/following",
+      path: { username: r },
+      query: { per_page: e, page: n },
+    });
+  }
+  static usersCheckFollowingForUser(r, e) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}/following/{target_user}",
+      path: { username: r, target_user: e },
+      errors: { 404: "if the user does not follow the target user" },
+    });
+  }
+  static usersListGpgKeysForUser(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}/gpg_keys",
+      path: { username: r },
+      query: { per_page: e, page: n },
+    });
+  }
+  static usersGetContextForUser(r, e, n) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}/hovercard",
+      path: { username: r },
+      query: { subject_type: e, subject_id: n },
+      errors: { 404: "Resource not found", 422: "Validation failed, or the endpoint has been spammed." },
+    });
+  }
+  static usersListPublicKeysForUser(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}/keys",
+      path: { username: r },
+      query: { per_page: e, page: n },
+    });
+  }
+  static usersListSocialAccountsForUser(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}/social_accounts",
+      path: { username: r },
+      query: { per_page: e, page: n },
+    });
+  }
+  static usersListSshSigningKeysForUser(r, e = 30, n = 1) {
+    return o(i, {
+      method: "GET",
+      url: "/users/{username}/ssh_signing_keys",
+      path: { username: r },
+      query: { per_page: e, page: n },
+    });
+  }
+};
+export {
+  lr as ActionsService,
+  ar as ActivityService,
+  J as ApiError,
+  ur as AppsService,
+  _r as BillingService,
+  tr as CancelError,
+  rr as CancelablePromise,
+  gr as ChecksService,
+  mr as CodeScanningService,
+  pr as CodesOfConductService,
+  dr as CodespacesService,
+  cr as CopilotService,
+  br as DependabotService,
+  hr as DependencyGraphService,
+  yr as EmojisService,
+  fr as GistsService,
+  wr as GitService,
+  Er as GitignoreService,
+  vr as InteractionsService,
+  Rr as IssuesService,
+  Tr as LicensesService,
+  Ar as MarkdownService,
+  kr as MetaService,
+  xr as MigrationsService,
+  Ir as OidcService,
+  i as OpenAPI,
+  Or as OrgsService,
+  Nr as PackagesService,
+  zr as ProjectsService,
+  Pr as PullsService,
+  Cr as RateLimitService,
+  Dr as ReactionsService,
+  qr as ReposService,
+  Sr as SearchService,
+  Lr as SecretScanningService,
+  Ur as SecurityAdvisoriesService,
+  Mr as TeamsService,
+  Gr as UsersService,
+  Br as _import,
+  Wr as _package,
+  Fr as actions_cache_list_sort,
+  jr as actions_default_workflow_permissions,
+  Vr as actions_workflow_access_to_repository,
+  Hr as activity,
+  Qr as allowed_actions,
+  Kr as app_permissions,
+  Yr as authentication_token,
+  Zr as author_association,
+  Xr as auto_merge,
+  $r as check_run,
+  Jr as check_run_with_simple_check_suite,
+  re as check_suite,
+  ee as code_scanning_alert_classification,
+  te as code_scanning_alert_dismissed_reason,
+  ne as code_scanning_alert_rule,
+  se as code_scanning_alert_rule_summary,
+  ie as code_scanning_alert_set_state,
+  oe as code_scanning_alert_severity,
+  le as code_scanning_alert_state,
+  ae as code_scanning_alert_state_query,
+  ue as code_scanning_default_setup,
+  _e as code_scanning_default_setup_update,
+  ge as code_scanning_sarifs_status,
+  me as codespace,
+  pe as codespace_machine,
+  de as codespace_with_full_repository,
+  ce as codespaces_org_secret,
+  be as codespaces_secret,
+  he as commit_comparison,
+  ye as content_file,
+  fe as content_submodule,
+  we as content_symlink,
+  Ee as dependabot_alert,
+  ve as dependabot_alert_scope,
+  Re as dependabot_alert_security_advisory,
+  Te as dependabot_alert_security_vulnerability,
+  Ae as dependabot_alert_sort,
+  ke as dependabot_alert_with_repository,
+  xe as dependency,
+  Ie as deployment_reviewer_type,
+  Oe as deployment_status,
+  Ne as diff_entry,
+  ze as direction,
+  Pe as discussion,
+  Ce as enabled_repositories,
+  De as environment_approvals,
+  qe as full_repository,
+  Se as global_advisory,
+  Le as installation,
+  Ue as installation_token,
+  Me as interaction_expiry,
+  Ge as interaction_group,
+  Be as issue,
+  We as job,
+  Fe as marketplace_listing_plan,
+  je as merged_upstream,
+  Ve as milestone,
+  He as nullable_codespace_machine,
+  Qe as nullable_issue,
+  Ke as nullable_milestone,
+  Ye as nullable_repository,
+  Ze as nullable_scoped_installation,
+  Xe as order,
+  $e as org_membership,
+  Je as org_security_product_enablement,
+  rt as organization_actions_secret,
+  et as organization_actions_variable,
+  tt as organization_dependabot_secret,
+  nt as organization_programmatic_access_grant,
+  st as organization_programmatic_access_grant_request,
+  it as package_type,
+  ot as package_version,
+  lt as package_visibility,
+  at as pages_https_certificate,
+  ut as per,
+  _t as personal_access_token_request,
+  gt as personal_access_token_sort,
+  mt as private_vulnerability_report_create,
+  pt as project,
+  dt as projects_v2_item_content_type,
+  ct as pull_request,
+  bt as pull_request_review_comment,
+  ht as reaction,
+  yt as release_asset,
+  ft as repository,
+  wt as repository_advisory,
+  Et as repository_advisory_create,
+  vt as repository_advisory_credit,
+  Rt as repository_advisory_update,
+  Tt as repository_invitation,
+  At as repository_rule_branch_name_pattern,
+  kt as repository_rule_commit_author_email_pattern,
+  xt as repository_rule_commit_message_pattern,
+  It as repository_rule_committer_email_pattern,
+  Ot as repository_rule_creation,
+  Nt as repository_rule_deletion,
+  zt as repository_rule_enforcement,
+  Pt as repository_rule_non_fast_forward,
+  Ct as repository_rule_pull_request,
+  Dt as repository_rule_required_deployments,
+  qt as repository_rule_required_linear_history,
+  St as repository_rule_required_signatures,
+  Lt as repository_rule_required_status_checks,
+  Ut as repository_rule_tag_name_pattern,
+  Mt as repository_rule_update,
+  Gt as repository_ruleset,
+  Bt as repository_ruleset_bypass_actor,
+  Wt as review_comment,
+  Ft as review_custom_gates_state_required,
+  jt as runner_label,
+  Vt as secret_scanning_alert_resolution_webhook,
+  Ht as secret_scanning_alert_sort,
+  Qt as secret_scanning_alert_state,
+  Kt as secret_scanning_location,
+  Yt as security_advisory_credit_types,
+  Zt as security_advisory_ecosystems,
+  Xt as security_and_analysis,
+  $t as security_product,
+  Jt as simple_check_suite,
+  rn as sort,
+  en as sort_starred,
+  tn as status,
+  nn as team_full,
+  sn as team_membership,
+  on as webhook_branch_protection_rule_created,
+  ln as webhook_branch_protection_rule_deleted,
+  an as webhook_branch_protection_rule_edited,
+  un as webhook_check_run_completed,
+  _n as webhook_check_run_created,
+  gn as webhook_check_run_requested_action,
+  mn as webhook_check_run_rerequested,
+  pn as webhook_check_suite_completed,
+  dn as webhook_check_suite_requested,
+  cn as webhook_check_suite_rerequested,
+  bn as webhook_code_scanning_alert_appeared_in_branch,
+  hn as webhook_code_scanning_alert_closed_by_user,
+  yn as webhook_code_scanning_alert_created,
+  fn as webhook_code_scanning_alert_fixed,
+  wn as webhook_code_scanning_alert_reopened,
+  En as webhook_code_scanning_alert_reopened_by_user,
+  vn as webhook_commit_comment_created,
+  Rn as webhook_create,
+  Tn as webhook_delete,
+  An as webhook_dependabot_alert_auto_dismissed,
+  kn as webhook_dependabot_alert_auto_reopened,
+  xn as webhook_dependabot_alert_created,
+  In as webhook_dependabot_alert_dismissed,
+  On as webhook_dependabot_alert_fixed,
+  Nn as webhook_dependabot_alert_reintroduced,
+  zn as webhook_dependabot_alert_reopened,
+  Pn as webhook_deploy_key_created,
+  Cn as webhook_deploy_key_deleted,
+  Dn as webhook_deployment_created,
+  qn as webhook_deployment_protection_rule_requested,
+  Sn as webhook_deployment_status_created,
+  Ln as webhook_discussion_answered,
+  Un as webhook_discussion_category_changed,
+  Mn as webhook_discussion_closed,
+  Gn as webhook_discussion_comment_created,
+  Bn as webhook_discussion_comment_deleted,
+  Wn as webhook_discussion_comment_edited,
+  Fn as webhook_discussion_created,
+  jn as webhook_discussion_deleted,
+  Vn as webhook_discussion_edited,
+  Hn as webhook_discussion_labeled,
+  Qn as webhook_discussion_locked,
+  Kn as webhook_discussion_pinned,
+  Yn as webhook_discussion_reopened,
+  Zn as webhook_discussion_transferred,
+  Xn as webhook_discussion_unanswered,
+  $n as webhook_discussion_unlabeled,
+  Jn as webhook_discussion_unlocked,
+  rs as webhook_discussion_unpinned,
+  es as webhook_fork,
+  ts as webhook_github_app_authorization_revoked,
+  ns as webhook_installation_created,
+  ss as webhook_installation_deleted,
+  is as webhook_installation_new_permissions_accepted,
+  os as webhook_installation_repositories_added,
+  ls as webhook_installation_repositories_removed,
+  as as webhook_installation_suspend,
+  us as webhook_installation_unsuspend,
+  _s as webhook_issue_comment_created,
+  gs as webhook_issue_comment_deleted,
+  ms as webhook_issue_comment_edited,
+  ps as webhook_issues_assigned,
+  ds as webhook_issues_closed,
+  cs as webhook_issues_deleted,
+  bs as webhook_issues_demilestoned,
+  hs as webhook_issues_edited,
+  ys as webhook_issues_labeled,
+  fs as webhook_issues_locked,
+  ws as webhook_issues_milestoned,
+  Es as webhook_issues_opened,
+  vs as webhook_issues_pinned,
+  Rs as webhook_issues_reopened,
+  Ts as webhook_issues_transferred,
+  As as webhook_issues_unassigned,
+  ks as webhook_issues_unlabeled,
+  xs as webhook_issues_unlocked,
+  Is as webhook_issues_unpinned,
+  Os as webhook_label_created,
+  Ns as webhook_label_deleted,
+  zs as webhook_label_edited,
+  Ps as webhook_marketplace_purchase_cancelled,
+  Cs as webhook_marketplace_purchase_changed,
+  Ds as webhook_marketplace_purchase_pending_change,
+  qs as webhook_marketplace_purchase_pending_change_cancelled,
+  Ss as webhook_marketplace_purchase_purchased,
+  Ls as webhook_member_added,
+  Us as webhook_member_edited,
+  Ms as webhook_member_removed,
+  Gs as webhook_membership_added,
+  Bs as webhook_membership_removed,
+  Ws as webhook_merge_group_checks_requested,
+  Fs as webhook_merge_group_destroyed,
+  js as webhook_meta_deleted,
+  Vs as webhook_milestone_closed,
+  Hs as webhook_milestone_created,
+  Qs as webhook_milestone_deleted,
+  Ks as webhook_milestone_edited,
+  Ys as webhook_milestone_opened,
+  Zs as webhook_org_block_blocked,
+  Xs as webhook_org_block_unblocked,
+  $s as webhook_organization_deleted,
+  Js as webhook_organization_member_added,
+  ri as webhook_organization_member_invited,
+  ei as webhook_organization_member_removed,
+  ti as webhook_organization_renamed,
+  ni as webhook_package_published,
+  si as webhook_package_updated,
+  ii as webhook_page_build,
+  oi as webhook_personal_access_token_request_approved,
+  li as webhook_personal_access_token_request_cancelled,
+  ai as webhook_personal_access_token_request_created,
+  ui as webhook_personal_access_token_request_denied,
+  _i as webhook_ping,
+  gi as webhook_project_card_converted,
+  mi as webhook_project_card_created,
+  pi as webhook_project_card_deleted,
+  di as webhook_project_card_edited,
+  ci as webhook_project_card_moved,
+  bi as webhook_project_closed,
+  hi as webhook_project_column_created,
+  yi as webhook_project_column_deleted,
+  fi as webhook_project_column_edited,
+  wi as webhook_project_column_moved,
+  Ei as webhook_project_created,
+  vi as webhook_project_deleted,
+  Ri as webhook_project_edited,
+  Ti as webhook_project_reopened,
+  Ai as webhook_projects_v2_item_archived,
+  ki as webhook_projects_v2_item_converted,
+  xi as webhook_projects_v2_item_created,
+  Ii as webhook_projects_v2_item_deleted,
+  Oi as webhook_projects_v2_item_edited,
+  Ni as webhook_projects_v2_item_reordered,
+  zi as webhook_projects_v2_item_restored,
+  Pi as webhook_projects_v2_project_closed,
+  Ci as webhook_projects_v2_project_created,
+  Di as webhook_projects_v2_project_deleted,
+  qi as webhook_projects_v2_project_edited,
+  Si as webhook_projects_v2_project_reopened,
+  Li as webhook_pull_request_assigned,
+  Ui as webhook_pull_request_auto_merge_disabled,
+  Mi as webhook_pull_request_auto_merge_enabled,
+  Gi as webhook_pull_request_closed,
+  Bi as webhook_pull_request_converted_to_draft,
+  Wi as webhook_pull_request_demilestoned,
+  Fi as webhook_pull_request_dequeued,
+  ji as webhook_pull_request_edited,
+  Vi as webhook_pull_request_enqueued,
+  Hi as webhook_pull_request_labeled,
+  Qi as webhook_pull_request_locked,
+  Ki as webhook_pull_request_milestoned,
+  Yi as webhook_pull_request_opened,
+  Zi as webhook_pull_request_ready_for_review,
+  Xi as webhook_pull_request_reopened,
+  $i as webhook_pull_request_review_comment_created,
+  Ji as webhook_pull_request_review_comment_deleted,
+  ro as webhook_pull_request_review_comment_edited,
+  eo as webhook_pull_request_review_dismissed,
+  to as webhook_pull_request_review_edited,
+  no as webhook_pull_request_review_request_removed,
+  so as webhook_pull_request_review_requested,
+  io as webhook_pull_request_review_submitted,
+  oo as webhook_pull_request_review_thread_resolved,
+  lo as webhook_pull_request_review_thread_unresolved,
+  ao as webhook_pull_request_synchronize,
+  uo as webhook_pull_request_unassigned,
+  _o as webhook_pull_request_unlabeled,
+  go as webhook_pull_request_unlocked,
+  mo as webhook_push,
+  po as webhook_registry_package_published,
+  co as webhook_release_created,
+  bo as webhook_release_deleted,
+  ho as webhook_release_edited,
+  yo as webhook_release_prereleased,
+  fo as webhook_release_published,
+  wo as webhook_release_released,
+  Eo as webhook_release_unpublished,
+  vo as webhook_repository_advisory_published,
+  Ro as webhook_repository_advisory_reported,
+  To as webhook_repository_archived,
+  Ao as webhook_repository_created,
+  ko as webhook_repository_deleted,
+  xo as webhook_repository_edited,
+  Io as webhook_repository_import,
+  Oo as webhook_repository_privatized,
+  No as webhook_repository_publicized,
+  zo as webhook_repository_renamed,
+  Po as webhook_repository_transferred,
+  Co as webhook_repository_unarchived,
+  Do as webhook_repository_vulnerability_alert_create,
+  qo as webhook_repository_vulnerability_alert_dismiss,
+  So as webhook_repository_vulnerability_alert_reopen,
+  Lo as webhook_repository_vulnerability_alert_resolve,
+  Uo as webhook_secret_scanning_alert_created,
+  Mo as webhook_secret_scanning_alert_location_created,
+  Go as webhook_secret_scanning_alert_reopened,
+  Bo as webhook_secret_scanning_alert_resolved,
+  Wo as webhook_secret_scanning_alert_revoked,
+  Fo as webhook_security_advisory_published,
+  jo as webhook_security_advisory_updated,
+  Vo as webhook_security_advisory_withdrawn,
+  Ho as webhook_sponsorship_cancelled,
+  Qo as webhook_sponsorship_created,
+  Ko as webhook_sponsorship_edited,
+  Yo as webhook_sponsorship_pending_cancellation,
+  Zo as webhook_sponsorship_pending_tier_change,
+  Xo as webhook_sponsorship_tier_changed,
+  $o as webhook_star_created,
+  Jo as webhook_star_deleted,
+  rl as webhook_status,
+  el as webhook_team_add,
+  tl as webhook_team_added_to_repository,
+  nl as webhook_team_created,
+  sl as webhook_team_deleted,
+  il as webhook_team_edited,
+  ol as webhook_team_removed_from_repository,
+  ll as webhook_watch_started,
+  al as webhook_workflow_job_completed,
+  ul as webhook_workflow_job_in_progress,
+  _l as webhook_workflow_job_queued,
+  gl as webhook_workflow_job_waiting,
+  ml as webhook_workflow_run_completed,
+  pl as webhook_workflow_run_in_progress,
+  dl as webhook_workflow_run_requested,
+  cl as workflow,
+  bl as workflow_run_status,
+};

--- a/packages/openapi-vue-query/test/helpers/render-hook.ts
+++ b/packages/openapi-vue-query/test/helpers/render-hook.ts
@@ -1,5 +1,5 @@
-import { createApp, defineComponent, h } from "vue";
 import { VueQueryPlugin } from "@tanstack/vue-query";
+import { createApp, defineComponent, h } from "vue";
 
 type InstanceType<V> = V extends { new (...arg: any[]): infer X } ? X : never;
 type VM<V> = InstanceType<V> & { unmount: () => void };

--- a/packages/openapi-vue-query/test/index.test.tsx
+++ b/packages/openapi-vue-query/test/index.test.tsx
@@ -1,11 +1,11 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { server, baseUrl, useMockRequestHandler } from "./fixtures/mock-server.js";
-import type { paths } from "./fixtures/api.js";
-import createClient, { type MethodResponse } from "../src/index.js";
-import createFetchClient from "openapi-fetch";
-import { defineComponent } from "vue";
+import { QueryClient, skipToken, useQueries, useQuery } from "@tanstack/vue-query";
 import { fireEvent, render, waitFor } from "@testing-library/vue";
-import { QueryClient, useQueries, useQuery, skipToken } from "@tanstack/vue-query";
+import createFetchClient from "openapi-fetch";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { defineComponent } from "vue";
+import createClient, { type MethodResponse } from "../src/index.js";
+import type { paths } from "./fixtures/api.js";
+import { baseUrl, server, useMockRequestHandler } from "./fixtures/mock-server.js";
 import { renderHook } from "./helpers/render-hook.js";
 
 type minimalGetPaths = {
@@ -813,7 +813,7 @@ describe("client", () => {
       expect(firstRequestUrl?.searchParams.get("cursor")).toBe("0");
 
       // Set up mock for second page before triggering next page fetch
-      const secondRequestHandler = useMockRequestHandler({
+      const _secondRequestHandler = useMockRequestHandler({
         baseUrl,
         method: "get",
         path: "/paginated-data",

--- a/packages/openapi-vue-query/vitest.config.ts
+++ b/packages/openapi-vue-query/vitest.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig, type Plugin } from "vitest/config";
 import vue from "@vitejs/plugin-vue";
 import vueJsx from "@vitejs/plugin-vue-jsx";
+import { defineConfig, type Plugin } from "vitest/config";
 
 export default defineConfig({
   plugins: [vue() as unknown as Plugin, vueJsx() as unknown as Plugin],


### PR DESCRIPTION
## Changes

- Update schema version from 1.9.4 to 2.2.5
- Replace files.ignore with files.experimentalScannerIgnores
- Replace overrides.include with overrides.includes
- Change noConsoleLog to noConsole
- Remove organizeImports configuration (deprecated)
- Format test fixtures with updated configuration
