### PR TITLE
chore: add changeset for type compatibility fixes

### DIFF
--- a/.changeset/fix-type-compatibility.md
+++ b/.changeset/fix-type-compatibility.md
@@ -1,0 +1,10 @@
+---
+"openapi-vue-query": patch
+---
+
+Fix TypeScript type compatibility with @tanstack/vue-query updates
+
+- Fix UseInfiniteQueryOptions type argument count (6 to 5)
+- Add required getNextPageParam and initialPageParam parameters
+- Replace empty object type {} with Record<string, any> for better type safety
+- Remove unused Vue type imports


### PR DESCRIPTION
Add changeset for TypeScript type compatibility fixes with @tanstack/vue-query updates.

## Changes
- Fix UseInfiniteQueryOptions type argument count (6 to 5)
- Add required getNextPageParam and initialPageParam parameters
- Replace empty object type {} with Record<string, any> for better type safety
- Remove unused Vue type imports

## Version
This will be released as a patch version (0.0.3 → 0.0.4)